### PR TITLE
Geoff/put query updates on a diet

### DIFF
--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -51,8 +51,8 @@ if(BUILD_TESTING)
       yaml-cpp
   )
 
-  add_executable(
-    missing_query_schedule_node test/mock_schedule_nodes/missing_query.cpp
+  add_executable(missing_query_schedule_node
+    test/mock_schedule_nodes/missing_query_schedule.cpp
   )
   target_include_directories(missing_query_schedule_node
     PUBLIC
@@ -64,8 +64,21 @@ if(BUILD_TESTING)
   )
   target_link_libraries(missing_query_schedule_node rmf_traffic_ros2)
 
-  add_executable(
-    wrong_query_schedule_node test/mock_schedule_nodes/wrong_query.cpp
+  add_executable(missing_query_monitor_node
+    test/mock_monitor_nodes/missing_query_monitor.cpp
+  )
+  target_include_directories(missing_query_monitor_node
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+      ${rmf_traffic_msgs_INCLUDE_DIRS}
+      ${rclcpp_INCLUDE_DIRS}
+      "src"
+  )
+  target_link_libraries(missing_query_monitor_node rmf_traffic_ros2)
+
+  add_executable(wrong_query_schedule_node
+    test/mock_schedule_nodes/wrong_query.cpp
   )
   target_include_directories(wrong_query_schedule_node
     PUBLIC
@@ -77,10 +90,25 @@ if(BUILD_TESTING)
   )
   target_link_libraries(wrong_query_schedule_node rmf_traffic_ros2)
 
+  add_executable(delayed_query_broadcast_monitor_node
+    test/mock_monitor_nodes/delayed_query_broadcast_monitor.cpp
+  )
+  target_include_directories(delayed_query_broadcast_monitor_node
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+      ${rmf_traffic_msgs_INCLUDE_DIRS}
+      ${rclcpp_INCLUDE_DIRS}
+      "src"
+  )
+  target_link_libraries(delayed_query_broadcast_monitor_node rmf_traffic_ros2)
+
   install(
     TARGETS
       missing_query_schedule_node
+      missing_query_monitor_node
       wrong_query_schedule_node
+      delayed_query_broadcast_monitor_node
     RUNTIME DESTINATION lib/rmf_traffic_ros2
   )
 endif()

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
@@ -205,9 +205,9 @@ public:
     update_timer = node.create_wall_timer(
       5s,
       [&]() -> void
-        {
-          handle_update_timeout();
-        });
+      {
+        handle_update_timeout();
+      });
   }
 
   void handle_participants_info(const ParticipantsInfo::SharedPtr msg)
@@ -291,7 +291,7 @@ public:
           RCLCPP_WARN(
             node.get_logger(),
             "Failed to update using patch for DB version %d; "
-              "requesting new update",
+            "requesting new update",
             patch.latest_version());
           request_update(mirror->latest_version());
         }
@@ -303,7 +303,7 @@ public:
           RCLCPP_WARN(
             node.get_logger(),
             "Failed to update using patch for DB version %d; "
-              "requesting new update",
+            "requesting new update",
             patch.latest_version());
           request_update(mirror->latest_version());
         }
@@ -390,7 +390,9 @@ public:
   {
     if (register_query_client->service_is_ready())
     {
-      RCLCPP_DEBUG(node.get_logger(), "Redoing query registration: Calling service");
+      RCLCPP_DEBUG(
+        node.get_logger(),
+        "Redoing query registration: Calling service");
       RegisterQuery::Request register_query_request;
       register_query_request.query = convert(query);
       register_query_client->async_send_request(

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
@@ -159,6 +159,7 @@ public:
               node.get_logger(),
               "Mismatched query ID detected from schedule node; "
               "re-registering query");
+            dump_stashed_queries();
             // Re-register our query to get a (possibly new) correct query ID
             redo_query_registration();
           }
@@ -174,6 +175,7 @@ public:
           RCLCPP_ERROR(
             node.get_logger(),
             "Missing query ID; re-registering query");
+          dump_stashed_queries();
           redo_query_registration();
         }
       });
@@ -249,6 +251,12 @@ public:
       // impossible for require_query_validation to go true while in here?
       handle_update(msg);
     }
+    stashed_query_updates.clear();
+  }
+
+  // Call this if the stashed queries are found to be for an incorrect query
+  void dump_stashed_queries()
+  {
     stashed_query_updates.clear();
   }
 
@@ -409,6 +417,7 @@ public:
           this->register_query_client.reset();
         });
       redo_query_registration_timer.reset();
+      request_update();
     }
     else
     {

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -461,6 +461,8 @@ void ScheduleNode::setup_redundancy()
     create_publisher<ScheduleQueries>(
     rmf_traffic_ros2::QueriesInfoTopicName,
     rclcpp::SystemDefaultsQoS().reliable().keep_last(1).transient_local());
+
+  broadcast_queries();
 }
 
 //==============================================================================

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_MonitorNode.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_MonitorNode.hpp
@@ -43,10 +43,18 @@ using namespace std::chrono_literals;
 class MonitorNode : public rclcpp::Node
 {
 public:
+  static struct NoAutomaticSetup{} no_automatic_setup;
+
+  MonitorNode(
+    std::function<void(std::shared_ptr<rclcpp::Node>)> callback,
+    const rclcpp::NodeOptions& options,
+    NoAutomaticSetup);
 
   MonitorNode(
     std::function<void(std::shared_ptr<rclcpp::Node>)> callback,
     const rclcpp::NodeOptions& options);
+
+  void setup();
 
   std::chrono::milliseconds heartbeat_period = 1s;
   rclcpp::QoS heartbeat_qos_profile;
@@ -62,7 +70,7 @@ public:
   FailOverEventPub::SharedPtr fail_over_event_pub;
 
   void start_fail_over_event_broadcaster();
-  void announce_fail_over();
+  virtual void announce_fail_over();
 
   using ScheduleQuery = rmf_traffic_msgs::msg::ScheduleQuery;
   using ScheduleQueries = rmf_traffic_msgs::msg::ScheduleQueries;
@@ -70,7 +78,7 @@ public:
 
   void start_data_synchronisers();
 
-  std::shared_ptr<rclcpp::Node> create_new_schedule_node();
+  virtual std::shared_ptr<rclcpp::Node> create_new_schedule_node();
 
   std::optional<rmf_traffic_ros2::schedule::MirrorManager> mirror;
   std::function<void(std::shared_ptr<rclcpp::Node>)> on_fail_over_callback;

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
@@ -80,22 +80,30 @@ public:
   using QuerySubscriberCountMap =
     std::unordered_map<uint64_t, uint64_t>;
 
+  using NodeEdition = unsigned int;
+  NodeEdition node_edition = 0;
+
   static struct NoAutomaticSetup{} no_automatic_setup;
 
   ScheduleNode(
+    NodeEdition edition,
     std::shared_ptr<rmf_traffic::schedule::Database> database_,
     QueryMap registered_queries_,
     const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
   ScheduleNode(
+    NodeEdition edition,
     std::shared_ptr<rmf_traffic::schedule::Database> database_,
     QueryMap registered_queries_,
     QuerySubscriberCountMap registered_query_subscriber_counts,
     const rclcpp::NodeOptions& options);
 
-  ScheduleNode(const rclcpp::NodeOptions& options);
+  ScheduleNode(NodeEdition edition, const rclcpp::NodeOptions& options);
 
-  ScheduleNode(const rclcpp::NodeOptions& options, NoAutomaticSetup);
+  ScheduleNode(
+    NodeEdition edition,
+    const rclcpp::NodeOptions& options,
+    NoAutomaticSetup);
 
   ~ScheduleNode();
 

--- a/rmf_traffic_ros2/test/mock_monitor_nodes/delayed_query_broadcast_monitor.cpp
+++ b/rmf_traffic_ros2/test/mock_monitor_nodes/delayed_query_broadcast_monitor.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <chrono>
+
+#include <rmf_traffic_ros2/schedule/internal_MonitorNode.hpp>
+#include <rmf_traffic/schedule/Database.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+using namespace std::chrono_literals;
+
+class DelayedQueryBroadcastScheduleNode
+  : public rmf_traffic_ros2::schedule::ScheduleNode
+{
+public:
+  DelayedQueryBroadcastScheduleNode(
+    NodeEdition edition,
+    std::shared_ptr<rmf_traffic::schedule::Database> database_,
+    QueryMap registered_queries_,
+    QuerySubscriberCountMap registered_query_subscriber_counts,
+    const rclcpp::NodeOptions& options)
+    : ScheduleNode(
+        edition,
+        database_,
+        registered_queries_,
+        registered_query_subscriber_counts,
+        options)
+  {
+    timer = create_wall_timer(5s, [this]() -> void
+      {
+        RCLCPP_WARN(
+          get_logger(),
+          "Enabling query broadcasts and doing one broadcast");
+        broadcast_enabled = true;
+        broadcast_queries();
+        timer.reset();
+      });
+  }
+
+  void broadcast_queries() override
+  {
+    if (broadcast_enabled)
+    {
+      ScheduleNode::broadcast_queries();
+    }
+  }
+
+  bool broadcast_enabled = false;
+  rclcpp::TimerBase::SharedPtr timer;
+};
+
+
+class DelayedQueryBroadcastMonitorNode
+  : public rmf_traffic_ros2::schedule::MonitorNode
+{
+public:
+  DelayedQueryBroadcastMonitorNode(
+    std::function<void(std::shared_ptr<rclcpp::Node>)> callback,
+    const rclcpp::NodeOptions& options)
+    : MonitorNode(callback, options, MonitorNode::no_automatic_setup)
+  {}
+
+  std::shared_ptr<rclcpp::Node> create_new_schedule_node() override
+  {
+    auto database =
+      std::make_shared<rmf_traffic::schedule::Database>(mirror.value().fork());
+
+    auto node =
+      std::make_shared<DelayedQueryBroadcastScheduleNode>(
+        1, // Bump the node edition by one
+        database,
+        registered_queries,
+        query_subscriber_counts,
+        rclcpp::NodeOptions());
+    return node;
+  }
+};
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  std::promise<std::shared_ptr<rclcpp::Node>> active_node_promise;
+  auto active_node_future = active_node_promise.get_future().share();
+
+  auto node = std::make_shared<DelayedQueryBroadcastMonitorNode>(
+    [&active_node_promise](
+      std::shared_ptr<rclcpp::Node> new_active_schedule_node)
+      {
+        active_node_promise.set_value(new_active_schedule_node);
+      },
+    rclcpp::NodeOptions());
+  node->setup();
+
+  auto mirror_future = rmf_traffic_ros2::schedule::make_mirror(
+    *node, rmf_traffic::schedule::query_all());
+  using namespace std::chrono_literals;
+  bool success = false;
+  const auto stop_time = std::chrono::steady_clock::now() + 10s;
+  while (rclcpp::ok() && std::chrono::steady_clock::now() < stop_time)
+  {
+    rclcpp::spin_some(node);
+
+    if (mirror_future.wait_for(0s) == std::future_status::ready)
+    {
+      RCLCPP_INFO(node->get_logger(), "Got mirror for monitor node");
+      node->mirror = mirror_future.get();
+      success = true;
+      break;
+    }
+  }
+  if (!success)
+  {
+    RCLCPP_ERROR(node->get_logger(), "Failed to start mirror");
+    std::exit(1);
+  }
+
+  rclcpp::spin_until_future_complete(node, active_node_future);
+
+  using namespace std::chrono_literals;
+  if (active_node_future.wait_for(0s) == std::future_status::ready
+    && rclcpp::ok())
+  {
+    auto active_schedule_node = active_node_future.get();
+    // Delete the monitor to prevent it reacting to any future events
+    node.reset();
+
+    RCLCPP_INFO(
+      active_schedule_node->get_logger(),
+      "Spinning up replacement schedule node");
+    rclcpp::spin(active_schedule_node);
+    RCLCPP_INFO(
+      active_schedule_node->get_logger(),
+      "Shutting down replacement schedule node");
+  }
+
+  rclcpp::shutdown();
+}

--- a/rmf_traffic_ros2/test/mock_monitor_nodes/missing_query_monitor.cpp
+++ b/rmf_traffic_ros2/test/mock_monitor_nodes/missing_query_monitor.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <chrono>
+#include <thread>
+
+#include <rmf_traffic_ros2/schedule/internal_MonitorNode.hpp>
+#include <rmf_traffic/schedule/Database.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+using namespace std::chrono_literals;
+
+class MissingQueryMonitorNode : public rmf_traffic_ros2::schedule::MonitorNode
+{
+public:
+  MissingQueryMonitorNode(
+    std::function<void(std::shared_ptr<rclcpp::Node>)> callback,
+    const rclcpp::NodeOptions& options)
+    : MonitorNode(callback, options, MonitorNode::no_automatic_setup)
+  {}
+
+  void announce_fail_over()
+  {
+    if (rclcpp::ok())
+    {
+      // Wait a while before announcing. This will ensure that mirrors pick up
+      // on the missing query via the query check logic, not the failover
+      // handling logic. (But the announcement still has to be made to ensure
+      // mirrors reconnect services.)
+      std::this_thread::sleep_for(5s);
+      RCLCPP_INFO(get_logger(), "Announcing fail over");
+      auto message = FailOverEvent();
+      fail_over_event_pub->publish(message);
+    }
+    else
+    {
+      // Skip announcing the fail over because other nodes shouldn't bother doing
+      // anything to handle it when the system is shutting down.
+      RCLCPP_INFO(
+        get_logger(),
+        "Not announcing fail over because ROS is shutting down");
+    }
+  }
+
+  std::shared_ptr<rclcpp::Node> create_new_schedule_node() override
+  {
+    auto database =
+      std::make_shared<rmf_traffic::schedule::Database>(mirror.value().fork());
+
+    // Drop the first registered query to trigger a missing query situation
+    auto modified_registered_queries = registered_queries;
+    modified_registered_queries.erase(modified_registered_queries.begin());
+    auto modified_query_subscriber_counts = query_subscriber_counts;
+    modified_query_subscriber_counts.erase(modified_query_subscriber_counts.begin());
+
+    auto node = std::make_shared<rmf_traffic_ros2::schedule::ScheduleNode>(
+      1, // Bump the node edition by one
+      database,
+      modified_registered_queries,
+      modified_query_subscriber_counts,
+      rclcpp::NodeOptions());
+    return node;
+  }
+};
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  std::promise<std::shared_ptr<rclcpp::Node>> active_node_promise;
+  auto active_node_future = active_node_promise.get_future().share();
+
+  auto node = std::make_shared<MissingQueryMonitorNode>(
+    [&active_node_promise](
+      std::shared_ptr<rclcpp::Node> new_active_schedule_node)
+      {
+        active_node_promise.set_value(new_active_schedule_node);
+      },
+    rclcpp::NodeOptions());
+  node->setup();
+
+  auto mirror_future = rmf_traffic_ros2::schedule::make_mirror(
+    *node, rmf_traffic::schedule::query_all());
+  using namespace std::chrono_literals;
+  bool success = false;
+  const auto stop_time = std::chrono::steady_clock::now() + 10s;
+  while (rclcpp::ok() && std::chrono::steady_clock::now() < stop_time)
+  {
+    rclcpp::spin_some(node);
+
+    if (mirror_future.wait_for(0s) == std::future_status::ready)
+    {
+      RCLCPP_INFO(node->get_logger(), "Got mirror for monitor node");
+      node->mirror = mirror_future.get();
+      success = true;
+      break;
+    }
+  }
+  if (!success)
+  {
+    RCLCPP_ERROR(node->get_logger(), "Failed to start mirror");
+    std::exit(1);
+  }
+
+  rclcpp::spin_until_future_complete(node, active_node_future);
+
+  using namespace std::chrono_literals;
+  if (active_node_future.wait_for(0s) == std::future_status::ready
+    && rclcpp::ok())
+  {
+    auto active_schedule_node = active_node_future.get();
+    // Delete the monitor to prevent it reacting to any future events
+    node.reset();
+
+    RCLCPP_INFO(
+      active_schedule_node->get_logger(),
+      "Spinning up replacement schedule node");
+    rclcpp::spin(active_schedule_node);
+    RCLCPP_INFO(
+      active_schedule_node->get_logger(),
+      "Shutting down replacement schedule node");
+  }
+
+  rclcpp::shutdown();
+}

--- a/rmf_traffic_ros2/test/mock_schedule_nodes/missing_query_schedule.cpp
+++ b/rmf_traffic_ros2/test/mock_schedule_nodes/missing_query_schedule.cpp
@@ -29,7 +29,7 @@ class MissingQueryScheduleNode : public rmf_traffic_ros2::schedule::ScheduleNode
 {
 public:
   MissingQueryScheduleNode(const rclcpp::NodeOptions& options)
-    : ScheduleNode(options)
+    : ScheduleNode(0, options)
   {
     timer = create_wall_timer(35s, [this]() -> void
       {

--- a/rmf_traffic_ros2/test/mock_schedule_nodes/wrong_query.cpp
+++ b/rmf_traffic_ros2/test/mock_schedule_nodes/wrong_query.cpp
@@ -30,7 +30,7 @@ class WrongQueryScheduleNode : public rmf_traffic_ros2::schedule::ScheduleNode
 {
 public:
   WrongQueryScheduleNode(const rclcpp::NodeOptions& options)
-    : ScheduleNode(options, ScheduleNode::no_automatic_setup)
+    : ScheduleNode(0, options, ScheduleNode::no_automatic_setup)
   {
   }
 
@@ -63,6 +63,9 @@ public:
     // registered
     if (is_first_query)
     {
+      RCLCPP_WARN(
+        get_logger(),
+        "Fiddling with first query to cause a registered query mismatch");
       rmf_traffic::schedule::Query query = rmf_traffic::schedule::make_query({});
       auto region = rmf_traffic::Region{"L1", {}};
       const auto circle = rmf_traffic::geometry::Circle(1000);


### PR DESCRIPTION
Closes https://github.com/open-rmf/rmf/issues/75.

## New feature implementation

### Implemented feature

Remove the query and query ID from the `MirrorUpdate` message.

### Implementation description

The query ID was previously used to know if a query update should be ignored or applied to the mirror's internal copy of the database. This is no longer necessary because query updates are separated by topic, so a mirror will only receive the updates for its registered query. Thus the query ID is removed from the `MirrorUpdate` message along with checks on it in the `MirrorManager` class.

The query was added to the query update message as part of the initial redundancy work to allow a `MirrorManager` to verify that it is receiving updates for the correct query (it hasn't subscribed to the wrong topic, or the schedule node hasn't got its queries mixed up, etc.). This is inefficient, as the query may be large and query updates are frequent. Therefore the query is removed from the query update message. To retain the functionality that it allowed, the `MirrorManager` now subscribes to the latched "registered queries" broadcast topic. Each time it receives the list of registered queries from the Schedule node, it verifies both that its own query is present and that the query ID assigned by the Schedule node matches its own opinion of the query ID.

When the query is missing, or the ID is incorrect, the `MirrorManager` will re-register its query and request a new update.

To handle possible corner cases when the Schedule node fails and the redundant backup takes over (such as a query being registered just before failure and the redundant backup not being aware of it), the `MirrorManager` will force query validation mode on when it receives the fail-over announcement. However there is a possibility of a query update from the new schedule node arriving before the fail-over announcement, which may not be for the correct query anymore. To identify this situation, the Schedule node is given an "edition" number. Each time fail-over occurs, the new schedule node gets a new edition number. The edition number is sent with each query update. The `MirrorManager` checks the received edition number, and if it is greater than the expected edition number, it also enters query validation mode. While in query validation mode, it stashes all updates. If the query is validated, then it processes the stashed updates. If the query is found to be missing or the ID is found to be incorrect, the stashed updates are dumped and a fresh update is requested.