### PR TITLE
exporting dependencies on rmf_traffic_ros2

### DIFF
--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -70,7 +70,15 @@ target_include_directories(rmf_traffic_ros2
 )
 
 ament_export_targets(rmf_traffic_ros2 HAS_LIBRARY_TARGET)
-ament_export_dependencies(rmf_traffic rmf_traffic_msgs rclcpp)
+ament_export_dependencies(
+  rclcpp
+  rmf_traffic
+  rmf_traffic_msgs
+  rmf_fleet_msgs
+  Eigen3
+  rclcpp
+  yaml-cpp
+)
 
 # TODO(MXG): Change these executables into shared libraries that can act as
 # ROS2 node components


### PR DESCRIPTION
`rmf_task_ros2` fails to find `yaml-cpp` [here](https://github.com/open-rmf/rmf_visualization/blob/main/rmf_visualization_schedule/CMakeLists.txt#L15), however the dependency is only found on the upstream `rmf_traffic_ros2`. I believe exporting the dependencies at the `rmf_traffic_ros2` `CMakeLists.txt` level should fix the issue.
