### PR TITLE
Fix lookup of nearest charging waypoint in full control fleet adapters

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -749,7 +749,7 @@ std::optional<std::size_t> FleetUpdateHandle::Implementation::get_nearest_charge
   for (const auto& wp : charging_waypoints)
   {
     const rmf_traffic::agv::Planner::Goal goal{wp};
-    const auto& planner_result = (*planner)->plan(start, goal);
+    const auto& planner_result = (*planner)->setup(start, goal);
     const auto ideal_cost = planner_result.ideal_cost();
     if (ideal_cost.has_value() && ideal_cost.value() < min_cost)
     {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -739,8 +739,7 @@ auto FleetUpdateHandle::Implementation::is_valid_assignments(
 
 //==============================================================================
 std::optional<std::size_t> FleetUpdateHandle::Implementation::get_nearest_charger(
-  const rmf_traffic::agv::Planner::Start& start,
-  const std::unordered_set<std::size_t>& charging_waypoints)
+  const rmf_traffic::agv::Planner::Start& start)
 {
   if (charging_waypoints.empty())
     return std::nullopt;
@@ -1011,8 +1010,7 @@ void FleetUpdateHandle::add_robot(
          fleet = shared_from_this()](
         rmf_traffic::schedule::Participant participant)
   {
-    const auto charger_wp = fleet->_pimpl->get_nearest_charger(
-        start[0], fleet->_pimpl->charging_waypoints);
+    const auto charger_wp = fleet->_pimpl->get_nearest_charger(start[0]);
     
     if (!charger_wp.has_value())
     {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -266,10 +266,12 @@ public:
         });
 
     // Populate charging waypoints
-    const std::size_t num_waypoints =
-      (*handle._pimpl->planner)->get_configuration().graph().num_waypoints();
-    for (std::size_t i = 0; i < num_waypoints; ++i)
-      handle._pimpl->charging_waypoints.insert(i);
+    const auto& graph = (*handle._pimpl->planner)->get_configuration().graph();
+    for (std::size_t i = 0; i < graph.num_waypoints(); ++i)
+    {
+      if (graph.get_waypoint(i).is_charger())
+        handle._pimpl->charging_waypoints.insert(i);
+    }
     handle._pimpl->available_charging_waypoints =
       handle._pimpl->charging_waypoints;
 
@@ -282,7 +284,7 @@ public:
 
   void dispatch_request_cb(const DispatchRequest::SharedPtr msg);
 
-  std::size_t get_nearest_charger(
+  std::optional<std::size_t> get_nearest_charger(
     const rmf_traffic::agv::Planner::Start& start,
     const std::unordered_set<std::size_t>& charging_waypoints);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -172,8 +172,6 @@ public:
 
   // TODO Support for various charging configurations
   std::unordered_set<std::size_t> charging_waypoints = {};
-  // We assume each robot has a designated charging waypoint
-  std::unordered_set<std::size_t> available_charging_waypoints = {};
 
   double current_assignment_cost = 0.0;
   // Map to store task id with assignments for BidNotice
@@ -272,8 +270,6 @@ public:
       if (graph.get_waypoint(i).is_charger())
         handle._pimpl->charging_waypoints.insert(i);
     }
-    handle._pimpl->available_charging_waypoints =
-      handle._pimpl->charging_waypoints;
 
     return std::make_shared<FleetUpdateHandle>(std::move(handle));
   }
@@ -285,8 +281,7 @@ public:
   void dispatch_request_cb(const DispatchRequest::SharedPtr msg);
 
   std::optional<std::size_t> get_nearest_charger(
-    const rmf_traffic::agv::Planner::Start& start,
-    const std::unordered_set<std::size_t>& charging_waypoints);
+    const rmf_traffic::agv::Planner::Start& start);
 
   /// Generate task assignments for a collection of task requests comprising of
   /// task requests currently in TaskManager queues while optionally including a  

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<Task::ActivePhase> WaitForCharge::Pending::begin()
 
             RCLCPP_INFO(
               active->_context->node()->get_logger(),
-              "Robot [%s] is still waiting for its battery to charge to %.1f%% . "
+              "Robot [%s] is still waiting for its battery to charge to %.1f%%. "
               "The current battery percentage is %.1f%%. The robot is charging at "
               "an average rate of %.1f Ampere/hour. The expected charging rate is  "
               "%.1f Ampere/hour. If the battery percentage has not been rising, "

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -134,8 +134,8 @@ std::shared_ptr<Task::ActivePhase> WaitForCharge::Pending::begin()
               active->_context->node()->get_logger(),
               "Robot [%s] is still waiting for its battery to charge to %.1f%% . "
               "The current battery percentage is %.1f%%. The robot is charging at "
-              "an average rate of %.1fAmpere/hr. The expected charging rate is  "
-              "%.1fAmpere/hour. If the battery percentage has not been rising, "
+              "an average rate of %.1f Ampere/hour. The expected charging rate is  "
+              "%.1f Ampere/hour. If the battery percentage has not been rising, "
               "please check that the robot is connected to its charger.",
               active->_context->name().c_str(),
               active->_charge_to_soc * 100.0,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -66,7 +66,6 @@ WaitForCharge::Active::Active(
   _charge_to_soc(charge_to_soc),
   _start_time(start_time)
 {
-
   _last_update_time = start_time;
   _initial_battery_soc = _context->current_battery_soc();
   _expected_charging_rate = (100.0 / (

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -59,14 +59,20 @@ const std::string& WaitForCharge::Active::description() const
 WaitForCharge::Active::Active(
   agv::RobotContextPtr context,
   rmf_battery::agv::BatterySystem battery_system,
-  double charge_to_soc)
+  double charge_to_soc,
+  rmf_traffic::Time start_time)
 : _context(std::move(context)),
   _battery_system(battery_system),
-  _charge_to_soc(charge_to_soc)
+  _charge_to_soc(charge_to_soc),
+  _start_time(start_time)
 {
+
+  _last_update_time = start_time;
+
+  _initial_battery_soc = _context->current_battery_soc();
+
   _description = "Charging [" + _context->requester_id() + "] to ["
       + std::to_string(100.0 * _charge_to_soc) + "]";
-
 
   StatusMsg initial_msg;
   initial_msg.status = _description;
@@ -84,9 +90,18 @@ WaitForCharge::Active::Active(
 //==============================================================================
 std::shared_ptr<Task::ActivePhase> WaitForCharge::Pending::begin()
 {
+  const auto& now = std::chrono::steady_clock::now();
+
   auto active =
       std::shared_ptr<Active>(new Active(
-        _context, _battery_system, _charge_to_soc));
+        _context, _battery_system, _charge_to_soc, now));
+
+  RCLCPP_INFO(
+    _context->node()->get_logger(),
+    "Robot [%s] has begun waiting for its battery to charge to %.1f%%. "
+    "Please ensure that the robot is charging.",
+    _context->name().c_str(),
+    _charge_to_soc * 100.0);
 
   active->_battery_soc_subscription = _context->observe_battery_soc()
       .observe_on(rxcpp::identity_same_worker(_context->worker()))
@@ -102,8 +117,35 @@ std::shared_ptr<Task::ActivePhase> WaitForCharge::Pending::begin()
           {
             active->_status_publisher.get_subscriber().on_completed();
           }
-          // TODO Publish warning message to alert user if battery is not
-          // charging at expected rate
+
+          const auto& now = std::chrono::steady_clock::now();
+          if (std::chrono::seconds(60) <= now - active->_last_update_time)
+          {
+            const double delta_soc = battery_soc - active->_initial_battery_soc;
+            const double elapsed_seconds = 
+              (now - active->_start_time).count() / 1e9;
+            const double average_charging_rate =
+              delta_soc / (elapsed_seconds / 3600.0);
+            const double expected_charging_rate =
+              active->_battery_system.capacity() /
+              active->_battery_system.charging_current();
+
+            RCLCPP_INFO(
+              active->_context->node()->get_logger(),
+              "Robot [%s] is still waiting for its battery to charge to %.1f%% . "
+              "The current battery percentage is %.1f%%. The robot is charging at "
+              "an average rate of %.1fAmpere/hr. The expected charging rate is  "
+              "%.1fAmpere/hour. If the battery percentage has not been rising, "
+              "please check that the robot is connected to its charger.",
+              active->_context->name().c_str(),
+              active->_charge_to_soc * 100.0,
+              battery_soc * 100,
+              average_charging_rate,
+              expected_charging_rate);
+            
+            active->_last_update_time = now;
+          }
+
         });
 
   return active;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.hpp
@@ -75,6 +75,7 @@ public:
     rmf_traffic::Time _start_time;
     rmf_traffic::Time _last_update_time;
     double _initial_battery_soc;
+    double _expected_charging_rate; // % per hour
 
   };
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.hpp
@@ -23,6 +23,8 @@
 
 #include <rmf_battery/agv/BatterySystem.hpp>
 
+#include <rmf_traffic/Time.hpp>
+
 namespace rmf_fleet_adapter {
 namespace phases {
 
@@ -60,7 +62,8 @@ public:
     Active(
       agv::RobotContextPtr context,
       rmf_battery::agv::BatterySystem battery_system,
-      double charge_to_soc);
+      double charge_to_soc,
+      rmf_traffic::Time start_time);
 
     agv::RobotContextPtr _context;
     rmf_battery::agv::BatterySystem _battery_system;
@@ -69,6 +72,9 @@ public:
     rxcpp::observable<StatusMsg> _status_obs;
     rxcpp::subjects::subject<StatusMsg> _status_publisher;
     rmf_rxcpp::subscription_guard _battery_soc_subscription;
+    rmf_traffic::Time _start_time;
+    rmf_traffic::Time _last_update_time;
+    double _initial_battery_soc;
 
   };
 


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug
<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

The full control fleet adapter presently suffers from a nasty bug due to a logical error in determining the charging waypoint of a robot when it is added to the fleet. Inside the implementation of `FleetUpdateHandle::add_robot()`, the [get_nearest_charger()](https://github.com/open-rmf/rmf_ros2/blob/5cbef9bff4778f83d54fb4318008f7e169706540/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp#L1012-L1013) method is invoked to return the nearest charging waypoint given the Start of the robot and a list of charging waypoints in the navigation graph. 

The error lies in the list of charging waypoints. This list was incorrectly populated with all the waypoints in the graph as opposed to only those with the `is_charger()` property set `true`. As a result, the charging waypoint for a robot was always set to the waypoint nearest to the robot at the time. Hence, when the `ChargeBattery` task begins, the robot would head to this waypoint and wait indefinitely for its battery to charge up. The problem is silent as no messages are printed during the `WaitForCharge` phase of the task. This problem went undetected for so long given that in all our simulations, the robots spawn at their charging waypoints so by coincidence the nearest waypoint was always a charging waypoint. In other non-legacy fleet adapters, the [RobotUpdateHandle::set_charger_waypoint()](https://github.com/open-rmf/rmf_ros2/blob/5cbef9bff4778f83d54fb4318008f7e169706540/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp#L94) method was being called to correctly set the charging waypoint and therefore overwriting the value set in `FleetUpdateHandle::add_robot()`. 

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->
* The list of charging waypoints is now correctly populated. 
* An error is thrown if none of the waypoints in the graph is a charger location
* A descriptive message with the expected and current charging rates is printed periodically when the `WaitForCharge` phase is active.

This branch has was successfully tested with hardware.
