### PR TITLE
Adding reference_internal tag to function bindings that return raw pointers

### DIFF
--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -123,6 +123,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
              [&](agv::RobotUpdateHandle& self){
                 return self.unstable().get_participant();
              },
+             py::return_value_policy::reference_internal,
              "Experimental API to access the schedule participant");
 
     // FLEETUPDATE HANDLE ======================================================

--- a/rmf_fleet_adapter_python/src/graph/graph.cpp
+++ b/rmf_fleet_adapter_python/src/graph/graph.cpp
@@ -168,10 +168,15 @@ void bind_graph(py::module &m) {
       .def("get_lane", py::overload_cast<std::size_t>(&Graph::get_lane))
       .def("get_lane", py::overload_cast<std::size_t>(
           &Graph::get_lane, py::const_))
-      .def("lane_from", py::overload_cast<std::size_t, std::size_t>(
-        &Graph::lane_from))
-      .def("lane_from", py::overload_cast<std::size_t, std::size_t>(
-        &Graph::lane_from, py::const_))
+      .def(
+        "lane_from",
+        py::overload_cast<std::size_t, std::size_t>(&Graph::lane_from),
+        py::return_value_policy::reference_internal)
+      .def(
+        "lane_from",
+        py::overload_cast<std::size_t, std::size_t>(
+          &Graph::lane_from, py::const_),
+        py::return_value_policy::reference_internal)
       .def_property_readonly("num_lanes", &Graph::num_lanes)
       .def("lanes_from_waypoint",
           py::overload_cast<std::size_t>(&Graph::lanes_from, py::const_),


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

https://github.com/open-rmf/rmf_ros2/issues/4

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

The functions that were bound returns a raw pointer, using the fallback `return_value_policy::take_ownership`, it deletes the item after it goes out of scope in python. Specifying them to use `return_value_policy::reference_internal` prevents that.
