### PR TITLE
Give a floating tail prediction to the Responsive Wait phase

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/GoToPlace.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/GoToPlace.hpp
@@ -68,7 +68,8 @@ public:
     Active(
         agv::RobotContextPtr context,
         rmf_traffic::agv::Plan::Goal goal,
-        double original_time_estimate);
+        double original_time_estimate,
+        std::optional<rmf_traffic::Duration> tail_period);
 
     void find_plan();
 
@@ -92,6 +93,7 @@ public:
     rclcpp::TimerBase::SharedPtr _find_path_timer;
     std::shared_ptr<services::FindEmergencyPullover> _pullover_service;
     rclcpp::TimerBase::SharedPtr _find_pullover_timer;
+    std::optional<rmf_traffic::Duration> _tail_period;
 
     rmf_rxcpp::subscription_guard _interrupt_subscription;
 
@@ -126,10 +128,12 @@ public:
     Pending(
         agv::RobotContextPtr context,
         rmf_traffic::agv::Plan::Goal goal,
-        double time_estimate);
+        double time_estimate,
+        std::optional<rmf_traffic::Duration> tail_period);
     agv::RobotContextPtr _context;
     rmf_traffic::agv::Plan::Goal _goal;
     double _time_estimate;
+    std::optional<rmf_traffic::Duration> _tail_period;
     std::string _description;
   };
 
@@ -137,7 +141,8 @@ public:
   static std::unique_ptr<Pending> make(
     agv::RobotContextPtr context,
     rmf_traffic::agv::Plan::Start start_estimate,
-    rmf_traffic::agv::Plan::Goal goal);
+    rmf_traffic::agv::Plan::Goal goal,
+    std::optional<rmf_traffic::Duration> tail_period = std::nullopt);
 
 };
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.cpp
@@ -24,8 +24,10 @@ namespace phases {
 //==============================================================================
 MoveRobot::ActivePhase::ActivePhase(
   agv::RobotContextPtr context,
-  std::vector<rmf_traffic::agv::Plan::Waypoint> waypoints)
-  : _context{std::move(context)}
+  std::vector<rmf_traffic::agv::Plan::Waypoint> waypoints,
+  std::optional<rmf_traffic::Duration> tail_period)
+: _context{std::move(context)},
+  _tail_period(tail_period)
 {
   std::ostringstream oss;
   oss << "Moving [" << _context->requester_id() << "]: ("
@@ -33,7 +35,8 @@ MoveRobot::ActivePhase::ActivePhase(
       << ") -> (" << waypoints.back().position().transpose() << ")";
   _description = oss.str();
 
-  _action = std::make_shared<MoveRobot::Action>(_context, waypoints);
+  _action = std::make_shared<MoveRobot::Action>(
+    _context, waypoints, _tail_period);
 
   auto job = rmf_rxcpp::make_job<Task::StatusMsg>(_action);
   _obs = make_cancellable(job, _cancel_subject.get_observable())
@@ -76,9 +79,11 @@ const std::string& MoveRobot::ActivePhase::description() const
 //==============================================================================
 MoveRobot::PendingPhase::PendingPhase(
   agv::RobotContextPtr context,
-  std::vector<rmf_traffic::agv::Plan::Waypoint> waypoints)
-  : _context{std::move(context)},
-    _waypoints{std::move(waypoints)}
+  std::vector<rmf_traffic::agv::Plan::Waypoint> waypoints,
+  std::optional<rmf_traffic::Duration> tail_period)
+: _context{std::move(context)},
+  _waypoints{std::move(waypoints)},
+  _tail_period(tail_period)
 {
   std::ostringstream oss;
   oss << "Move [" << _context->requester_id() << "] to ("
@@ -89,7 +94,8 @@ MoveRobot::PendingPhase::PendingPhase(
 //==============================================================================
 std::shared_ptr<Task::ActivePhase> MoveRobot::PendingPhase::begin()
 {
-  return std::make_shared<MoveRobot::ActivePhase>(_context, _waypoints);
+  return std::make_shared<MoveRobot::ActivePhase>(
+    _context, _waypoints, _tail_period);
 }
 
 //==============================================================================
@@ -106,10 +112,13 @@ const std::string& MoveRobot::PendingPhase::description() const
 }
 
 //==============================================================================
-MoveRobot::Action::Action(agv::RobotContextPtr& context,
-  std::vector<rmf_traffic::agv::Plan::Waypoint>& waypoints)
+MoveRobot::Action::Action(
+  agv::RobotContextPtr& context,
+  std::vector<rmf_traffic::agv::Plan::Waypoint>& waypoints,
+  std::optional<rmf_traffic::Duration> tail_period)
   : _context{context},
-    _waypoints{waypoints}
+    _waypoints{waypoints},
+    _tail_period{tail_period}
 {
   // no op
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.cpp
@@ -104,7 +104,12 @@ void ResponsiveWait::Active::_begin_movement()
       "bug in rmf_fleet_adapter. Please report it to the maintainers.");
   }
 
-  _movement = GoToPlace::make(_info.context, start_estimate, goal)->begin();
+  std::optional<rmf_traffic::Duration> tail;
+  if (_info.period.has_value())
+    tail = std::chrono::seconds(1);
+
+  _movement = GoToPlace::make(
+    _info.context, start_estimate, goal, tail)->begin();
 
   _movement_subscription =
     _movement->observe()


### PR DESCRIPTION
## Bug fix

### Fixed bug

Robots may sometimes have difficulty navigating around or negotiating with Responsive Waiting robots because the Responsive Waiting phase always reports to the schedule that its robot is going to vanish in a finite amount of time.

### Fix applied

In this PR, we add a "floating tail" to the schedule of the idle Responsive Wait robots. This floating tail will keep moving itself forward in time so that any robots that were planning on waiting for the Responsive Waiter to vanish will quickly end up in a conflict, and they will be forced to negotiate.