### PR TITLE
Check if an active phase exists before trying to cancel it

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/Task.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/Task.cpp
@@ -79,7 +79,8 @@ auto Task::pending_phases() const -> const PendingPhases&
 void Task::cancel()
 {
   _pending_phases.clear();
-  _active_phase->cancel();
+  if (_active_phase)
+    _active_phase->cancel();
 }
 
 //==============================================================================


### PR DESCRIPTION
## Bug fix

### Fixed bug

Due to race conditions that can arise from the order in which the main rxcpp worker processes work, it's possible that `Task::cancel()` can be called on a `Task` instance that has no active phase. That will result in a segfault.

This PR fixes that issue by simply checking if the active phase exists before attempting to cancel it.