### PR TITLE
Lane closure

### DIFF
--- a/rmf_fleet_adapter/CHANGELOG.rst
+++ b/rmf_fleet_adapter/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog for package rmf_fleet_adapter
 
 1.3.0 (2021-XX-XX)
 ------------------
+* Add API for opening and closing lanes: [#15](https://github.com/open-rmf/rmf_ros2/pull/15)
+    * Added `open_lanes` and `close_lanes` CLI tools for issuing requests
 * Allow Traffic Light APIs to update the location of a robot while it is idle: [#270](https://github.com/osrf/rmf_core/pull/270)
 * Allow TrafficLight and EasyTrafficLight API to update battery level: [#263](https://github.com/osrf/rmf_core/pull/263)
 * Migrating to a task dispatcher framework: [#217](https://github.com/osrf/rmf_core/pull/217)

--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -319,6 +319,38 @@ target_include_directories(task_aggregator
 
 # -----------------------------------------------------------------------------
 
+add_executable(open_lanes src/open_lanes/main.cpp)
+
+target_link_libraries(open_lanes
+  PRIVATE
+    ${rmf_fleet_msgs_LIBRARIES}
+    rclcpp::rclcpp
+    rmf_fleet_adapter
+)
+
+target_include_directories(open_lanes
+  PRIVATE
+    ${rmf_fleet_msgs_INCLUDE_DIRS}
+)
+
+# -----------------------------------------------------------------------------
+
+add_executable(close_lanes src/close_lanes/main.cpp)
+
+target_link_libraries(close_lanes
+  PRIVATE
+    ${rmf_fleet_msgs_LIBRARIES}
+    rclcpp::rclcpp
+    rmf_fleet_adapter
+)
+
+target_include_directories(close_lanes
+  PRIVATE
+    ${rmf_fleet_msgs_INCLUDE_DIRS}
+)
+
+# -----------------------------------------------------------------------------
+
 ament_export_targets(rmf_fleet_adapter HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   rmf_task
@@ -342,6 +374,8 @@ install(
     robot_state_aggregator
     test_read_only_adapter
     task_aggregator
+    open_lanes
+    close_lanes
   EXPORT rmf_fleet_adapter
   RUNTIME DESTINATION lib/rmf_fleet_adapter
   LIBRARY DESTINATION lib

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -57,6 +57,9 @@ const std::string DispatchAckTopicName = "rmf_task/dispatch_ack";
 
 const std::string DockSummaryTopicName = "dock_summary";
 
+const std::string LaneClosureRequestTopicName = "lane_closure_requests";
+const std::string ClosedLaneTopicName = "closed_lanes";
+
 } // namespace rmf_fleet_adapter
 
 #endif // RMF_FLEET_ADAPTER__STANDARDNAMES_HPP

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -68,6 +68,12 @@ public:
       rmf_traffic::agv::Plan::StartSet start,
       std::function<void(std::shared_ptr<RobotUpdateHandle> handle)> handle_cb);
 
+  /// Specify a set of lanes that should be closed.
+  void close_lanes(std::vector<std::size_t> lane_indices);
+
+  /// Specify a set of lanes that should be open.
+  void open_lanes(std::vector<std::size_t> lane_indices);
+
   /// Set the parameters required for task planning
   ///
   /// \param[in] battery_system

--- a/rmf_fleet_adapter/src/close_lanes/main.cpp
+++ b/rmf_fleet_adapter/src/close_lanes/main.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/executors.hpp>
+
+#include <rmf_fleet_msgs/msg/lane_request.hpp>
+#include <rmf_fleet_msgs/msg/closed_lanes.hpp>
+
+#include <rmf_fleet_adapter/StandardNames.hpp>
+
+#include <iostream>
+#include <vector>
+#include <unordered_set>
+
+//==============================================================================
+int help(const std::string& extra_message)
+{
+  if (!extra_message.empty())
+    std::cout << extra_message << "\n";
+
+  std::cout << R"raw(
+  Usage:
+    close_lanes <fleet_name> <lane0 [lane1 [lane2 ...]]>
+)raw";
+  std::cout << std::endl;
+
+  return 1;
+}
+
+//==============================================================================
+int main(int argc, char* argv[])
+{
+  const auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
+
+  if (args.size() <= 2)
+    return help("Not enough arguments");
+
+  const std::string fleet_name = std::string(args[1]);
+
+  std::vector<uint64_t> lanes;
+  std::vector<std::size_t> failed_conversions;
+  for (std::size_t i = 2; i < args.size(); ++i)
+  {
+    try
+    {
+      lanes.push_back(std::stoll(argv[i]));
+    }
+    catch (const std::exception&)
+    {
+      failed_conversions.push_back(i);
+    }
+  }
+
+  if (!failed_conversions.empty())
+  {
+    std::string extra_message = "Could not convert argument";
+    if (failed_conversions.size() > 1)
+      extra_message += "s";
+
+    for (const auto& f : failed_conversions)
+      extra_message += " " + std::to_string(f);
+
+    extra_message + " into integers";
+    return help(extra_message);
+  }
+
+  std::cout << "Requesting [" << fleet_name << "] to close lanes { ";
+  for (const auto& l : lanes)
+    std::cout << l << " ";
+  std::cout << "}..." << std::endl;
+
+  const auto node = std::make_shared<rclcpp::Node>(fleet_name + "_close_lanes");
+  std::promise<void> request_complete;
+  std::shared_future<void> future = request_complete.get_future();
+
+  rmf_fleet_msgs::msg::LaneRequest request;
+  request.fleet_name = fleet_name;
+  request.close_lanes = lanes;
+
+  const auto publisher =
+    node->create_publisher<rmf_fleet_msgs::msg::LaneRequest>(
+      rmf_fleet_adapter::LaneClosureRequestTopicName,
+      rclcpp::SystemDefaultsQoS().transient_local());
+
+  publisher->publish(request);
+
+  const auto timer = node->create_wall_timer(
+    std::chrono::milliseconds(100),
+    [request, publisher]()
+  {
+    publisher->publish(request);
+  });
+
+  std::unordered_set<uint64_t> close_lanes(lanes.begin(), lanes.end());
+  const auto listener =
+    node->create_subscription<rmf_fleet_msgs::msg::ClosedLanes>(
+      rmf_fleet_adapter::ClosedLaneTopicName,
+      rclcpp::SystemDefaultsQoS().transient_local(),
+      [&request_complete, fleet_name, close_lanes = std::move(close_lanes)](
+        std::unique_ptr<rmf_fleet_msgs::msg::ClosedLanes> msg)
+  {
+    if (msg->fleet_name != fleet_name)
+      return;
+
+    auto still_open = close_lanes;
+    for (const auto& l : msg->closed_lanes)
+    {
+      still_open.erase(l);
+    }
+
+    if (still_open.empty())
+      request_complete.set_value();
+  });
+
+  rclcpp::spin_until_future_complete(node, future);
+
+  if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+    std::cout << "\n... The requested lanes are closed!" << std::endl;
+  else
+    std::cout << "\n... Interrupted" << std::endl;
+}

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -123,6 +123,7 @@ public:
     auto lock = _lock();
     _clear_last_command();
 
+    _travel_info.target_plan_index = std::nullopt;
     _travel_info.waypoints = waypoints;
     _travel_info.next_arrival_estimator = std::move(next_arrival_estimator);
     _travel_info.path_finished_callback = std::move(path_finished_callback);

--- a/rmf_fleet_adapter/src/open_lanes/main.cpp
+++ b/rmf_fleet_adapter/src/open_lanes/main.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/executors.hpp>
+
+#include <rmf_fleet_msgs/msg/lane_request.hpp>
+#include <rmf_fleet_msgs/msg/closed_lanes.hpp>
+
+#include <rmf_fleet_adapter/StandardNames.hpp>
+
+#include <iostream>
+#include <vector>
+#include <unordered_set>
+
+//==============================================================================
+int help(const std::string& extra_message)
+{
+  if (!extra_message.empty())
+    std::cout << extra_message << "\n";
+
+  std::cout << R"raw(
+  Usage:
+    open_lanes <fleet_name> <lane0 [lane1 [lane2 ...]]>
+)raw";
+  std::cout << std::endl;
+
+  return 1;
+}
+
+//==============================================================================
+int main(int argc, char* argv[])
+{
+  const auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
+
+  if (args.size() <= 2)
+    return help("Not enough arguments");
+
+  const std::string fleet_name = std::string(args[1]);
+
+  std::vector<uint64_t> lanes;
+  std::vector<std::size_t> failed_conversions;
+  for (std::size_t i = 2; i < args.size(); ++i)
+  {
+    try
+    {
+      lanes.push_back(std::stoll(argv[i]));
+    }
+    catch (const std::exception&)
+    {
+      failed_conversions.push_back(i);
+    }
+  }
+
+  if (!failed_conversions.empty())
+  {
+    std::string extra_message = "Could not convert argument";
+    if (failed_conversions.size() > 1)
+      extra_message += "s";
+
+    for (const auto& f : failed_conversions)
+      extra_message += " " + std::to_string(f);
+
+    extra_message + " into integers";
+    return help(extra_message);
+  }
+
+  std::cout << "Requesting [" << fleet_name << "] to open lanes { ";
+  for (const auto& l : lanes)
+    std::cout << l << " ";
+  std::cout << "}..." << std::endl;
+
+  const auto node = std::make_shared<rclcpp::Node>(fleet_name + "_open_lanes");
+  std::promise<void> request_complete;
+  std::shared_future<void> future = request_complete.get_future();
+
+  rmf_fleet_msgs::msg::LaneRequest request;
+  request.fleet_name = fleet_name;
+  request.open_lanes = lanes;
+
+  const auto publisher =
+    node->create_publisher<rmf_fleet_msgs::msg::LaneRequest>(
+      rmf_fleet_adapter::LaneClosureRequestTopicName,
+      rclcpp::SystemDefaultsQoS().transient_local());
+
+  publisher->publish(request);
+
+  const auto timer = node->create_wall_timer(
+    std::chrono::milliseconds(100),
+    [request, publisher]()
+  {
+    publisher->publish(request);
+  });
+
+  std::unordered_set<uint64_t> open_lanes(lanes.begin(), lanes.end());
+  const auto listener =
+    node->create_subscription<rmf_fleet_msgs::msg::ClosedLanes>(
+      rmf_fleet_adapter::ClosedLaneTopicName,
+      rclcpp::SystemDefaultsQoS().transient_local(),
+      [&request_complete, fleet_name, open_lanes = std::move(open_lanes)](
+        std::unique_ptr<rmf_fleet_msgs::msg::ClosedLanes> msg)
+  {
+    if (msg->fleet_name != fleet_name)
+      return;
+
+    for (const auto& l : msg->closed_lanes)
+    {
+      if (open_lanes.count(l))
+        return;
+    }
+
+    request_complete.set_value();
+  });
+
+  rclcpp::spin_until_future_complete(node, future);
+
+  if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+    std::cout << "\n... The requested lanes are open!" << std::endl;
+  else
+    std::cout << "\n... Interrupted" << std::endl;
+}

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -469,7 +469,7 @@ void TaskManager::retreat_to_charger()
   const double retreat_threshold = 1.2 * threshold_soc;
   const double current_battery_soc = _context->current_battery_soc();
 
-  const auto task_planner_config = task_planner->config();
+  const auto& task_planner_config = task_planner->config();
   const auto estimate_cache = task_planner->estimate_cache();
 
   double retreat_battery_drain = 0.0;
@@ -485,7 +485,7 @@ void TaskManager::retreat_to_charger()
   {
     const rmf_traffic::agv::Planner::Goal retreat_goal{
       current_state.charging_waypoint()};
-    const auto result_to_charger = task_planner_config->planner()->plan(
+    const auto result_to_charger = task_planner_config.planner()->plan(
       current_state.location(), retreat_goal);
 
     // We assume we can always compute a plan
@@ -502,10 +502,10 @@ void TaskManager::retreat_to_charger()
         finish_time - itinerary_start_time;
 
       dSOC_motion =
-        task_planner_config->motion_sink()->compute_change_in_charge(
+        task_planner_config.motion_sink()->compute_change_in_charge(
           trajectory);
       dSOC_device =
-        task_planner_config->ambient_sink()->compute_change_in_charge(
+        task_planner_config.ambient_sink()->compute_change_in_charge(
           rmf_traffic::time::to_seconds(itinerary_duration));
       retreat_battery_drain += dSOC_motion + dSOC_device;
       retreat_duration +=itinerary_duration;
@@ -523,10 +523,10 @@ void TaskManager::retreat_to_charger()
   {
     // Add a new charging task to the task queue
     auto charging_request = rmf_task::requests::ChargeBattery::make(
-      task_planner_config->battery_system(),
-      task_planner_config->motion_sink(),
-      task_planner_config->ambient_sink(),
-      task_planner_config->planner(),
+      task_planner_config.battery_system(),
+      task_planner_config.motion_sink(),
+      task_planner_config.ambient_sink(),
+      task_planner_config.planner(),
       current_state.finish_time());
 
     const auto finish = charging_request->description()->estimate_finish(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -209,11 +209,13 @@ std::shared_ptr<FleetUpdateHandle> Adapter::add_fleet(
     rmf_traffic::agv::VehicleTraits traits,
     rmf_traffic::agv::Graph navigation_graph)
 {
-  auto planner = std::make_shared<rmf_traffic::agv::Planner>(
+  auto planner =
+    std::make_shared<std::shared_ptr<const rmf_traffic::agv::Planner>>(
+      std::make_shared<rmf_traffic::agv::Planner>(
         rmf_traffic::agv::Planner::Configuration(
           std::move(navigation_graph),
           std::move(traits)),
-        rmf_traffic::agv::Planner::Options(nullptr));
+        rmf_traffic::agv::Planner::Options(nullptr)));
 
   auto fleet = FleetUpdateHandle::Implementation::make(
         fleet_name, std::move(planner), _pimpl->node, _pimpl->worker,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -244,7 +244,7 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       motion_sink,
       ambient_sink,
       tool_sink,
-      planner,
+      *planner,
       start_time,
       drain_battery,
       priority);
@@ -742,7 +742,7 @@ std::size_t FleetUpdateHandle::Implementation::get_nearest_charger(
   const std::unordered_set<std::size_t>& charging_waypoints)
 {
   assert(!charging_waypoints.empty());
-  const auto& graph = planner->get_configuration().graph();
+  const auto& graph = (*planner)->get_configuration().graph();
   Eigen::Vector2d p = graph.get_waypoint(start.waypoint()).get_location();
 
   if (start.location().has_value())
@@ -1015,7 +1015,6 @@ void FleetUpdateHandle::add_robot(
             fleet->_pimpl->planner,
             fleet->_pimpl->node,
             fleet->_pimpl->worker,
-            fleet->_pimpl->lane_closures,
             fleet->_pimpl->default_maximum_delay,
             state,
             task_planning_constraints,
@@ -1074,8 +1073,33 @@ void FleetUpdateHandle::close_lanes(std::vector<std::size_t> lane_indices)
       if (!self)
         return;
 
+      const auto& current_lane_closures =
+        (*self->_pimpl->planner)->get_configuration().lane_closures();
+
+      bool any_changes = false;
       for (const auto& lane : lane_indices)
-        self->_pimpl->lane_closures->close(lane);
+      {
+        if (current_lane_closures.is_open(lane))
+        {
+          any_changes = true;
+          break;
+        }
+      }
+
+      if (!any_changes)
+      {
+        // No changes are needed to the planner
+        return;
+      }
+
+      auto new_config = (*self->_pimpl->planner)->get_configuration();
+      auto& new_lane_closures = new_config.lane_closures();
+      for (const auto& lane : lane_indices)
+        new_lane_closures.close(lane);
+
+      *self->_pimpl->planner =
+        std::make_shared<const rmf_traffic::agv::Planner>(
+          new_config, rmf_traffic::agv::Planner::Options(nullptr));
     });
 }
 
@@ -1089,8 +1113,33 @@ void FleetUpdateHandle::open_lanes(std::vector<std::size_t> lane_indices)
       if (!self)
         return;
 
+      const auto& current_lane_closures =
+        (*self->_pimpl->planner)->get_configuration().lane_closures();
+
+      bool any_changes = false;
       for (const auto& lane : lane_indices)
-        self->_pimpl->lane_closures->open(lane);
+      {
+        if (current_lane_closures.is_closed(lane))
+        {
+          any_changes = true;
+          break;
+        }
+      }
+
+      if (!any_changes)
+      {
+        // No changes are needed to the planner
+        return;
+      }
+
+      auto new_config = (*self->_pimpl->planner)->get_configuration();
+      auto& new_lane_closures = new_config.lane_closures();
+      for (const auto& lane : lane_indices)
+        new_lane_closures.open(lane);
+
+      *self->_pimpl->planner =
+        std::make_shared<const rmf_traffic::agv::Planner>(
+            new_config, rmf_traffic::agv::Planner::Options(nullptr));
     });
 }
 
@@ -1147,17 +1196,17 @@ bool FleetUpdateHandle::set_task_planner_params(
     _pimpl->ambient_sink = ambient_sink;
     _pimpl->tool_sink = tool_sink;
 
-    std::shared_ptr<rmf_task::agv::TaskPlanner::Configuration> task_config =
-      std::make_shared<rmf_task::agv::TaskPlanner::Configuration>(
+    auto task_config =
+      rmf_task::agv::TaskPlanner::Configuration(
         *battery_system,
         motion_sink,
         ambient_sink,
-        _pimpl->planner,
+        *_pimpl->planner,
         _pimpl->cost_calculator);
-    
+
     _pimpl->task_planner = std::make_shared<rmf_task::agv::TaskPlanner>(
-      task_config);
-    
+      std::move(task_config));
+
     _pimpl->initialized_task_planner = true;
 
     return _pimpl->initialized_task_planner;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1196,8 +1196,8 @@ bool FleetUpdateHandle::set_task_planner_params(
     _pimpl->ambient_sink = ambient_sink;
     _pimpl->tool_sink = tool_sink;
 
-    std::shared_ptr<rmf_task::agv::TaskPlanner::Configuration> task_config =
-      std::make_shared<rmf_task::agv::TaskPlanner::Configuration>(
+    auto task_config =
+      rmf_task::agv::TaskPlanner::Configuration(
         *battery_system,
         motion_sink,
         ambient_sink,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -118,14 +118,14 @@ const std::string& RobotContext::requester_id() const
 //==============================================================================
 const rmf_traffic::agv::Graph& RobotContext::navigation_graph() const
 {
-  return _planner->get_configuration().graph();
+  return (*_planner)->get_configuration().graph();
 }
 
 //==============================================================================
 const std::shared_ptr<const rmf_traffic::agv::Planner>&
 RobotContext::planner() const
 {
-  return _planner;
+  return *_planner;
 }
 
 //==============================================================================
@@ -197,6 +197,12 @@ std::shared_ptr<const Node> RobotContext::node() const
 const rxcpp::schedulers::worker& RobotContext::worker() const
 {
   return _worker;
+}
+
+//==============================================================================
+const rmf_traffic::agv::LaneClosure& RobotContext::lane_closures() const
+{
+  return *_lane_closure;
 }
 
 //==============================================================================
@@ -307,7 +313,7 @@ RobotContext::RobotContext(
   std::vector<rmf_traffic::agv::Plan::Start> _initial_location,
   rmf_traffic::schedule::Participant itinerary,
   std::shared_ptr<const Snappable> schedule,
-  std::shared_ptr<const rmf_traffic::agv::Planner> planner,
+  std::shared_ptr<std::shared_ptr<const rmf_traffic::agv::Planner>> planner,
   std::shared_ptr<rmf_fleet_adapter::agv::Node> node,
   const rxcpp::schedulers::worker& worker,
   rmf_utils::optional<rmf_traffic::Duration> maximum_delay,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -200,12 +200,6 @@ const rxcpp::schedulers::worker& RobotContext::worker() const
 }
 
 //==============================================================================
-const rmf_traffic::agv::LaneClosure& RobotContext::lane_closures() const
-{
-  return *_lane_closure;
-}
-
-//==============================================================================
 rmf_utils::optional<rmf_traffic::Duration> RobotContext::maximum_delay() const
 {
   return _maximum_delay;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -156,7 +156,7 @@ private:
     std::vector<rmf_traffic::agv::Plan::Start> _initial_location,
     rmf_traffic::schedule::Participant itinerary,
     std::shared_ptr<const Snappable> schedule,
-    std::shared_ptr<const rmf_traffic::agv::Planner> planner,
+    std::shared_ptr<std::shared_ptr<const rmf_traffic::agv::Planner>> planner,
     std::shared_ptr<Node> node,
     const rxcpp::schedulers::worker& worker,
     rmf_utils::optional<rmf_traffic::Duration> maximum_delay,
@@ -168,7 +168,7 @@ private:
   std::vector<rmf_traffic::agv::Plan::Start> _location;
   rmf_traffic::schedule::Participant _itinerary;
   std::shared_ptr<const Snappable> _schedule;
-  std::shared_ptr<const rmf_traffic::agv::Planner> _planner;
+  std::shared_ptr<std::shared_ptr<const rmf_traffic::agv::Planner>> _planner;
   std::shared_ptr<const rmf_traffic::Profile> _profile;
 
   std::shared_ptr<void> _negotiation_license;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -42,6 +42,7 @@
 #include <rmf_traffic/schedule/Snapshot.hpp>
 #include <rmf_traffic/agv/Interpolate.hpp>
 #include <rmf_traffic/Trajectory.hpp>
+#include <rmf_traffic/agv/LaneClosure.hpp>
 
 #include <rmf_traffic_ros2/schedule/Writer.hpp>
 #include <rmf_traffic_ros2/schedule/Negotiation.hpp>
@@ -130,12 +131,14 @@ class FleetUpdateHandle::Implementation
 public:
 
   std::string name;
-  std::shared_ptr<rmf_traffic::agv::Planner> planner;
+  std::shared_ptr<std::shared_ptr<const rmf_traffic::agv::Planner>> planner;
   std::shared_ptr<Node> node;
   rxcpp::schedulers::worker worker;
   std::shared_ptr<ParticipantFactory> writer;
   std::shared_ptr<rmf_traffic::schedule::Snappable> snappable;
   std::shared_ptr<rmf_traffic_ros2::schedule::Negotiation> negotiation;
+  std::shared_ptr<rmf_traffic::agv::LaneClosure> lane_closures =
+    std::make_shared<rmf_traffic::agv::LaneClosure>();
 
   // Task planner params
   std::shared_ptr<rmf_battery::agv::BatterySystem> battery_system = nullptr;
@@ -170,9 +173,9 @@ public:
   double recharge_threshold = 0.2;
 
   // TODO Support for various charging configurations
-  std::unordered_set<std::size_t> charging_waypoints;
+  std::unordered_set<std::size_t> charging_waypoints = {};
   // We assume each robot has a designated charging waypoint
-  std::unordered_set<std::size_t> available_charging_waypoints;
+  std::unordered_set<std::size_t> available_charging_waypoints = {};
 
   double current_assignment_cost = 0.0;
   // Map to store task id with assignments for BidNotice

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -137,8 +137,6 @@ public:
   std::shared_ptr<ParticipantFactory> writer;
   std::shared_ptr<rmf_traffic::schedule::Snappable> snappable;
   std::shared_ptr<rmf_traffic_ros2::schedule::Negotiation> negotiation;
-  std::shared_ptr<rmf_traffic::agv::LaneClosure> lane_closures =
-    std::make_shared<rmf_traffic::agv::LaneClosure>();
 
   // Task planner params
   std::shared_ptr<rmf_battery::agv::BatterySystem> battery_system = nullptr;
@@ -269,7 +267,7 @@ public:
 
     // Populate charging waypoints
     const std::size_t num_waypoints =
-      handle._pimpl->planner->get_configuration().graph().num_waypoints();
+      (*handle._pimpl->planner)->get_configuration().graph().num_waypoints();
     for (std::size_t i = 0; i < num_waypoints; ++i)
       handle._pimpl->charging_waypoints.insert(i);
     handle._pimpl->available_charging_waypoints =

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/test/MockAdapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/test/MockAdapter.cpp
@@ -71,11 +71,13 @@ std::shared_ptr<FleetUpdateHandle> MockAdapter::add_fleet(
     rmf_traffic::agv::VehicleTraits traits,
     rmf_traffic::agv::Graph navigation_graph)
 {
-  auto planner = std::make_shared<rmf_traffic::agv::Planner>(
+  auto planner =
+    std::make_shared<std::shared_ptr<const rmf_traffic::agv::Planner>>(
+      std::make_shared<rmf_traffic::agv::Planner>(
         rmf_traffic::agv::Planner::Configuration(
           std::move(navigation_graph),
           std::move(traits)),
-        rmf_traffic::agv::Planner::Options(nullptr));
+        rmf_traffic::agv::Planner::Options(nullptr)));
 
   auto fleet = FleetUpdateHandle::Implementation::make(
         fleet_name, std::move(planner), _pimpl->node, _pimpl->worker,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/estimation.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/estimation.cpp
@@ -79,8 +79,10 @@ void estimate_path_traveling(
     TravelInfo& info)
 {
   assert(!state.path.empty());
+
   const std::size_t remaining_count = state.path.size();
   const std::size_t i_target_wp = info.waypoints.size() - remaining_count;
+  info.target_plan_index = i_target_wp;
   const auto& target_wp = info.waypoints.at(i_target_wp);
 
   const auto& l = state.location;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/estimation.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/estimation.hpp
@@ -43,6 +43,8 @@ struct TravelInfo
 
   std::string fleet_name;
   std::string robot_name;
+
+  std::optional<std::size_t> target_plan_index = std::nullopt;
 };
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DispenseItem.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DispenseItem.cpp
@@ -55,7 +55,7 @@ rmf_traffic::Duration DispenseItem::ActivePhase::estimate_remaining_time() const
 }
 
 //==============================================================================
-void DispenseItem::ActivePhase::emergency_alarm(bool on)
+void DispenseItem::ActivePhase::emergency_alarm(bool)
 {
   // TODO: implement
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DockRobot.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DockRobot.cpp
@@ -49,7 +49,7 @@ rmf_traffic::Duration DockRobot::ActivePhase::estimate_remaining_time() const
 }
 
 //==============================================================================
-void DockRobot::ActivePhase::emergency_alarm(bool on)
+void DockRobot::ActivePhase::emergency_alarm(bool)
 {
   // TODO: implement
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/IngestItem.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/IngestItem.cpp
@@ -55,7 +55,7 @@ rmf_traffic::Duration IngestItem::ActivePhase::estimate_remaining_time() const
 }
 
 //==============================================================================
-void IngestItem::ActivePhase::emergency_alarm(bool on)
+void IngestItem::ActivePhase::emergency_alarm(bool)
 {
   // TODO: implement
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.cpp
@@ -55,7 +55,7 @@ rmf_traffic::Duration MoveRobot::ActivePhase::estimate_remaining_time() const
 }
 
 //==============================================================================
-void MoveRobot::ActivePhase::emergency_alarm(bool on)
+void MoveRobot::ActivePhase::emergency_alarm(bool)
 {
   // TODO: implement
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -38,7 +38,7 @@ rmf_traffic::Duration WaitForCharge::Active::estimate_remaining_time() const
 }
 
 //==============================================================================
-void WaitForCharge::Active::emergency_alarm(const bool value)
+void WaitForCharge::Active::emergency_alarm(const bool)
 {
   // Assume charging station is a holding point
 }


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Allow fleet adapters to close navigation graph lanes.

### Implementation description

The `rmf_fleet_adapter::agv::FleetUpdateHandle` API can now be told to close or open navigation graph lanes during runtime.

For the legacy fleet adapter (aka the `full_control` adapter) you can send a `LaneRequest` message to open or close lanes at any time. If the `full_control` adapter detects that the robot is currently on a lane that was just closed, then it will have the robot retreat back to the start of the lane and find a new plan from there. **NOTE**: We do not offer very strong guarantees about the effectiveness or reliability of this behavior for the legacy fleet adapter, because the `rmf_fleet_msgs` API does not always convey as much information as we need to make the behavior reliable.

### Dependencies

- [x] https://github.com/open-rmf/rmf_internal_msgs/pull/5
- [x] https://github.com/open-rmf/rmf_traffic/pull/11