### PR TITLE
Remove printouts in robot_state_aggregator

### DIFF
--- a/rmf_fleet_adapter/src/robot_state_aggregator/RobotStateAggregator.cpp
+++ b/rmf_fleet_adapter/src/robot_state_aggregator/RobotStateAggregator.cpp
@@ -42,7 +42,7 @@ public:
   explicit RobotStateAggregator(const rclcpp::NodeOptions& options)
   : rclcpp::Node("robot_state_aggregator", options)
   {
-    RCLCPP_WARN(get_logger(), "RobotStateAggregator called");
+    RCLCPP_DEBUG(get_logger(), "RobotStateAggregator called");
     const auto default_qos = rclcpp::SystemDefaultsQoS();
     const auto sensor_qos = rclcpp::SensorDataQoS();
 
@@ -82,7 +82,7 @@ public:
         Status::SharedPtr msg) -> void
         {
           const auto sensor_qos = rclcpp::SensorDataQoS();
-          RCLCPP_WARN(get_logger(), "Watchdog rised at %s, "
+          RCLCPP_DEBUG(get_logger(), "Watchdog rised at %s, "
           "self activation triggered",
           _active_status_topic.c_str(),
           msg->stamp.sec);

--- a/rmf_fleet_adapter/src/robot_state_aggregator/main.cpp
+++ b/rmf_fleet_adapter/src/robot_state_aggregator/main.cpp
@@ -60,22 +60,18 @@ int main(int argc, char* argv[])
 
   for (auto library : libraries)
   {
-    RCLCPP_INFO(logger, "Library");
-
     auto loader = new class_loader::ClassLoader(library);
     auto classes =
       loader->getAvailableClasses<rclcpp_components::NodeFactory>();
 
     for (auto clazz : classes)
     {
-      RCLCPP_INFO(logger, "before if %s", clazz.c_str());
       if (failover_mode || 
          ((clazz.compare("rclcpp_components::NodeFactoryTemplate"
          "<lifecycle_heartbeat::LifecycleHeartbeat>") != 0) &&
          ((clazz.compare("rclcpp_components::NodeFactoryTemplate"
          "<lifecycle_watchdog::LifecycleWatchdog>") != 0))))
       {
-        RCLCPP_INFO(logger, "Instantiate class %s", clazz.c_str());
         auto node_factory =
           loader->createInstance<rclcpp_components::NodeFactory>(clazz);
         auto wrapper = node_factory->create_node_instance(options);


### PR DESCRIPTION
Signed-off-by: Yadunund <yadunund@openrobotics.org>

PR https://github.com/open-rmf/rmf_ros2/pull/54 introduced a few debugging printouts to the `robot_state_aggregator` that pollute the terminal. This PR removes them.
