### PR TITLE
Feature/python binding planner

### DIFF
--- a/rmf_fleet_adapter_python/CMakeLists.txt
+++ b/rmf_fleet_adapter_python/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
 find_package(ament_cmake REQUIRED)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -123,6 +123,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
              [&](agv::RobotUpdateHandle& self){
                 return self.unstable().get_participant();
              },
+             py::return_value_policy::reference_internal,
              "Experimental API to access the schedule participant");
 
     // FLEETUPDATE HANDLE ======================================================

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -276,7 +276,12 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::class_<rclcpp::Node, std::shared_ptr<rclcpp::Node> >(m, "Node")
         .def("now", [](rclcpp::Node& self){
             return rmf_traffic_ros2::convert(self.now());
-        });
+        })
+        .def("use_sim_time", [](rclcpp::Node& self)
+            {
+              rclcpp::Parameter param("use_sim_time", true);
+              self.set_parameter(param);
+            });
 
     // Python rclcpp init and spin call
     m.def("init_rclcpp", [](){ rclcpp::init(0, nullptr); });

--- a/rmf_fleet_adapter_python/src/graph/graph.cpp
+++ b/rmf_fleet_adapter_python/src/graph/graph.cpp
@@ -168,10 +168,15 @@ void bind_graph(py::module &m) {
       .def("get_lane", py::overload_cast<std::size_t>(&Graph::get_lane))
       .def("get_lane", py::overload_cast<std::size_t>(
           &Graph::get_lane, py::const_))
-      .def("lane_from", py::overload_cast<std::size_t, std::size_t>(
-        &Graph::lane_from))
-      .def("lane_from", py::overload_cast<std::size_t, std::size_t>(
-        &Graph::lane_from, py::const_))
+      .def(
+        "lane_from",
+        py::overload_cast<std::size_t, std::size_t>(&Graph::lane_from),
+        py::return_value_policy::reference_internal)
+      .def(
+        "lane_from",
+        py::overload_cast<std::size_t, std::size_t>(
+          &Graph::lane_from, py::const_),
+        py::return_value_policy::reference_internal)
       .def_property_readonly("num_lanes", &Graph::num_lanes)
       .def("lanes_from_waypoint",
           py::overload_cast<std::size_t>(&Graph::lanes_from, py::const_),

--- a/rmf_fleet_adapter_python/src/planner/planner.cpp
+++ b/rmf_fleet_adapter_python/src/planner/planner.cpp
@@ -7,8 +7,6 @@
 #include "rmf_traffic_ros2/Time.hpp"
 #include <rmf_traffic/agv/Planner.hpp>
 
-#include <stdexcept>
-
 namespace py = pybind11;
 
 using Plan = rmf_traffic::agv::Plan;
@@ -182,14 +180,14 @@ void bind_plan(py::module &m) {
               Start start,
               Goal goal)
           {
+            std::vector<Plan::Waypoint> waypoints;
             const auto result = self.plan(start, goal);
             if (result.success())
             {
-              const auto& waypoints = result->get_waypoints();
-              return waypoints;
+              waypoints = result->get_waypoints();
             }
 
-            throw std::runtime_error("Unable to generate a plan");
+            return waypoints;
 
           },
           py::arg("start"), py::arg("goal"),

--- a/rmf_fleet_adapter_python/src/planner/planner.cpp
+++ b/rmf_fleet_adapter_python/src/planner/planner.cpp
@@ -18,6 +18,9 @@ using Goal = Planner::Goal;
 using Options = Planner::Options;
 using Configuration = Planner::Configuration;
 using Result = Planner::Result;
+using Graph = rmf_traffic::agv::Graph;
+using VehicleTraits = rmf_traffic::agv::VehicleTraits;
+using Interpolate = rmf_traffic::agv::Interpolate;
 
 using TimePoint = std::chrono::time_point<std::chrono::system_clock,
                                           std::chrono::nanoseconds>;
@@ -144,4 +147,35 @@ void bind_plan(py::module &m) {
                     py::overload_cast<>(&Plan::Goal::orientation, py::const_),
                     py::overload_cast<double>(&Plan::Goal::orientation))
       .def("any_orientation", &Plan::Goal::any_orientation);
+
+  // Configuration =============================================================
+  py::class_<Configuration>(m_plan, "Configuration")
+      .def(py::init<Graph, VehicleTraits, Interpolate::Options>(),
+           py::arg("graph"),
+           py::arg("traits"),
+           py::arg("interpolation") = Interpolate::Options())
+      .def_property_readonly("graph", &Configuration::graph)
+      .def_property_readonly("traits", &Configuration::vehicle_traits)
+      .def_property_readonly("interpolation", &Configuration::interpolation);
+  
+  // Options =============================================================
+  // TODO
+
+  // Planner ===================================================================
+  py::class_<Planner>(m_plan, "Planner")
+      .def(py::init<Configuration, Options>(),
+           py::arg("config"),
+           py::arg("options") = Planner::Options{nullptr})
+      .def("plan",
+          [&](Planner& self,
+              Start& start,
+              Goal goal)
+          {
+            auto result = self.plan(start, goal);
+            return *result;
+          },
+          py::arg("start"), py::arg("goal"),
+          py::call_guard<py::scoped_ostream_redirect,
+                         py::scoped_estream_redirect>());
+
 }

--- a/rmf_fleet_adapter_python/src/planner/planner.cpp
+++ b/rmf_fleet_adapter_python/src/planner/planner.cpp
@@ -164,9 +164,6 @@ void bind_plan(py::module &m) {
   
   // Options =============================================================
   // TODO
-  // Light wrappers
-  py::class_<Interpolate::Options>(m, "InterpolateOptions")
-      .def(py::init<>());
  
   // Planner ===================================================================
   py::class_<Planner>(m_plan, "Planner")

--- a/rmf_fleet_adapter_python/tests/unit/test_planner.py
+++ b/rmf_fleet_adapter_python/tests/unit/test_planner.py
@@ -1,11 +1,12 @@
+#! /usr/bin/env python3 
+
 import rmf_adapter.vehicletraits as traits
 import rmf_adapter.geometry as geometry
 import rmf_adapter.graph as graph
 import rmf_adapter.graph.lane as lane
 import rmf_adapter.plan as plan
 
-from datetime import timedelta
-
+import datetime
 
 """
                   10
@@ -39,6 +40,22 @@ nav_graph.add_waypoint(map_name, [5.0, 5.0]) \
 nav_graph.add_waypoint(map_name, [0.0, 10.0]) \
     .set_parking_spot(True)  # 10
 
+lanes = [[0, 1],
+         [1, 2],
+         [1, 5],
+         [2, 6],
+         [3, 4],
+         [4, 5],
+         [5, 6],
+         [6, 7],
+         [5, 8],
+         [6, 9],
+         [8, 9],
+         [8, 10]]
+for _lane in lanes:
+    nav_graph.add_bidir_lane(*_lane)
+assert nav_graph.num_lanes == 24
+
 profile = traits.Profile(geometry.make_final_convex_circle(1.0),
     geometry.make_final_convex_circle(1.5))
 vehicle_traits = traits.VehicleTraits(
@@ -51,11 +68,10 @@ config = plan.Configuration(nav_graph, vehicle_traits)
 planner = plan.Planner(config)
 assert(planner)
 
-
 start = plan.Start(
-    timedelta(seconds=0),
+    datetime.datetime.today(),
     0,
     0.0)
 goal = plan.Goal(7)
-computed_plan = planner.plan(start, goal)
-assert(computed_plan)
+waypoints = planner.get_plan_waypoints(start, goal)
+assert(waypoints)

--- a/rmf_fleet_adapter_python/tests/unit/test_planner.py
+++ b/rmf_fleet_adapter_python/tests/unit/test_planner.py
@@ -1,0 +1,61 @@
+import rmf_adapter.vehicletraits as traits
+import rmf_adapter.geometry as geometry
+import rmf_adapter.graph as graph
+import rmf_adapter.graph.lane as lane
+import rmf_adapter.plan as plan
+
+from datetime import timedelta
+
+
+"""
+                  10
+                   |
+                   |
+                   8------9
+                   |      |
+                   |      |
+     3------4------5------6------7
+                   |      |
+                   |      |
+                   1------2
+                   |
+                   |
+                   0
+"""
+map_name = "test_map"
+nav_graph = graph.Graph()
+nav_graph.add_waypoint(map_name, [0.0, -10.0])  # 0
+nav_graph.add_waypoint(map_name, [0.0, -5.0])  # 1
+nav_graph.add_waypoint(map_name, [5.0, -5.0])  # 2
+nav_graph.add_waypoint(map_name, [-10.0, 0])  # 3
+nav_graph.add_waypoint(map_name, [-5.0, 0.0])  # 4
+nav_graph.add_waypoint(map_name, [0.0, 0.0])  # 5
+nav_graph.add_waypoint(map_name, [5.0, 0.0])  # 6
+nav_graph.add_waypoint(map_name, [10.0, 0.0])  # 7
+nav_graph.add_waypoint(map_name, [0.0, 5.0]) \
+    .set_holding_point(True)  # 8
+nav_graph.add_waypoint(map_name, [5.0, 5.0]) \
+    .set_passthrough_point(True)  # 9
+nav_graph.add_waypoint(map_name, [0.0, 10.0]) \
+    .set_parking_spot(True)  # 10
+
+profile = traits.Profile(geometry.make_final_convex_circle(1.0),
+    geometry.make_final_convex_circle(1.5))
+vehicle_traits = traits.VehicleTraits(
+    linear=traits.Limits(0.5, 0.3),
+    angular=traits.Limits(0.3, 0.4),
+    profile=profile)
+vehicle_traits.differential.reversible = False
+
+config = plan.Configuration(nav_graph, vehicle_traits)
+planner = plan.Planner(config)
+assert(planner)
+
+
+start = plan.Start(
+    timedelta(seconds=0),
+    0,
+    0.0)
+goal = plan.Goal(7)
+computed_plan = planner.plan(start, goal)
+assert(computed_plan)


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## New feature implementation

### Implemented feature
Added additional python bindings:
1. Minimal support for `rmf_traffic::agv::Planner`. A `get_plan_waypoints` function is implemented which returns a list of waypoints in the plan if the planner was successful.
2. Updated the Node wrapper to allow users to set `use_sim_time` parameter to `true`. This is helpful for testing fleet adapters in simulation.
<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

