### PR TITLE
rewrite include to be packaging friendly

### DIFF
--- a/rmf_traffic_ros2/src/update_participant/main.cpp
+++ b/rmf_traffic_ros2/src/update_participant/main.cpp
@@ -21,7 +21,7 @@
 #include <rclcpp/node.hpp>
 #include <rclcpp/executors.hpp>
 
-#include "../src/rmf_traffic_ros2/schedule/internal_YamlSerialization.hpp"
+#include "../rmf_traffic_ros2/schedule/internal_YamlSerialization.hpp"
 
 #include <iostream>
 

--- a/rmf_traffic_ros2/src/update_participant/main.cpp
+++ b/rmf_traffic_ros2/src/update_participant/main.cpp
@@ -21,7 +21,7 @@
 #include <rclcpp/node.hpp>
 #include <rclcpp/executors.hpp>
 
-#include "../../rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_YamlSerialization.hpp"
+#include "../src/rmf_traffic_ros2/schedule/internal_YamlSerialization.hpp"
 
 #include <iostream>
 


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Bug fix

### Fixed bug

Include fails to find `.hpp` file when packaging:
https://build.ros2.org/view/Rbin_uF64/job/Rbin_uF64__rmf_traffic_ros2__ubuntu_focal_amd64__binary/3/console

### Fix applied

Rewrite include to work at the package level
