### PR TITLE
Update footprints

### DIFF
--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Change.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Change.hpp
@@ -24,6 +24,7 @@
 #include <rmf_traffic_msgs/msg/schedule_change_delay.hpp>
 #include <rmf_traffic_msgs/msg/schedule_register.hpp>
 #include <rmf_traffic_msgs/msg/schedule_change_cull.hpp>
+#include <rmf_traffic_msgs/msg/schedule_update_participant.hpp>
 
 namespace rmf_traffic_ros2 {
 
@@ -50,6 +51,14 @@ rmf_traffic::schedule::Change::RegisterParticipant convert(
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleRegister convert(
   const rmf_traffic::schedule::Change::RegisterParticipant& from);
+
+//==============================================================================
+rmf_traffic_msgs::msg::ScheduleUpdateParticipant convert(
+  const rmf_traffic::schedule::Change::UpdateParticipantInfo& from);
+
+//==============================================================================
+rmf_traffic::schedule::Change::UpdateParticipantInfo convert(
+  const rmf_traffic_msgs::msg::ScheduleUpdateParticipant& from);
 
 //==============================================================================
 rmf_traffic::schedule::ParticipantId convert(

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/ParticipantRegistry.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/ParticipantRegistry.hpp
@@ -39,7 +39,8 @@ struct AtomicOperation
 {
   enum class OpType : uint8_t
   {
-    Add = 0
+    Add = 0,
+    Update = 1
   };
   OpType operation;
   ParticipantDescription description;

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -305,6 +305,15 @@ public:
       return convert(*response);
     }
 
+    void update_description(rmf_traffic::schedule::ParticipantId,
+      rmf_traffic::schedule::ParticipantDescription participant_info)
+    {
+      //For the ROS2 implememntation since each robot is uniquely 
+      //identified by its owner and name the registration service 
+      //handles updating of participant info as well. 
+      register_participant(participant_info);
+    }
+
     void unregister_participant(
       const rmf_traffic::schedule::ParticipantId participant) final
     {

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -305,13 +305,14 @@ public:
       return convert(*response);
     }
 
-    void update_description(rmf_traffic::schedule::ParticipantId,
+    void update_description(
+      rmf_traffic::schedule::ParticipantId,
       rmf_traffic::schedule::ParticipantDescription participant_info)
     {
-      //For the ROS2 implememntation since each robot is uniquely 
-      //identified by its owner and name the registration service 
-      //handles updating of participant info as well. 
-      register_participant(participant_info);
+      // Since each robot is uniquely identified by its owner and name pair in
+      // the ROS2 implementation, the registration service handles updating of
+      // participant info as well.
+      register_participant(std::move(participant_info));
     }
 
     void unregister_participant(

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
@@ -74,8 +74,7 @@ public:
       _name_to_index[uuid] = index;
       _buffer.push_back(serialize(operation));
     }
-    
-    
+
     std::ofstream file(_file_path);
     file << _buffer;
   }
@@ -93,15 +92,15 @@ public:
     
     std::string uuid = operation.description.name() + 
       operation.description.owner();
-    
+
     _name_to_index[uuid] = _counter;
-    _counter++;
-    
-    return {operation};
+    ++_counter;
+
+    return operation;
   }
 
 private:
-  YAML::Node _buffer; ///used when loading the file
+  YAML::Node _buffer; // used when loading the file
   std::size_t _initial_buffer_size;
   std::unordered_map<std::string, std::size_t> _name_to_index;
   std::size_t _counter;

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
@@ -36,6 +36,7 @@ public:
     {
       std::filesystem::create_directories(
             std::filesystem::absolute(file_path).parent_path());
+      _initial_buffer_size = 0;
       return;
     }
 

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
@@ -27,7 +27,7 @@ namespace schedule {
 class YamlLogger::Implementation 
 {
 public:
-  
+  //===========================================================================
   Implementation(std::string file_path):
   _file_path(file_path)
   {
@@ -48,65 +48,76 @@ public:
         "Malformatted file - Expected the root format of the"\
         " document to be a yaml sequence");
     }
+    _initial_buffer_size = _buffer.size();
   }
 
+  //=========================================================================
   void write_operation(AtomicOperation operation)
   {
+    std::string uuid = operation.description.name() 
+        + operation.description.owner();
     std::lock_guard<std::mutex> file_lock(_mutex);
-    
+
     if(operation.operation == AtomicOperation::OpType::Update)
     {
-      // Rewrite whole yaml file.
+      auto index = _name_to_index[uuid];
+      _buffer[index] = serialize(operation.description);
     }
-
-    //We will use YAML's block sequence format as this friendly for appending
-    //We only need to write the latest changes to the file.
-    YAML::Emitter emmiter;
-    emmiter << YAML::BeginSeq;
-    emmiter << serialize(operation);
-    emmiter << YAML::EndSeq;
-    assert(emmiter.good());
-
-    std::ofstream outfile;
-    outfile.open(_file_path, std::ofstream::out | std::ofstream::app);
-    if(!outfile.is_open())
+    else if(operation.operation == AtomicOperation::OpType::Add)
     {
-      //Unable to open the logfile successfully
-      //TODO: Figure out a way to log this error.
-      return;
+      auto index = _buffer.size();
+      _name_to_index[uuid] = index;
+      _buffer.push_back(serialize(operation));
     }
-    outfile << emmiter.c_str() << std::endl;
-    outfile.close();
+    
+    
+    std::ofstream file(_file_path);
+    file << _buffer;
   }
 
+  //===========================================================================
   std::optional<AtomicOperation> read_next_record()
   {
-    if(_counter >= _buffer.size())
+    if(_counter >= _initial_buffer_size)
     {
       //We have reached the end of the file, restoration is complete.   
       return std::nullopt;
     }
-    return {atomic_operation(_buffer[_counter++])};
+
+    auto operation = atomic_operation(_buffer[_counter]);
+    
+    std::string uuid = operation.description.name() + 
+      operation.description.owner();
+    
+    _name_to_index[uuid] = _counter;
+    _counter++;
+    
+    return {operation};
   }
 
 private:
   YAML::Node _buffer; ///used when loading the file
+  std::size_t _initial_buffer_size;
+  std::unordered_map<std::string, std::size_t> _name_to_index;
   std::size_t _counter;
   std::string _file_path;
   std::mutex _mutex;
 };
 
+//=============================================================================
 YamlLogger::YamlLogger(std::string file_path): 
   _pimpl(rmf_utils::make_unique_impl<Implementation>(file_path))
 {
   // Do nothing
 }
 
+//=============================================================================
 void YamlLogger::write_operation(AtomicOperation operation)
 {
   _pimpl->write_operation(operation);
 }
 
+//=============================================================================
 std::optional<AtomicOperation> YamlLogger::read_next_record()
 {
   return _pimpl->read_next_record();

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
@@ -53,6 +53,11 @@ public:
   void write_operation(AtomicOperation operation)
   {
     std::lock_guard<std::mutex> file_lock(_mutex);
+    
+    if(operation.operation == AtomicOperation::OpType::Update)
+    {
+      // Rewrite whole yaml file.
+    }
 
     //We will use YAML's block sequence format as this friendly for appending
     //We only need to write the latest changes to the file.

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlLogger.cpp
@@ -62,7 +62,11 @@ public:
     if(operation.operation == AtomicOperation::OpType::Update)
     {
       auto index = _name_to_index[uuid];
-      _buffer[index] = serialize(operation.description);
+      AtomicOperation op {
+        AtomicOperation::OpType::Add,
+        operation.description
+      };
+      _buffer[index] = serialize(op);
     }
     else if(operation.operation == AtomicOperation::OpType::Add)
     {

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Change.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Change.cpp
@@ -81,6 +81,26 @@ rmf_traffic_msgs::msg::ScheduleRegister convert(
 }
 
 //==============================================================================
+rmf_traffic_msgs::msg::ScheduleUpdateParticipant convert(
+  const rmf_traffic::schedule::Change::UpdateParticipantInfo& from)
+{
+  rmf_traffic_msgs::msg::ScheduleUpdateParticipant output;
+  output.participant_id = from.id();
+  output.description = convert(from.description());
+  return output;
+}
+
+//==============================================================================
+rmf_traffic::schedule::Change::UpdateParticipantInfo convert(
+  const rmf_traffic_msgs::msg::ScheduleUpdateParticipant& from)
+{
+   return rmf_traffic::schedule::Change::UpdateParticipantInfo{
+    from.participant_id,
+    convert(from.description)
+  };
+}
+
+//==============================================================================
 rmf_traffic::schedule::Change::Cull convert(
   const rmf_traffic_msgs::msg::ScheduleChangeCull& from)
 {

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Patch.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Patch.cpp
@@ -122,8 +122,10 @@ rmf_traffic::schedule::Patch convert(
     std::move(unregister),
     convert_vector<rmf_traffic::schedule::Change::RegisterParticipant>(
       from.register_participants),
-    convert_vector<rmf_traffic::schedule::Change::UpdateParticipantInfo>(from.updated_footprints),
-    convert_vector<rmf_traffic::schedule::Patch::Participant>(from.participants),
+    convert_vector<rmf_traffic::schedule::Change::UpdateParticipantInfo>(
+      from.updated_footprints),
+    convert_vector<rmf_traffic::schedule::Patch::Participant>(
+      from.participants),
     std::move(cull),
     from.latest_version
   };

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Patch.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Patch.cpp
@@ -90,6 +90,7 @@ rmf_traffic_msgs::msg::SchedulePatch convert(
     output.unregister_participants.emplace_back(u.id());
 
   convert_vector(output.register_participants, from.registered());
+  convert_vector(output.updated_footprints, from.updated());
 
   output.participants.reserve(from.size());
   for (const auto& p : from)
@@ -121,6 +122,7 @@ rmf_traffic::schedule::Patch convert(
     std::move(unregister),
     convert_vector<rmf_traffic::schedule::Change::RegisterParticipant>(
       from.register_participants),
+    convert_vector<rmf_traffic::schedule::Change::UpdateParticipantInfo>(from.updated_footprints),
     convert_vector<rmf_traffic::schedule::Patch::Participant>(from.participants),
     std::move(cull),
     from.latest_version

--- a/rmf_traffic_ros2/test/unit/test_ParticipantRegistry.cpp
+++ b/rmf_traffic_ros2/test/unit/test_ParticipantRegistry.cpp
@@ -30,13 +30,11 @@ SCENARIO("Test idempotency of shape type")
   YAML::Node node;
 
   // Check "None"
-  auto serialized = serialize_shape_type(
-    rmf_traffic_msgs::msg::ConvexShape::NONE);
-  node["type"] = serialized;  
-  CHECK(shape_type(node["type"]) == rmf_traffic_msgs::msg::ConvexShape::NONE);
+  REQUIRE_THROWS(serialize_shape_type(
+    rmf_traffic_msgs::msg::ConvexShape::NONE));
 
   // Check "Box"
-  serialized = serialize_shape_type(rmf_traffic_msgs::msg::ConvexShape::BOX);
+  auto serialized = serialize_shape_type(rmf_traffic_msgs::msg::ConvexShape::BOX);
   node["type"] = serialized;
   CHECK(shape_type(node["type"]) == rmf_traffic_msgs::msg::ConvexShape::BOX);
 
@@ -148,8 +146,8 @@ SCENARIO("Participant registry restores participants from logger")
   
   GIVEN("A stubbed out logger")
   {
-    std::vector<AtomicOperation>* journal;
-    auto logger = std::make_unique<TestOperationLogger>(journal);
+    std::vector<AtomicOperation> journal;
+    auto logger = std::make_unique<TestOperationLogger>(&journal);
     WHEN("Creating a new DB without errors")
     {
       auto db1 = std::make_shared<Database>();
@@ -161,7 +159,7 @@ SCENARIO("Participant registry restores participants from logger")
       THEN("Restoring DB")
       {
         auto db2 = std::make_shared<Database>();
-         auto logger2 = std::make_unique<TestOperationLogger>(journal);
+         auto logger2 = std::make_unique<TestOperationLogger>(&journal);
         ParticipantRegistry registry2(std::move(logger2), db2);
         auto restored_participants = db2->participant_ids();
         REQUIRE(restored_participants.count(participant_id1.id()) > 0);


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This adds an update feature to the database. We need this in order to allow for participant descriptions to change if the fleetadapter requests such a change.

This feature is related to the following PRs:

1. [rmf_trasffic](https://github.com/open-rmf/rmf_traffic/pull/2)
2. [rmf_ros2](https://github.com/open-rmf/rmf_ros2/pull/2)
3. [rmf_internal_msgs](https://github.com/open-rmf/rmf_internal_msgs/pull/2)

### Implementation description

##### Changes in `rmf_traffic`
There isn't too much magic going on. This PR adds a `update_descriptions` function to the writer API through which a client can update the footprint of an already registered client. To maintain sync with the mirrors we add an  `UpdateParticipantInfo` class to the `Change` class and a ` updated()` field to the patches class. This allows the database to update its mirrors accordingly.

At the heart of the change is a hash table `UpdateParticipantDescription update_participant_version;`  indexed by participant ID. If a participant is updated its ID is set in the hashtable along with the version in which an update is performed. During synchronization, the mirrors use this hash table for this job.

##### Changes in `rmf_traffic_ros2`
First of all, `ParticipantRegistry::add_or_register_participant` now also handles updates. This is done by keeping track of footprints within the `ParticipantRegistryClass` to detect an y changes. The other major change is that in order to reduce the log file size, instead of being an append-only log `YamlLogger` overwrites the entire `.rmf_schedule_node.yaml`. This is fine as we do not expect too many participants. 

##### Changes in `ros_internal_msgs`
We add a message to handle updates.

#### Testing with `rmf_ros2`
![footprint_update](https://user-images.githubusercontent.com/542272/110572787-18bbc080-8195-11eb-9f47-2f2fd37fd212.gif)

In the above gif you can see the footprint change to reproduce, you can checkout the `temporary/test_restart_fleet_adapter` branch in [rmf_demos](https://github.com/open-rmf/rmf_demos/tree/temporary/test_restart_fleet_adapter)

In one terminal window run `ros2 launch rmf_demos office.launch.xml` and in another run `ros2 launch rmf_demos adapters.launch`. Then edit the parameters in `tinyRobot_adapter.launch` and restart `adapters.launch` if successful,
you will see a change in the footprint.