### PR TITLE
Handle empty startset in full_control

### DIFF
--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -474,12 +474,15 @@ struct Connections : public std::enable_shared_from_this<Connections>
     {
       RCLCPP_ERROR(
         adapter->node()->get_logger(),
-        "Unable to compute a StartSet for robot [%s]. This can happen if the "
-        "level_name in the RobotState message does not match any of the "
-        "map names in the navigation graph supplied or if the location "
+        "Unable to compute a StartSet for robot [%s] using level_name [%s] and "
+        "location [%f,%f,%f] specified in its RobotState message. This can "
+        "happen if the level_name in the RobotState message does not match any "
+        "of the map names in the navigation graph supplied or if the location "
         "reported in the RobotState message is far way from the navigation "
-        "graph. This robot will not be added to the fleet [%s]",
+        "graph. This robot will not be added to the fleet [%s].",
         state.name.c_str(),
+        state.location.level_name.c_str(),
+        l.x, l.y, l.yaw,
         fleet_name.c_str());
 
         return;

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -476,7 +476,7 @@ struct Connections : public std::enable_shared_from_this<Connections>
       RCLCPP_ERROR(
         adapter->node()->get_logger(),
         "Unable to compute a StartSet for robot [%s] using level_name [%s] and "
-        "location [%f,%f,%f] specified in its RobotState message. This can "
+        "location [%f, %f, %f] specified in its RobotState message. This can "
         "happen if the level_name in the RobotState message does not match any "
         "of the map names in the navigation graph supplied or if the location "
         "reported in the RobotState message is far way from the navigation "

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -53,7 +53,6 @@
 
 #include <Eigen/Geometry>
 #include <unordered_set>
-#include <stdexcept>
 
 //==============================================================================
 rmf_fleet_adapter::agv::RobotUpdateHandle::Unstable::Decision
@@ -486,9 +485,7 @@ struct Connections : public std::enable_shared_from_this<Connections>
         l.x, l.y, l.yaw,
         fleet_name.c_str());
 
-        throw std::runtime_error(
-          "[full_control][Connections::add_robot] Empty StartSet generated.");
-
+      return;
     }
     fleet->add_robot(
           command, robot_name, traits->profile(),

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -53,6 +53,7 @@
 
 #include <Eigen/Geometry>
 #include <unordered_set>
+#include <stdexcept>
 
 //==============================================================================
 rmf_fleet_adapter::agv::RobotUpdateHandle::Unstable::Decision
@@ -485,7 +486,9 @@ struct Connections : public std::enable_shared_from_this<Connections>
         l.x, l.y, l.yaw,
         fleet_name.c_str());
 
-        return;
+        throw std::runtime_error(
+          "[full_control][Connections::add_robot] Empty StartSet generated.");
+
     }
     fleet->add_robot(
           command, robot_name, traits->profile(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -39,6 +39,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <stdexcept>
 
 namespace rmf_fleet_adapter {
 namespace agv {
@@ -984,7 +985,14 @@ void FleetUpdateHandle::add_robot(
     rmf_traffic::agv::Plan::StartSet start,
     std::function<void(std::shared_ptr<RobotUpdateHandle>)> handle_cb)
 {
-  assert(!start.empty());
+  
+  if (start.empty())
+  {
+    throw std::runtime_error(
+      "[FleetUpdateHandle::add_robot] StartSet is empty. The function requires"
+      "at least one rmf_traffic::agv::Plan::Start to be specified");
+  }
+
   rmf_traffic::schedule::ParticipantDescription description(
         name,
         _pimpl->name,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -989,8 +989,9 @@ void FleetUpdateHandle::add_robot(
   if (start.empty())
   {
     throw std::runtime_error(
-      "[FleetUpdateHandle::add_robot] StartSet is empty. The function requires"
-      "at least one rmf_traffic::agv::Plan::Start to be specified");
+      "[FleetUpdateHandle::add_robot] StartSet is empty. Adding a robot to a "
+      "fleet requires at least one rmf_traffic::agv::Plan::Start to be "
+      "specified.");
   }
 
   rmf_traffic::schedule::ParticipantDescription description(


### PR DESCRIPTION
Signed-off-by: Yadunund <yadunund@openrobotics.org>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

Fix for https://github.com/open-rmf/rmf_ros2/issues/12
<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

### Fix applied
Check if output of `compute_plan_starts() is empty and if so return after outputting an error
<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->
