### PR TITLE
Fix/rmf task ros2 cleanup

### DIFF
--- a/rmf_fleet_adapter_python/CMakeLists.txt
+++ b/rmf_fleet_adapter_python/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 
 find_package(rmf_fleet_adapter REQUIRED)
 find_package(rmf_task REQUIRED)
-find_package(rmf_task_ros2 REQUIRED)
 find_package(rmf_battery REQUIRED)
 find_package(rmf_task_msgs REQUIRED)
 
@@ -48,8 +47,7 @@ pybind11_add_module(rmf_adapter
   src/schedule/schedule.cpp
 )
 target_link_libraries(rmf_adapter PRIVATE
-  rmf_fleet_adapter::rmf_fleet_adapter
-  rmf_task_ros2::rmf_task_ros2)
+  rmf_fleet_adapter::rmf_fleet_adapter)
 
 target_include_directories(rmf_adapter
   PUBLIC
@@ -59,7 +57,6 @@ target_include_directories(rmf_adapter
     ${rmf_traffic_ros2_INCLUDE_DIRS}
     ${rmf_battery_INCLUDE_DIRS}
     ${rmf_task_INCLUDE_DIRS}
-    ${rmf_task_ros2_INCLUDE_DIRS}
     ${rmf_fleet_msgs_INCLUDE_DIRS}
     ${rclcpp_INCLUDE_DIRS}
   PRIVATE

--- a/rmf_fleet_adapter_python/package.xml
+++ b/rmf_fleet_adapter_python/package.xml
@@ -6,14 +6,6 @@
   <description>Python bindings for the rmf_fleet_adapter</description>
   <maintainer email="methylDragon@gmail.com">methylDragon</maintainer>
   <license>Apache License 2.0</license>
-
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <depend>pybind_ament</depend>
   <depend>rmf_fleet_adapter</depend>
-  <depend>rmf_task_ros2</depend>
-
-  <export>
-    <build_type>ament_python</build_type>
-  </export>
 </package>

--- a/rmf_fleet_adapter_python/src/nodes/nodes.cpp
+++ b/rmf_fleet_adapter_python/src/nodes/nodes.cpp
@@ -31,11 +31,8 @@
 
 #include <rmf_traffic_ros2/blockade/Node.hpp>
 #include <rmf_traffic_ros2/schedule/Node.hpp>
-#include <rmf_task_ros2/Dispatcher.hpp>
 
 namespace py = pybind11;
-using Dispatcher = rmf_task_ros2::Dispatcher;
-using TaskStatus = rmf_task_ros2::TaskStatus;
 
 /// Create a ros2 node of different major node components in RMF
 /// TODO (YL): Might move these nodes static functions to a different repo as
@@ -53,48 +50,4 @@ void bind_nodes(py::module &m)
   // Make Schedule Node
   m_nodes.def("make_schedule", &rmf_traffic_ros2::schedule::make_node,
               py::arg("options"));
-
-  /// Dispatcher Node Class
-  /// \brief Create a simple dispatcher node api mainly for testing
-  py::class_<Dispatcher, std::shared_ptr<Dispatcher>>(
-      m_nodes, "DispatcherNode")
-      .def_static("make_node", &Dispatcher::make_node,
-                  // py::arg("dispatcher_node_name"), TODO Remove in next version
-                  py::call_guard<py::scoped_ostream_redirect,
-                                 py::scoped_estream_redirect>())
-      // .def("submit_task",
-      //      py::overload_cast<const Dispatcher::TaskDescription&>(
-      //       &Dispatcher::submit_task),
-      //      py::arg("task_description"))
-      .def("cancel_task", &Dispatcher::cancel_task,
-           py::arg("task_id"))
-      .def("spin", &Dispatcher::spin,
-           "This is a blocking spin")
-      .def("node", &Dispatcher::node)
-      .def("get_active_task_ids", [](Dispatcher &self) {
-        std::vector<std::string> task_ids;
-        for (auto task : self.active_tasks())
-        {
-          task_ids.push_back(task.first);
-        }
-        return task_ids;
-      })
-      .def("get_terminated_task_ids", [](Dispatcher &self) {
-        std::vector<std::string> task_ids;
-        for (auto task : self.terminated_tasks())
-        {
-          task_ids.push_back(task.first);
-        }
-        return task_ids;
-      })
-      .def("get_task_state", &Dispatcher::get_task_state, py::arg("task_id"));
-
-  py::enum_<TaskStatus::State>(
-      m_nodes, "TaskState")
-      .value("Queued", TaskStatus::State::Queued)
-      .value("Executing", TaskStatus::State::Executing)
-      .value("Completed", TaskStatus::State::Completed)
-      .value("Failed", TaskStatus::State::Failed)
-      .value("Canceled", TaskStatus::State::Canceled)
-      .value("Pending", TaskStatus::State::Pending);
 }

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -85,31 +85,11 @@ public:
         const std::shared_ptr<SubmitTaskSrv::Request> request,
         std::shared_ptr<SubmitTaskSrv::Response> response)
       {
-        switch (request->evaluator)
-        {
-          using namespace rmf_task_ros2::bidding;
-          case SubmitTaskSrv::Request::LOWEST_DIFF_COST_EVAL:
-            this->auctioneer->select_evaluator(
-              std::make_shared<LeastFleetDiffCostEvaluator>());
-            break;
-          case SubmitTaskSrv::Request::LOWEST_COST_EVAL:
-            this->auctioneer->select_evaluator(
-              std::make_shared<LeastFleetCostEvaluator>());
-            break;
-          case SubmitTaskSrv::Request::QUICKEST_FINISH_EVAL:
-            this->auctioneer->select_evaluator(
-              std::make_shared<QuickestFinishEvaluator>());
-            break;
-          default:
-            RCLCPP_WARN(this->node->get_logger(),
-            "Selected Evaluator is invalid, switch back to previous");
-            break;
-        }
-
         const auto id = this->submit_task(request->description);
         if (id == std::nullopt)
         {
           response->success = false;
+          response->message = "Task type is invalid";
           return;
         }
 

--- a/rmf_task_ros2/src/rmf_task_ros2/action/Client.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/action/Client.cpp
@@ -40,6 +40,9 @@ Client::Client(std::shared_ptr<rclcpp::Node> node)
     [&](const std::unique_ptr<StatusMsg> msg)
     {
       const auto task_id = msg->task_profile.task_id;
+      if (task_id.empty())
+        return;
+
       // status update, check if task_id is previously known
       if (_active_task_status.count(task_id))
       {


### PR DESCRIPTION
## Fix

- Update srv field of `rmf_task_msgs` https://github.com/open-rmf/rmf_internal_msgs/pull/9
- Remove Stray task card stored in dispatcher for robots in `ResponsiveWait` phase
- remove unnecessary dependency of `rmf_task_ros2 ` in `rmf_fleet_adapter_python`
 
Note: This is a temporary quick fix to address some pending issues, while refactoring haul of the dispatcher node is underway