### PR TITLE
Topic based schedule updates

### DIFF
--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
@@ -33,8 +33,8 @@ const std::string UnregisterParticipantSrvName = Prefix +
   "unregister_participant";
 const std::string RegisterQueryServiceName = Prefix + "register_query";
 const std::string UnregisterQueryServiceName = Prefix + "unregister_query";
-const std::string MirrorUpdateServiceName = Prefix + "mirror_update";
-const std::string MirrorWakeupTopicName = Prefix + "mirror_wakeup";
+const std::string QueryUpdateTopicNameBase = Prefix + "query_update_";
+const std::string RequestChangesTopicName = Prefix + "request_changes";
 const std::string ScheduleInconsistencyTopicName = Prefix +
   "schedule_inconsistency";
 const std::string NegotiationAckTopicName = Prefix +

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/MirrorManager.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/MirrorManager.hpp
@@ -76,13 +76,9 @@ public:
 
   /// Attempt to update this mirror immediately.
   ///
-  /// \param[in] wait
-  ///   How long to block the current thread while waiting for the mirror to
-  ///   update. By default this will not block at all.
-  ///
   // TODO(MXG): Consider allowing this function to accept a callback that will
   // get triggered when the update is complete.
-  void update(rmf_traffic::Duration wait = rmf_traffic::Duration(0));
+  void update();
 
   /// Get the options for this mirror manager
   const Options& get_options() const;

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
@@ -15,14 +15,15 @@
  *
 */
 
+#include <rclcpp/logger.hpp>
 #include <rmf_traffic_ros2/StandardNames.hpp>
 #include <rmf_traffic_ros2/schedule/MirrorManager.hpp>
 #include <rmf_traffic_ros2/schedule/Patch.hpp>
 #include <rmf_traffic_ros2/schedule/Query.hpp>
 
-#include <rmf_traffic_msgs/msg/mirror_wakeup.hpp>
+#include <rmf_traffic_msgs/msg/mirror_update.hpp>
+#include <rmf_traffic_msgs/msg/request_changes.hpp>
 
-#include <rmf_traffic_msgs/srv/mirror_update.hpp>
 #include <rmf_traffic_msgs/srv/register_query.hpp>
 #include <rmf_traffic_msgs/srv/unregister_query.hpp>
 
@@ -31,15 +32,15 @@
 namespace rmf_traffic_ros2 {
 namespace schedule {
 
-using MirrorUpdate = rmf_traffic_msgs::srv::MirrorUpdate;
-using MirrorUpdateClient = rclcpp::Client<MirrorUpdate>::SharedPtr;
-using MirrorUpdateFuture = rclcpp::Client<MirrorUpdate>::SharedFuture;
+using MirrorUpdate = rmf_traffic_msgs::msg::MirrorUpdate;
+using MirrorUpdateSub = rclcpp::Subscription<MirrorUpdate>::SharedPtr;
+
+using RequestChanges = rmf_traffic_msgs::msg::RequestChanges;
+using RequestChangesPub = rclcpp::Publisher<RequestChanges>::SharedPtr;
 
 using UnregisterQuery = rmf_traffic_msgs::srv::UnregisterQuery;
 using UnregisterQueryClient = rclcpp::Client<UnregisterQuery>::SharedPtr;
 
-using MirrorWakeup = rmf_traffic_msgs::msg::MirrorWakeup;
-using MirrorWakeupSub = rclcpp::Subscription<MirrorWakeup>::SharedPtr;
 
 //==============================================================================
 class MirrorManager::Implementation
@@ -48,16 +49,14 @@ public:
 
   rclcpp::Node& node;
   Options options;
-  MirrorUpdateClient mirror_update_client;
   UnregisterQueryClient unregister_query_client;
-  MirrorWakeupSub mirror_wakeup_sub;
-
-  MirrorUpdate::Request::SharedPtr request_msg;
+  MirrorUpdateSub mirror_update_sub;
+  RequestChangesPub request_changes_pub;
+  uint64_t query_id = 0;
 
   std::shared_ptr<rmf_traffic::schedule::Mirror> mirror;
 
-  bool initial_request = true;
-  bool waiting_for_reply = false;
+  bool initial_update = true;
 
   rmf_traffic::schedule::Version next_minimum_version = 0;
 
@@ -65,102 +64,71 @@ public:
     rclcpp::Node& _node,
     Options _options,
     uint64_t _query_id,
-    MirrorUpdateClient _mirror_update_client,
     UnregisterQueryClient _unregister_query_client)
   : node(_node),
     options(std::move(_options)),
-    mirror_update_client(std::move(_mirror_update_client)),
     unregister_query_client(std::move(_unregister_query_client)),
-    request_msg(std::make_shared<MirrorUpdate::Request>()),
+    query_id(_query_id),
     mirror(std::make_shared<rmf_traffic::schedule::Mirror>())
   {
-    mirror_wakeup_sub = node.create_subscription<MirrorWakeup>(
-      MirrorWakeupTopicName, rclcpp::SystemDefaultsQoS(),
-      [&](const MirrorWakeup::SharedPtr msg)
+    mirror_update_sub = node.create_subscription<MirrorUpdate>(
+      QueryUpdateTopicNameBase + std::to_string(query_id),
+      rclcpp::SystemDefaultsQoS(),
+      [&](const MirrorUpdate::SharedPtr msg)
       {
-        trigger_wakeup(msg->latest_version);
+        handle_update(msg);
       });
 
-    request_msg->query_id = _query_id;
+    request_changes_pub = node.create_publisher<RequestChanges>(
+      rmf_traffic_ros2::RequestChangesTopicName,
+      rclcpp::SystemDefaultsQoS());
   }
 
-  void trigger_wakeup(uint64_t minimum_version)
+  void handle_update(const MirrorUpdate::SharedPtr msg)
   {
-    if (options.update_on_wakeup())
-      update(minimum_version);
-  }
-
-  void update(
-    uint64_t minimum_version,
-    const rmf_traffic::Duration wait = rmf_traffic::Duration(0))
-  {
-    if (waiting_for_reply)
+    try
     {
-      next_minimum_version = minimum_version;
-      return;
-    }
+      const rmf_traffic::schedule::Patch patch = convert(msg->patch);
 
-    waiting_for_reply = true;
-    // TODO(MXG): What if the latest version has wrapped around the integer
-    // overflow, but this is a fresh mirror starting up? We should have a ROS2
-    // service to ask the schedule database what its oldest version is, and
-    // initialize this value to that. Or maybe the mirror wakeup can publish
-    // both its oldest and latest version.
-    // This is also relevant to the next_minimum_version value.
-    request_msg->latest_mirror_version = mirror->latest_version();
-    request_msg->minimum_patch_version = minimum_version;
-    request_msg->initial_request = initial_request;
-    initial_request = false;
-
-    const auto future = mirror_update_client->async_send_request(
-      request_msg,
-      [&](const MirrorUpdateFuture response_future)
+      std::mutex* update_mutex = options.update_mutex();
+      if (update_mutex)
       {
-        const auto response = response_future.get();
+        std::lock_guard<std::mutex> lock(*update_mutex);
+        mirror->update(patch);
+      }
+      else
+      {
+        mirror->update(patch);
+      }
+    }
+    catch (const std::exception& e)
+    {
+      RCLCPP_ERROR(
+        node.get_logger(),
+        "[rmf_traffic_ros2::MirrorManager] Failed to deserialize Patch "
+        "message: " + std::string(e.what()));
+      // Get a full update in case we're just missing some information
+      request_update();
+    }
+  }
 
-        try
-        {
-          const rmf_traffic::schedule::Patch patch =
-          convert(response->patch);
-
-          RCLCPP_DEBUG(
-            node.get_logger(),
-            "Updating mirror ["
-            + std::to_string(response->patch.latest_version)
-            + "]: " + std::to_string(patch.size()) + " changes");
-
-          std::mutex* update_mutex = options.update_mutex();
-          if (update_mutex)
-          {
-            std::lock_guard<std::mutex> lock(*update_mutex);
-            mirror->update(patch);
-          }
-          else
-          {
-            mirror->update(patch);
-          }
-
-          waiting_for_reply = false;
-          if (patch.latest_version() < next_minimum_version)
-            update(next_minimum_version);
-        }
-        catch (const std::exception& e)
-        {
-          RCLCPP_ERROR(
-            node.get_logger(),
-            "[rmf_traffic_ros2::MirrorManager] Failed to deserialize Patch "
-            "message: " + std::string(e.what()));
-        }
-      });
-
-    if (wait > rmf_traffic::Duration(0))
-      future.wait_for(wait);
+  void request_update(uint64_t minimum_version=0)
+  {
+    RequestChanges request;
+    request.query_id = query_id;
+    request.version = minimum_version;
+    RCLCPP_INFO(
+      node.get_logger(),
+      "[rmf_traffic_ros2::MirrorManager::request_update] Requesting changes "
+      "for query ID [" + std::to_string(request.query_id) +
+      "] since version [" + std::to_string(request.version) + "]");
+    request_changes_pub->publish(request);
   }
 
   ~Implementation()
   {
     UnregisterQuery::Request msg;
-    msg.query_id = request_msg->query_id;
+    msg.query_id = query_id;
     unregister_query_client->async_send_request(
       std::make_shared<UnregisterQuery::Request>(std::move(msg)));
   }
@@ -240,9 +208,9 @@ MirrorManager::snapshot_handle() const
 }
 
 //==============================================================================
-void MirrorManager::update(const rmf_traffic::Duration wait)
+void MirrorManager::update()
 {
-  _pimpl->update(_pimpl->mirror->latest_version(), wait);
+  _pimpl->request_update(_pimpl->mirror->latest_version());
 }
 
 //==============================================================================
@@ -278,7 +246,6 @@ public:
   using RegisterQueryFuture = rclcpp::Client<RegisterQuery>::SharedFuture;
   using UnregisterQueryFuture = rclcpp::Client<UnregisterQuery>::SharedFuture;
   RegisterQueryClient register_query_client;
-  MirrorUpdateClient mirror_update_client;
   UnregisterQueryClient unregister_query_client;
 
   std::atomic_bool abandon_discovery;
@@ -301,9 +268,6 @@ public:
     register_query_client =
       node.create_client<RegisterQuery>(RegisterQueryServiceName);
 
-    mirror_update_client =
-      node.create_client<MirrorUpdate>(MirrorUpdateServiceName);
-
     unregister_query_client =
       node.create_client<UnregisterQuery>(UnregisterQueryServiceName);
 
@@ -319,7 +283,6 @@ public:
     while (!abandon_discovery && !ready)
     {
       ready = register_query_client->wait_for_service(timeout);
-      ready = ready && mirror_update_client->wait_for_service(timeout);
       ready = ready && unregister_query_client->wait_for_service(timeout);
     }
 
@@ -375,7 +338,6 @@ public:
       node,
       std::move(options),
       registration.query_id,
-      std::move(mirror_update_client),
       std::move(unregister_query_client));
   }
 

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
@@ -25,7 +25,8 @@
 
 #include <rclcpp/node.hpp>
 
-#include <rmf_traffic_msgs/msg/mirror_wakeup.hpp>
+#include <rmf_traffic_msgs/msg/mirror_update.hpp>
+#include <rmf_traffic_msgs/msg/request_changes.hpp>
 
 #include <rmf_traffic_msgs/msg/itinerary_clear.hpp>
 #include <rmf_traffic_msgs/msg/itinerary_delay.hpp>
@@ -44,9 +45,7 @@
 
 #include <rmf_traffic_msgs/msg/schedule_inconsistency.hpp>
 
-#include <rmf_traffic_msgs/srv/mirror_update.hpp>
 #include <rmf_traffic_msgs/srv/register_query.hpp>
-#include <rmf_traffic_msgs/srv/mirror_update.h>
 #include <rmf_traffic_msgs/srv/unregister_query.hpp>
 #include <rmf_traffic_msgs/srv/register_participant.hpp>
 #include <rmf_traffic_msgs/srv/unregister_participant.hpp>
@@ -57,8 +56,10 @@
 
 #include <rmf_utils/Modular.hpp>
 
+#include <optional>
 #include <set>
 #include <unordered_map>
+#include <utility>
 
 namespace rmf_traffic_ros2 {
 namespace schedule {
@@ -118,20 +119,18 @@ public:
   UnregisterParticipantSrv::SharedPtr unregister_participant_service;
 
 
-  using MirrorUpdate = rmf_traffic_msgs::srv::MirrorUpdate;
-  using MirrorUpdateService = rclcpp::Service<MirrorUpdate>;
+  using MirrorUpdate = rmf_traffic_msgs::msg::MirrorUpdate;
+  using MirrorUpdateTopicPublisher = rclcpp::Publisher<MirrorUpdate>::SharedPtr;
+  using MirrorUpdateTopic =
+    std::pair<rclcpp::Publisher<MirrorUpdate>::SharedPtr,
+    std::optional<rmf_traffic::schedule::Version>>;
+  using MirrorUpdateTopicsMap =
+    std::unordered_map<uint64_t, MirrorUpdateTopic>;
+  MirrorUpdateTopicsMap mirror_update_topics;
 
-  void mirror_update(
-    const request_id_ptr& request_header,
-    const MirrorUpdate::Request::SharedPtr& request,
-    const MirrorUpdate::Response::SharedPtr& response);
-
-  MirrorUpdateService::SharedPtr mirror_update_service;
-
-
-  using MirrorWakeup = rmf_traffic_msgs::msg::MirrorWakeup;
-  using MirrorWakeupPublisher = rclcpp::Publisher<MirrorWakeup>;
-  MirrorWakeupPublisher::SharedPtr mirror_wakeup_publisher;
+  using RequestChanges = rmf_traffic_msgs::msg::RequestChanges;
+  void request_changes(const RequestChanges& request);
+  rclcpp::Subscription<RequestChanges>::SharedPtr request_changes_sub;
 
   using ItinerarySet = rmf_traffic_msgs::msg::ItinerarySet;
   void itinerary_set(const ItinerarySet& set);
@@ -157,7 +156,7 @@ public:
   rclcpp::Publisher<InconsistencyMsg>::SharedPtr inconsistency_pub;
   void publish_inconsistencies(rmf_traffic::schedule::ParticipantId id);
 
-  void wakeup_mirrors();
+  void update_mirrors();
 
   // TODO(MXG): Consider using libguarded instead of a database_mutex
   std::mutex database_mutex;
@@ -403,7 +402,6 @@ public:
     std::unordered_map<ParticipantId, Wait> _waiting;
     std::shared_ptr<const rmf_traffic::schedule::Snappable> _viewer;
     Version _next_negotiation_version = 0;
-    
   };
 
   ConflictRecord active_conflicts;


### PR DESCRIPTION
## New feature implementation

### Implemented feature

The existing method of updating schedule mirrors via a pull-based service request is not scalable to large numbers of mirrors. This group of PRs changes schedule mirroring to use push-based communication via topics.

There are three related PRs that must be merged together:
1. This PR,  which adds the topic-based communication functionality.
2. [rmf_traffic#5](https://github.com/open-rmf/rmf_traffic/pull/5), which makes the mirrors more robust to duplicate changes arriving, at the cost of efficiency (this is a temporary work-around).
3. [rmf_internal_msg#3](https://github.com/open-rmf/rmf_internal_msgs/pull/3) which adds the necessary messages.

Additionally, [this PR adding equality comparison for `Query` objects](https://github.com/open-rmf/rmf_traffic/pull/3) is a dependency.

### Implementation description

The schedule node previously provided a service to pull updates from the schedule database. Mirrors would call this service when they wanted the recent changes in the schedule. Usually this was done in response to a broadcast from the schedule node informing them that changes are available; the mirrors would generally sleep until woken by this broadcast.

The functionality added in these PRs changes communication of schedule updates from pull to push. The service and the broadcast changes-available notifier are removed. Instead, when a query is registered with the schedule node, it creates a topic named `query_updates_` with the query ID appended, and responds to the query registration call with the ID of the registered query. The mirror manager node knows to subscribe to the correct topic based on the received query ID, and does so. The schedule node then broadcasts any changes relevant to that query over that topic, allowing the mirror to receive the changes without needing to make a request first.

For further scalability improvements, when a query is registered that is the same as an existing query, the schedule node does not create a new topic. Instead it sends the ID of the existing query. This allows multiple mirrors to listen to the same topic if they are interested in the same query.

To allow a new mirror to receive the entire database even though it joins after some changes have been broadcast, a new mirror joining an existing query will cause the entire database to be re-broadcast to all mirrors of that query. This mostly ensures that all mirrors have all information. However, there are two caveats to this that require temporary workarounds.

1. Delays in topic subscriptions being connected means that sometimes the whole-database message is missed by the new query mirror. This causes it to fail to interpret subsequent individual-change messages, such as a delay message for a participant that it doesn't know about or the erasure of a route that it doesn't have yet. To work around this, encountering an error in interpreting a patch will cause that mirror to request the full database again.
2. Existing mirrors will receive participants, changes, etc. that they already know about. This was previously considered an error. To work around this, these are no longer treated as errors. A log message is output and the duplicate entry is ignored.

These two workarounds will no longer be necessary once how schedules are synchronised is updated to split participant information synchronisation and itinerary information synchronisation. This will be done in a future PR.

### How to test

Start the office demo:

```
ros2 launch rmf_demos office.launch.xml
```

In another terminal, trigger a couple of loop requests:

```
ros2 run rmf_demos_tasks dispatch_loop -s coe -f lounge -n 3 --use_sim_time
```

The schedule should be displayed as normal in `rviz`.

The schedule information flowing over the topic can be verified:

```
ros2 topic echo /rmf_traffic/query_update_1
```

Finally, killing the node that is visualising the schedule in rviz and restarting it should show the schedule disappear when the node is killed and then get displayed again after restarting it.