### PR TITLE
Fixing race conditions in schedule node fail over

### DIFF
--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
@@ -37,7 +37,6 @@ const std::string RegisterParticipantSrvName = Prefix + "register_participant";
 const std::string UnregisterParticipantSrvName = Prefix +
   "unregister_participant";
 const std::string RegisterQueryServiceName = Prefix + "register_query";
-const std::string UnregisterQueryServiceName = Prefix + "unregister_query";
 const std::string ParticipantsInfoTopicName = Prefix + "participants";
 const std::string QueryUpdateTopicNameBase = Prefix + "query_update_";
 const std::string RequestChangesServiceName = Prefix + "request_changes";

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
@@ -206,10 +206,6 @@ public:
       rclcpp::SystemDefaultsQoS(),
       [&, qid = query_id](const MirrorUpdate::SharedPtr msg)
       {
-        RCLCPP_INFO(
-          node.get_logger(),
-          "Query update: topic %d, node edition %d",
-          qid, msg->node_edition);
         handle_update(msg);
       });
     // At this point we know we have the correct ID for our query

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
@@ -20,6 +20,8 @@
 #include <rclcpp/logger.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <rmf_utils/Modular.hpp>
+
 #include <rmf_traffic_ros2/StandardNames.hpp>
 #include <rmf_traffic_ros2/schedule/ParticipantDescription.hpp>
 #include <rmf_traffic_ros2/schedule/MirrorManager.hpp>
@@ -35,7 +37,6 @@
 #include <rmf_traffic_msgs/msg/fail_over_event.hpp>
 
 #include <rmf_traffic_msgs/srv/register_query.hpp>
-#include <rmf_traffic_msgs/srv/unregister_query.hpp>
 #include <rmf_traffic_msgs/srv/request_changes.hpp>
 
 using namespace std::chrono_literals;
@@ -61,9 +62,6 @@ using RegisterQueryFuture = rclcpp::Client<RegisterQuery>::SharedFuture;
 using ScheduleQuery = rmf_traffic_msgs::msg::ScheduleQuery;
 using ScheduleQueries = rmf_traffic_msgs::msg::ScheduleQueries;
 
-using UnregisterQuery = rmf_traffic_msgs::srv::UnregisterQuery;
-using UnregisterQueryClient = rclcpp::Client<UnregisterQuery>::SharedPtr;
-
 using FailOverEvent = rmf_traffic_msgs::msg::FailOverEvent;
 using FailOverEventSub = rclcpp::Subscription<FailOverEvent>::SharedPtr;
 
@@ -81,7 +79,6 @@ public:
   std::list<MirrorUpdate::SharedPtr> stashed_query_updates;
   Options options;
   FailOverEventSub fail_over_event_sub;
-  UnregisterQueryClient unregister_query_client;
   MirrorUpdateSub mirror_update_sub;
   ParticipantsInfoSub participants_info_sub;
   rclcpp::Subscription<ScheduleQueries>::SharedPtr queries_info_sub;
@@ -100,13 +97,11 @@ public:
     rclcpp::Node& _node,
     rmf_traffic::schedule::Query _query,
     Options _options,
-    uint64_t _query_id,
-    UnregisterQueryClient _unregister_query_client)
+    uint64_t _query_id)
   : node(_node),
     query(std::move(_query)),
     query_id(_query_id),
     options(std::move(_options)),
-    unregister_query_client(std::move(_unregister_query_client)),
     mirror(std::make_shared<rmf_traffic::schedule::Mirror>())
   {
     setup_update_topics();
@@ -118,9 +113,9 @@ public:
     fail_over_event_sub = node.create_subscription<FailOverEvent>(
       rmf_traffic_ros2::FailOverEventTopicName,
       rclcpp::SystemDefaultsQoS(),
-      [&](const FailOverEvent::SharedPtr)
+      [&](const FailOverEvent::SharedPtr msg)
       {
-        handle_fail_over_event();
+        handle_fail_over_event(msg->new_node_edition);
       });
   }
 
@@ -128,7 +123,7 @@ public:
   {
     queries_info_sub = node.create_subscription<ScheduleQueries>(
       rmf_traffic_ros2::QueriesInfoTopicName,
-      rclcpp::SystemDefaultsQoS().reliable().keep_last(1).transient_local(),
+      rclcpp::SystemDefaultsQoS().reliable().keep_last(100).transient_local(),
       [=](const ScheduleQueries::SharedPtr msg)
       {
         RCLCPP_INFO(
@@ -137,21 +132,21 @@ public:
           msg->queries.size());
 
         // Find what should be our query based on our query ID
-        bool found_query = false;
-        size_t ii;
-        for (ii = 0; ii < msg->queries.size(); ++ii)
+        std::optional<uint64_t> our_query = std::nullopt;
+        for (std::size_t ii = 0; ii < msg->queries.size(); ++ii)
         {
           if (msg->ids[ii] == query_id)
           {
-            found_query = true;
+            our_query = ii;
             break;
           }
         }
-        if (found_query)
+
+        if (our_query.has_value())
         {
           // Confirm that the schedule node's query with our query ID is
           // actually our query
-          if (rmf_traffic_ros2::convert(msg->queries[ii]) != query)
+          if (rmf_traffic_ros2::convert(msg->queries[*our_query]) != query)
           {
             // The schedule node has someone else's query registered for our
             // query ID
@@ -161,6 +156,7 @@ public:
               "re-registering query");
             dump_stashed_queries();
             // Re-register our query to get a (possibly new) correct query ID
+            std::cout << "redo_query_registration: " << __LINE__ << std::endl;
             redo_query_registration();
           }
           else
@@ -176,6 +172,7 @@ public:
             node.get_logger(),
             "Missing query ID; re-registering query");
           dump_stashed_queries();
+          std::cout << "redo_query_registration: " << __LINE__ << std::endl;
           redo_query_registration();
         }
       });
@@ -185,7 +182,7 @@ public:
   {
     participants_info_sub = node.create_subscription<ParticipantsInfo>(
       ParticipantsInfoTopicName,
-      rclcpp::SystemDefaultsQoS().reliable().keep_last(1).transient_local(),
+      rclcpp::SystemDefaultsQoS().reliable().keep_last(100).transient_local(),
       [&](const ParticipantsInfo::SharedPtr msg)
       {
         handle_participants_info(msg);
@@ -196,8 +193,12 @@ public:
     mirror_update_sub = node.create_subscription<MirrorUpdate>(
       QueryUpdateTopicNameBase + std::to_string(query_id),
       rclcpp::SystemDefaultsQoS(),
-      [&](const MirrorUpdate::SharedPtr msg)
+      [&, qid = query_id](const MirrorUpdate::SharedPtr msg)
       {
+        RCLCPP_INFO(
+          node.get_logger(),
+          "Query update: topic %d, node edition %d",
+          qid, msg->node_edition);
         handle_update(msg);
       });
     // At this point we know we have the correct ID for our query
@@ -265,7 +266,8 @@ public:
     update_timer->reset();
 
     // Verify that the expected node edition sent the update
-    if (msg->node_edition > expected_node_edition)
+
+    if (rmf_utils::modular(expected_node_edition).less_than(msg->node_edition))
     {
       RCLCPP_WARN(
         node.get_logger(),
@@ -273,6 +275,11 @@ public:
         msg->node_edition);
       require_query_validation = true;
       expected_node_edition = msg->node_edition;
+    }
+    else if (msg->node_edition != expected_node_edition)
+    {
+      // Ignore this message because it's coming from an out-of-date edition
+      return;
     }
 
     if (require_query_validation)
@@ -360,6 +367,7 @@ public:
       request.version = 0;
       request.full_update = true;
     }
+
     request_changes_client->async_send_request(
       std::make_shared<RequestChanges::Request>(request),
       [&](const RequestChangesFuture response)
@@ -377,7 +385,7 @@ public:
 
   void redo_query_registration()
   {
-    RCLCPP_DEBUG(node.get_logger(), "Redoing query registration");
+    RCLCPP_INFO(node.get_logger(), "Redoing query registration");
     // Make sure nothing is truly coming in on this topic and triggering a
     // callback while we are remaking it
     mirror_update_sub.reset();
@@ -398,7 +406,7 @@ public:
   {
     if (register_query_client->service_is_ready())
     {
-      RCLCPP_DEBUG(
+      RCLCPP_INFO(
         node.get_logger(),
         "Redoing query registration: Calling service");
       RegisterQuery::Request register_query_request;
@@ -407,17 +415,28 @@ public:
         std::make_shared<RegisterQuery::Request>(register_query_request),
         [this](const RegisterQueryFuture response)
         {
-          this->query_id = response.get()->query_id;
-          RCLCPP_DEBUG(
+          const auto msg = response.get();
+          if (rmf_utils::modular(
+                this->expected_node_edition)
+              .less_than(msg->node_edition))
+          {
+            this->expected_node_edition = msg->node_edition;
+          }
+
+          this->query_id = msg->query_id;
+          RCLCPP_INFO(
             node.get_logger(),
             "Redoing query registration: Got new ID %d",
             query_id);
           setup_update_topics();
           setup_queries_sub();
           this->register_query_client.reset();
+
+          // Finish by requesting an update on this newly subscribed query topic
+          request_update();
         });
+
       redo_query_registration_timer.reset();
-      request_update();
     }
     else
     {
@@ -427,44 +446,26 @@ public:
     }
   }
 
-  void handle_fail_over_event()
+  void handle_fail_over_event(uint64_t new_node_edition)
   {
     RCLCPP_INFO(node.get_logger(), "Handling fail over event for mirror");
 
     // We need to validate that the replacement schedule node has our query
-    // correctly. This will be reset to false by one of:
-    // 1. The next set of queries being published, and our query being in it
-    //    correctly.
-    // 2. The query update topic being subscribed to, which indicates that
-    //    our query was not stored by the schedule node correctly and we have
-    //    re-registered.
+    // correctly. This will be reset to false once we have received the query
+    // info for the new edition and confirmed that it has our query stored in it
+    // correctly.
+    //
     // While true, all query updates received will be stashed in a list, and
     // will be popped in FIFO order and processed when this is reset to false.
-    require_query_validation = true;
-    // The new schedule node will be one edition higher
-    ++expected_node_edition;
-
-    // Deleting the old one will shut it down
-    unregister_query_client =
-      node.create_client<UnregisterQuery>(UnregisterQueryServiceName);
-    unregister_query_client->wait_for_service(std::chrono::milliseconds(100));
-    // TODO(Geoff): If the above does not return a valid service, the destructor
-    // will fail to send the unregister request. Do we care about that? Do we
-    // even need to bother waiting for the service here?
-  }
-
-  ~Implementation()
-  {
-    // Only send the unregister request if the service is actually available.
-    // This avoids a race condition between a replacement schedule node
-    // starting up while this node shuts down.
-    if (unregister_query_client->service_is_ready())
+    if (rmf_utils::modular(expected_node_edition).less_than(new_node_edition))
     {
-      RCLCPP_DEBUG(node.get_logger(), "Unregistering query");
-      UnregisterQuery::Request msg;
-      msg.query_id = query_id;
-      unregister_query_client->async_send_request(
-        std::make_shared<UnregisterQuery::Request>(std::move(msg)));
+      require_query_validation = true;
+      // The new schedule node will be one edition higher
+      expected_node_edition = new_node_edition;
+      RCLCPP_INFO(
+        node.get_logger(),
+        "New expected node edition: %ld",
+        expected_node_edition);
     }
   }
 
@@ -582,9 +583,7 @@ public:
   rmf_traffic::schedule::Query query;
   MirrorManager::Options options;
 
-  using UnregisterQueryFuture = rclcpp::Client<UnregisterQuery>::SharedFuture;
   RegisterQueryClient register_query_client;
-  UnregisterQueryClient unregister_query_client;
 
   std::atomic_bool abandon_discovery;
   std::atomic_bool registration_sent;
@@ -606,9 +605,6 @@ public:
     register_query_client =
       node.create_client<RegisterQuery>(RegisterQueryServiceName);
 
-    unregister_query_client =
-      node.create_client<UnregisterQuery>(UnregisterQueryServiceName);
-
     registration_future = registration_promise.get_future();
 
     discovery_thread = std::thread([=]() { this->discover(); });
@@ -621,7 +617,6 @@ public:
     while (!abandon_discovery && !ready)
     {
       ready = register_query_client->wait_for_service(timeout);
-      ready = ready && unregister_query_client->wait_for_service(timeout);
     }
 
     // If the schedule node falls over right now, the promise will never be
@@ -679,8 +674,7 @@ public:
       node,
       std::move(query),
       std::move(options),
-      registration.query_id,
-      std::move(unregister_query_client));
+      registration.query_id);
   }
 
   ~Implementation()
@@ -689,54 +683,6 @@ public:
 
     assert(discovery_thread.joinable());
     discovery_thread.join();
-
-    if (registration_sent && registration_future.valid())
-    {
-      // If the future is still valid, then the MirrorManager was never created,
-      // so its destructor will never be called. Therefore we should unregister
-      // the query in this destructor instead if the query was successfully
-      // registered.
-      if (std::future_status::ready ==
-        registration_future.wait_for(std::chrono::milliseconds(10)))
-      {
-        const auto registration_response = registration_future.get();
-        if (!registration_response.error.empty())
-        {
-          RCLCPP_WARN(
-            node.get_logger(),
-            "[rmf_traffic_ros2::~MirrorManagerFuture] Error received "
-            "while trying to register the query a MirrorManager: %s",
-            registration_response.error.c_str());
-        }
-        else
-        {
-          UnregisterQuery::Request msg;
-          msg.query_id = registration_response.query_id;
-          unregister_query_client->async_send_request(
-            std::make_shared<UnregisterQuery::Request>(std::move(msg)),
-            [&](const UnregisterQueryFuture response_future)
-            {
-              const auto response = response_future.get();
-              if (!response->error.empty())
-              {
-                RCLCPP_WARN(
-                  node.get_logger(),
-                  "[rmf_traffic_ros2::~MirrorManagerFuture] Error received "
-                  "while trying to unregister the query of an uninstantiated "
-                  "MirrorManager: %s",
-                  response->error.c_str());
-              }
-            });
-        }
-      }
-      else
-      {
-        RCLCPP_WARN(
-          node.get_logger(),
-          "[rmf_traffic_ros2::~MirrorManagerFuture] Timeout while waiting "
-          "for the acknowlegment of a query registration.");
-      }
-    }
   }
 
   template<typename... Args>

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MonitorNode.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MonitorNode.cpp
@@ -161,19 +161,12 @@ void MonitorNode::start_data_synchronisers()
         msg->queries.size());
       // Delete past sync'd data
       registered_queries.clear();
-      query_subscriber_counts.clear();
+
       // Fill up with the new sync'd data
       for (uint64_t ii = 0; ii < msg->ids.size(); ++ii)
       {
-        RCLCPP_DEBUG(
-          get_logger(),
-          "Query %d has %d subscribers",
-          msg->ids[ii],
-          msg->subscriber_counts[ii]);
         registered_queries.insert(
           {msg->ids[ii], rmf_traffic_ros2::convert(msg->queries[ii])});
-        query_subscriber_counts.insert(
-          {msg->ids[ii], msg->subscriber_counts[ii]});
       }
     });
 }
@@ -186,7 +179,6 @@ std::shared_ptr<rclcpp::Node> MonitorNode::create_new_schedule_node()
     1, // Bump the node edition by one
     database,
     registered_queries,
-    query_subscriber_counts,
     rclcpp::NodeOptions());
   return node;
 }

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -89,13 +89,12 @@ std::vector<ScheduleNode::ConflictSet> get_conflicts(
 ScheduleNode::ScheduleNode(
   NodeEdition edition,
   std::shared_ptr<rmf_traffic::schedule::Database> database_,
-  QueryMap registered_queries_,
-  const rclcpp::NodeOptions& options)
+  const rclcpp::NodeOptions& options,
+  NoAutomaticSetup)
 : Node("rmf_traffic_schedule_node", options),
   node_edition(edition),
   heartbeat_qos_profile(1),
   database(std::move(database_)),
-  registered_queries(std::move(registered_queries_)),
   active_conflicts(database)
 {
   // Period, in milliseconds, for sending out a heartbeat signal to the monitor
@@ -116,15 +115,14 @@ ScheduleNode::ScheduleNode(
   NodeEdition edition,
   std::shared_ptr<rmf_traffic::schedule::Database> database_,
   QueryMap registered_queries_,
-  QuerySubscriberCountMap registered_query_subscriber_counts,
   const rclcpp::NodeOptions& options)
 : ScheduleNode(
     edition,
     database_,
-    registered_queries_,
-    options)
+    options,
+    no_automatic_setup)
 {
-  setup(registered_query_subscriber_counts);
+  setup(registered_queries_);
 }
 
 //==============================================================================
@@ -137,9 +135,9 @@ ScheduleNode::ScheduleNode(
     edition,
     std::make_shared<rmf_traffic::schedule::Database>(),
     QueryMap(),
-    QuerySubscriberCountMap(),
     options)
 {
+  // Do nothing
 }
 
 //==============================================================================
@@ -152,8 +150,8 @@ ScheduleNode::ScheduleNode(
 : ScheduleNode(  // Call the version that does not call setup(...)
     edition,
     std::make_shared<rmf_traffic::schedule::Database>(),
-    QueryMap(),
-    options)
+    options,
+    no_automatic_setup)
 {
   // No setup(...) call here; it must be called manually
 }
@@ -167,8 +165,7 @@ ScheduleNode::~ScheduleNode()
 }
 
 //==============================================================================
-void ScheduleNode::setup(
-  QuerySubscriberCountMap registered_query_subscriber_counts)
+void ScheduleNode::setup(const QueryMap& queries)
 {
   //Attempt to load/create participant registry.
   std::string log_file_name;
@@ -178,7 +175,7 @@ void ScheduleNode::setup(
     ".rmf_schedule_node.yaml");
 
   // Re-instantiate any query update topics based on received queries
-  remake_mirror_update_topics(registered_query_subscriber_counts);
+  make_mirror_update_topics(queries);
 
   try
   {
@@ -221,13 +218,11 @@ void ScheduleNode::setup_query_services()
     const RegisterQuery::Response::SharedPtr response)
     { this->register_query(request_header, request, response); });
 
-  unregister_query_service =
-    create_service<UnregisterQuery>(
-    rmf_traffic_ros2::UnregisterQueryServiceName,
-    [=](const std::shared_ptr<rmw_request_id_t> request_header,
-    const UnregisterQuery::Request::SharedPtr request,
-    const UnregisterQuery::Response::SharedPtr response)
-    { this->unregister_query(request_header, request, response); });
+  // TODO(MXG): We could make the timing parameterized
+  query_cleanup_timer =
+    create_wall_timer(
+      query_cleanup_period,
+      [this]() { this->cleanup_queries(); });
 }
 
 //==============================================================================
@@ -496,146 +491,17 @@ void ScheduleNode::start_heartbeat()
 }
 
 //==============================================================================
-void ScheduleNode::add_query_topic(uint64_t query_id)
-{
-  RCLCPP_INFO(get_logger(), "Adding query topic for query %d", query_id);
-  MirrorUpdateTopicPublisher update_topic_publisher =
-    create_publisher<MirrorUpdate>(
-    rmf_traffic_ros2::QueryUpdateTopicNameBase + std::to_string(query_id),
-    rclcpp::SystemDefaultsQoS());
-  // Start the latest version sent for this query at the oldest version of the
-  // database. This will cause the new participant to be updated with all
-  // currently-relevant information from the database, not just the next
-  // change to come in.
-  MirrorUpdateTopicInfo update_topic {
-    update_topic_publisher,
-    std::nullopt,
-    1
-  };
-  mirror_update_topics.insert({query_id, update_topic});
-}
-
-//==============================================================================
-void ScheduleNode::remove_query_topic(uint64_t query_id)
-{
-  RCLCPP_INFO(get_logger(), "Removing query topic for query %d", query_id);
-  const auto& query_topic = mirror_update_topics.find(query_id);
-  if (query_topic == mirror_update_topics.end())
-  {
-    // Missing query update topic; something has gone very wrong but it doesn't
-    // matter much since we were going to remove the topic anyway
-    RCLCPP_ERROR(
-      get_logger(),
-      "Could not find expected mirror update topic to remove for query ID %d",
-      query_id);
-    return;
-  }
-  mirror_update_topics.erase(query_topic);
-}
-
-//==============================================================================
-void ScheduleNode::add_subscriber_to_query_topic(uint64_t query_id)
-{
-  RCLCPP_INFO(
-    get_logger(),
-    "Adding subscriber to query topic for query %d",
-    query_id);
-  const auto& query_topic = mirror_update_topics.find(query_id);
-  if (query_topic == mirror_update_topics.end())
-  {
-    // Missing query update topic; something has gone very wrong.
-    // TODO(Geoff): Make a new topic if an existing one can't be found? Or
-    // respond with failure to the request?
-    RCLCPP_ERROR(
-      get_logger(),
-      "Could not find expected mirror update topic for existing query ID %d "
-      "to add subscriber to",
-      query_id);
-    return;
-  }
-  auto mirror_update_topic_info = query_topic->second;
-  mirror_update_topic_info.subscriber_count += 1;
-  mirror_update_topics.insert_or_assign(query_id, mirror_update_topic_info);
-  RCLCPP_INFO(get_logger(), "Query topic has %d subscribers",
-    mirror_update_topic_info.subscriber_count);
-}
-
-//==============================================================================
-ScheduleNode::SubscriberRemovalResult
-ScheduleNode::remove_subscriber_from_query_topic(
-  uint64_t query_id)
-{
-  RCLCPP_INFO(
-    get_logger(),
-    "Removing subscriber from query topic for query %d",
-    query_id);
-  const auto& query_topic = mirror_update_topics.find(query_id);
-  if (query_topic == mirror_update_topics.end())
-  {
-    // Missing query update topic; something has gone very wrong.
-    // TODO(Geoff): Make a new topic if an existing one can't be found? Or
-    // respond with failure to the request?
-    RCLCPP_ERROR(
-      get_logger(),
-      "Could not find expected mirror update topic for existing query ID %d "
-      "to remove subscriber from",
-      query_id);
-    return SubscriberRemovalResult::query_missing;
-  }
-
-  auto mirror_update_topic_info = query_topic->second;
-  mirror_update_topic_info.subscriber_count -= 1;
-  RCLCPP_DEBUG(get_logger(), "Query topic has %d subscribers",
-    mirror_update_topic_info.subscriber_count);
-  if (mirror_update_topic_info.subscriber_count == 0)
-  {
-    remove_query_topic(query_id);
-    return SubscriberRemovalResult::query_removed;
-  }
-  else
-  {
-    mirror_update_topics.insert_or_assign(query_id, mirror_update_topic_info);
-    return SubscriberRemovalResult::query_in_use;
-  }
-}
-
-//==============================================================================
-void ScheduleNode::remake_mirror_update_topics(
-  const QuerySubscriberCountMap& subscriber_counts)
+void ScheduleNode::make_mirror_update_topics(const QueryMap& queries)
 {
   // Delete any existing topics, just to be sure
-  mirror_update_topics.clear();
+  registered_queries.clear();
 
-  for (const auto& subscriber_count: subscriber_counts)
+  for (const auto& [query_id, query] : queries)
   {
-    auto query_id = subscriber_count.first;
-    RCLCPP_INFO(
-      get_logger(),
-      "Remaking query topic for query ID %d (%d subscribers)",
-      query_id,
-      subscriber_count.second);
-    add_query_topic(query_id);
-    // Set the subscriber count manually
-    const auto& query_topic = mirror_update_topics.find(query_id);
-    if (query_topic == mirror_update_topics.end())
-    {
-      // Missing query update topic; something has gone _unbelievably_ wrong.
-      // Didn't we just add this topic?
-      RCLCPP_ERROR(
-        get_logger(),
-        "Could not find expected mirror update topic for existing query ID %d "
-        "to set subscriber count on",
-        query_id);
-      continue;
-    }
-    auto mirror_update_topic_info = query_topic->second;
-    mirror_update_topic_info.subscriber_count = subscriber_count.second;
-    mirror_update_topics.insert_or_assign(
-      query_id,
-      mirror_update_topic_info);
+    register_query(query_id, query);
+    RCLCPP_INFO(get_logger(), "Registering query ID %d", query_id);
   }
 }
-
 
 //==============================================================================
 void ScheduleNode::register_query(
@@ -645,129 +511,125 @@ void ScheduleNode::register_query(
 {
   rmf_traffic::schedule::Query new_query =
     rmf_traffic_ros2::convert(request->query);
-  bool query_exists = false;
-  uint64_t query_id = last_query_id;
+
+  response->node_edition = node_edition;
+
   // Search for an existing query with the same search parameters
-  for (const auto& [existing_query_id, existing_query] : registered_queries)
+  for (auto& [existing_query_id, existing_query] : registered_queries)
   {
-    if (existing_query == new_query)
+    if (existing_query.query == new_query)
     {
-      query_exists = true;
-      query_id = existing_query_id;
-      break;
+      RCLCPP_INFO(
+        get_logger(),
+        "A new mirror is tracking query ID [%ld]",
+        existing_query_id);
+
+      existing_query.last_registration_time = std::chrono::steady_clock::now();
+      response->query_id = existing_query_id;
+      broadcast_queries();
+      return;
     }
   }
 
-  if (query_exists)
+  // Find an unused query ID, store the query, and create a topic to publish
+  // updates that match it.
+  //
+  // Note that this search may begin at query ID 0 if this is the first time
+  // it is performed on a replacement schedule node. This is because the set
+  // of queries will have been filled in from the original schedule node's
+  // synchronised data, but last_query_id will have been initialised to zero
+  // when the replacement was constructed. This is not a problem because a
+  // search for the next available query ID does not need to be performed
+  // until we actually need a new query ID, so performing it in the
+  // constructor in advance would be unnecessary early optimisation.
+  uint64_t query_id = last_query_id;
+  uint64_t attempts = 0;
+  do
   {
-    // Query exists and query_id will be the existing query.
-
-    // Reset the latest version sent for this query to the oldest version of the
-    // database. This will ensure that the new participant receives all
-    // currently-relevant information from the database, not just the next
-    // change to come in.
-
-    // Record an additional subscriber for this query
-    add_subscriber_to_query_topic(query_id);
-    RCLCPP_INFO(get_logger(), "[%ld] Added mirror to query", query_id);
-  }
-  else
-  {
-    // If the query does not exist, then query_id is still at last_query_id.
-    // Find an unused query ID, store the query, and create a topic to publish
-    // updates that match it.
-    // Note that this search may begin at query ID 0 if this is the first time
-    // it is performed on a replacement schedule node. This is because the set
-    // of queries will have been filled in from the original schedule node's
-    // synchronised data, but last_query_id will have been initialised to zero
-    // when the replacement was constructed. This is not a problem because a
-    // search for the next available query ID does not need to be performed
-    // until we actually need a new query ID, so performing it in the
-    // constructor in advance would be unnecessary early optimisation.
-    uint64_t attempts = 0;
-    do
+    ++query_id;
+    ++attempts;
+    if (attempts == std::numeric_limits<uint64_t>::max())
     {
-      ++query_id;
-      ++attempts;
-      if (attempts == std::numeric_limits<uint64_t>::max())
-      {
-        // I suspect a computer would run out of RAM before we reach this point,
-        // but there's no harm in double-checking.
-        response->error =
-          "No more space for additional queries to be registered";
-        RCLCPP_ERROR(
-          get_logger(),
-          "[ScheduleNode::register_query] %s",
-          response->error.c_str());
-        return;
-      }
-    } while (registered_queries.find(query_id) != registered_queries.end());
+      // I suspect a computer would run out of RAM before we reach this point,
+      // but there's no harm in double-checking.
+      response->error =
+        "No more space for additional queries to be registered";
+      RCLCPP_ERROR(
+        get_logger(),
+        "[ScheduleNode::register_query] %s",
+        response->error.c_str());
+      return;
+    }
+  } while (registered_queries.find(query_id) != registered_queries.end());
 
-    last_query_id = query_id;
-    registered_queries.insert(
-      std::make_pair(query_id, rmf_traffic_ros2::convert(request->query)));
-
-    // Create the topic for updating those interested in this query
-    add_query_topic(query_id);
-    RCLCPP_INFO(get_logger(), "[%ld] Registered query", query_id);
-  }
+  response->query_id = query_id;
+  register_query(query_id, new_query);
+  last_query_id = query_id;
+  RCLCPP_INFO(get_logger(), "Registered new query [%ld]", query_id);
 
   broadcast_queries();
-
-  // If query does exist, query_id is already at the existing query ID and a
-  // topic already exists. Return the query ID to the client without creating a
-  // new topic or query.
-  response->query_id = query_id;
 }
 
 //==============================================================================
-void ScheduleNode::unregister_query(
-  const std::shared_ptr<rmw_request_id_t>& /*request_header*/,
-  const UnregisterQuery::Request::SharedPtr& request,
-  const UnregisterQuery::Response::SharedPtr& response)
+void ScheduleNode::register_query(
+  const uint64_t query_id,
+  const rmf_traffic::schedule::Query& query)
 {
-  const auto it = registered_queries.find(request->query_id);
-  if (it == registered_queries.end())
-  {
-    response->error = "No query found with the id ["
-      + std::to_string(request->query_id) + "]";
-    response->confirmation = false;
+  MirrorUpdateTopicPublisher update_publisher =
+    create_publisher<MirrorUpdate>(
+      rmf_traffic_ros2::QueryUpdateTopicNameBase + std::to_string(query_id),
+      rclcpp::SystemDefaultsQoS());
 
-    RCLCPP_INFO(
-      get_logger(),
-      "[ScheduleNode::unregister_query] %s",
-      response->error.c_str());
-    return;
-  }
+  registered_queries.emplace(
+    query_id,
+    QueryInfo{
+      query,
+      std::move(update_publisher),
+      std::nullopt,
+      std::chrono::steady_clock::now()
+    });
+}
 
-  // Remove a subscriber for this query
-  auto removal_result = remove_subscriber_from_query_topic(request->query_id);
-  if (removal_result == SubscriberRemovalResult::query_removed)
+//==============================================================================
+void ScheduleNode::cleanup_queries()
+{
+  const auto now = std::chrono::steady_clock::now();
+  auto it = registered_queries.begin();
+  while (it != registered_queries.end())
   {
-    registered_queries.erase(it);
-    RCLCPP_INFO(get_logger(), "[%ld] Unregistered query", request->query_id);
+    if (it->second.publisher->get_subscription_count() == 0)
+    {
+      if (query_grace_period < now - it->second.last_registration_time)
+      {
+        // This query is considered deprecated, so we should erase it.
+        // It's important that we use the post-increment operator here so that
+        // we increment the iterator to its next value while erasing the element
+        // that it used to point at.
+        registered_queries.erase(it++);
+        continue;
+      }
+    }
+
+    ++it;
   }
-  broadcast_queries();
-  response->confirmation = true;
 }
 
 //==============================================================================
 void ScheduleNode::broadcast_queries()
 {
   ScheduleQueries msg;
+  msg.node_edition = node_edition;
 
   for (const auto& registered_query: registered_queries)
   {
     msg.ids.push_back(registered_query.first);
 
-    rmf_traffic::schedule::Query original =
-      registered_queries.at(registered_query.first);
-    ScheduleQuery query = rmf_traffic_ros2::convert(original);
-    msg.queries.push_back(query);
+    const rmf_traffic::schedule::Query& original =
+      registered_queries.at(registered_query.first).query;
 
-    const auto& query_topic = mirror_update_topics.find(registered_query.first);
-    msg.subscriber_counts.push_back(query_topic->second.subscriber_count);
+    msg.queries.emplace_back(rmf_traffic_ros2::convert(original));
   }
+
   queries_info_pub->publish(msg);
 }
 
@@ -892,20 +754,20 @@ void ScheduleNode::request_changes(
   const RequestChanges::Request::SharedPtr& request,
   const RequestChanges::Response::SharedPtr& response)
 {
-  const auto query_topic = mirror_update_topics.find(request->query_id);
-  if (query_topic == mirror_update_topics.end())
+  const auto query = registered_queries.find(request->query_id);
+  if (query == registered_queries.end())
   {
     // Missing query update topic; something has gone very wrong.
     RCLCPP_ERROR(
       get_logger(),
-      "[ScheduleNode::request_changes] Could not find mirror update topic "
-      "for query ID %ld",
+      "[ScheduleNode::request_changes] "
+      "Could not find a query registered with ID [%ld]",
       request->query_id);
     response->result = RequestChanges::Response::UNKNOWN_QUERY_ID;
   }
   else
   {
-    auto& mirror_update_topic_info = query_topic->second;
+    auto& mirror_update_topic_info = query->second;
     // Tell the next update to send the changes since the requested version by
     // resetting the last sent version number to the requested version,
     // which may be std::nullopt if a full update is requested
@@ -1035,39 +897,31 @@ void ScheduleNode::update_mirrors()
   msg.node_edition = node_edition;
   msg.database_version = database->latest_version();
 
-  for (const auto& query_it : registered_queries)
+  for (auto& [query_id, query_info] : registered_queries)
   {
-    const auto query_topic = mirror_update_topics.find(query_it.first);
-    if (query_topic == mirror_update_topics.end())
+    const auto patch = database->changes(
+      query_info.query,
+      query_info.last_sent_version);
+
+    if (patch.size() == 0 && !patch.cull())
     {
-      // Missing query update topic; not a fatal error, but still a sign that
-      // something has gone wrong.
-      RCLCPP_ERROR(
+      RCLCPP_DEBUG(
         get_logger(),
-        "[ScheduleNode::update_mirrors] Could not find mirror update topic "
-        "to remove for query ID %ld",
-        query_it.first);
+        "[ScheduleNode::update_mirrors] Skipping query [%ld]",
+        query_id);
       continue;
     }
 
-    auto& mirror_update_topic_info = query_topic->second;
-    const auto patch = database->changes(
-      query_it.second,
-      mirror_update_topic_info.last_sent_version);
-
-    if (patch.size() == 0 && !patch.cull())
-      continue;
-
     msg.patch = rmf_traffic_ros2::convert(patch);
-    mirror_update_topic_info.publisher->publish(msg);
+    query_info.publisher->publish(msg);
 
     // Update the latest version sent to this topic
-    mirror_update_topic_info.last_sent_version = msg.database_version;
+    query_info.last_sent_version = msg.database_version;
 
     RCLCPP_DEBUG(
       get_logger(),
-      "[ScheduleNode::update_mirrors] Updated query " +
-      std::to_string(query_it.first));
+      "[ScheduleNode::update_mirrors] Updated query [%ld]",
+      query_id);
   }
 
   conflict_check_cv.notify_all();

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_MonitorNode.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_MonitorNode.hpp
@@ -83,7 +83,6 @@ public:
   std::optional<rmf_traffic_ros2::schedule::MirrorManager> mirror;
   std::function<void(std::shared_ptr<rclcpp::Node>)> on_fail_over_callback;
   ScheduleNode::QueryMap registered_queries;
-  ScheduleNode::QuerySubscriberCountMap query_subscriber_counts;
 };
 
 } // namespace schedule

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
@@ -76,7 +76,7 @@ class ScheduleNode : public rclcpp::Node
 public:
   using QueryMap = std::unordered_map<uint64_t, rmf_traffic::schedule::Query>;
 
-  using NodeEdition = uint32_t;
+  using NodeEdition = uint64_t;
   NodeEdition node_edition = 0;
 
   static struct NoAutomaticSetup{} no_automatic_setup;

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
@@ -50,7 +50,6 @@
 #include <rmf_traffic_msgs/msg/heartbeat.hpp>
 
 #include <rmf_traffic_msgs/srv/register_query.hpp>
-#include <rmf_traffic_msgs/srv/unregister_query.hpp>
 #include <rmf_traffic_msgs/srv/request_changes.hpp>
 #include <rmf_traffic_msgs/srv/register_participant.hpp>
 #include <rmf_traffic_msgs/srv/unregister_participant.hpp>
@@ -75,12 +74,9 @@ using namespace std::chrono_literals;
 class ScheduleNode : public rclcpp::Node
 {
 public:
-  using QueryMap =
-    std::unordered_map<uint64_t, rmf_traffic::schedule::Query>;
-  using QuerySubscriberCountMap =
-    std::unordered_map<uint64_t, uint64_t>;
+  using QueryMap = std::unordered_map<uint64_t, rmf_traffic::schedule::Query>;
 
-  using NodeEdition = unsigned int;
+  using NodeEdition = uint32_t;
   NodeEdition node_edition = 0;
 
   static struct NoAutomaticSetup{} no_automatic_setup;
@@ -88,14 +84,13 @@ public:
   ScheduleNode(
     NodeEdition edition,
     std::shared_ptr<rmf_traffic::schedule::Database> database_,
-    QueryMap registered_queries_,
-    const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+    const rclcpp::NodeOptions& options,
+    NoAutomaticSetup);
 
   ScheduleNode(
     NodeEdition edition,
     std::shared_ptr<rmf_traffic::schedule::Database> database_,
     QueryMap registered_queries_,
-    QuerySubscriberCountMap registered_query_subscriber_counts,
     const rclcpp::NodeOptions& options);
 
   ScheduleNode(NodeEdition edition, const rclcpp::NodeOptions& options);
@@ -107,8 +102,7 @@ public:
 
   ~ScheduleNode();
 
-  virtual void setup(
-    QuerySubscriberCountMap registered_query_subscriber_counts);
+  virtual void setup(const QueryMap& queries);
 
   std::chrono::milliseconds heartbeat_period = 1s;
   rclcpp::QoS heartbeat_qos_profile;
@@ -129,18 +123,22 @@ public:
     const RegisterQuery::Request::SharedPtr& request,
     const RegisterQuery::Response::SharedPtr& response);
 
+  void register_query(
+    uint64_t query_id,
+    const rmf_traffic::schedule::Query& query);
+
   RegisterQueryService::SharedPtr register_query_service;
 
+  // How often we should check the query topics to see if they have lost all
+  // their subscribers.
+  std::chrono::nanoseconds query_cleanup_period = std::chrono::minutes(5);
 
-  using UnregisterQuery = rmf_traffic_msgs::srv::UnregisterQuery;
-  using UnregisterQueryService = rclcpp::Service<UnregisterQuery>;
+  // If a query has no subscribers, we will unregister it, unless it has
+  // received a new registration request within this time period.
+  std::chrono::nanoseconds query_grace_period = std::chrono::minutes(5);
 
-  virtual void unregister_query(
-    const request_id_ptr& request_header,
-    const UnregisterQuery::Request::SharedPtr& request,
-    const UnregisterQuery::Response::SharedPtr& response);
-
-  UnregisterQueryService::SharedPtr unregister_query_service;
+  rclcpp::TimerBase::SharedPtr query_cleanup_timer;
+  void cleanup_queries();
 
   virtual void setup_query_services();
 
@@ -153,7 +151,6 @@ public:
     const RegisterParticipant::Response::SharedPtr& response);
 
   RegisterParticipantSrv::SharedPtr register_participant_service;
-
 
   using UnregisterParticipant = rmf_traffic_msgs::srv::UnregisterParticipant;
   using UnregisterParticipantSrv = rclcpp::Service<UnregisterParticipant>;
@@ -169,29 +166,11 @@ public:
 
   using MirrorUpdate = rmf_traffic_msgs::msg::MirrorUpdate;
   using MirrorUpdateTopicPublisher = rclcpp::Publisher<MirrorUpdate>::SharedPtr;
-  struct MirrorUpdateTopicInfo
-  {
-    MirrorUpdateTopicPublisher publisher;
-    std::optional<rmf_traffic::schedule::Version> last_sent_version;
-    std::size_t subscriber_count;
-  };
-  using MirrorUpdateTopicsMap =
-    std::unordered_map<uint64_t, MirrorUpdateTopicInfo>;
-  MirrorUpdateTopicsMap mirror_update_topics;
+
   void add_query_topic(uint64_t query_id);
   void remove_query_topic(uint64_t query_id);
-  void add_subscriber_to_query_topic(uint64_t query_id);
 
-  enum class SubscriberRemovalResult
-  {
-    query_in_use,
-    query_removed,
-    query_missing
-  };
-
-  SubscriberRemovalResult remove_subscriber_from_query_topic(uint64_t query_id);
-  void remake_mirror_update_topics(
-    const QuerySubscriberCountMap& subscriber_counts);
+  void make_mirror_update_topics(const QueryMap& queries);
 
   using SingleParticipantInfo = rmf_traffic_msgs::msg::Participant;
   using ParticipantsInfo = rmf_traffic_msgs::msg::Participants;
@@ -247,10 +226,17 @@ public:
   std::mutex database_mutex;
   std::shared_ptr<rmf_traffic::schedule::Database> database;
 
-  // TODO(MXG): Have a way to make query registrations expire after they have
-  // not been used for some set amount of time (e.g. 24 hours? 48 hours?).
+  struct QueryInfo
+  {
+    rmf_traffic::schedule::Query query;
+    MirrorUpdateTopicPublisher publisher;
+    std::optional<rmf_traffic::schedule::Version> last_sent_version;
+    std::chrono::steady_clock::time_point last_registration_time;
+  };
+  using QueryInfoMap = std::unordered_map<uint64_t, QueryInfo>;
+
   std::size_t last_query_id = 0;
-  QueryMap registered_queries;
+  QueryInfoMap registered_queries;
 
   // TODO(MXG): Make this a separate node
   std::thread conflict_check_thread;

--- a/rmf_traffic_ros2/test/mock_monitor_nodes/delayed_query_broadcast_monitor.cpp
+++ b/rmf_traffic_ros2/test/mock_monitor_nodes/delayed_query_broadcast_monitor.cpp
@@ -32,13 +32,11 @@ public:
     NodeEdition edition,
     std::shared_ptr<rmf_traffic::schedule::Database> database_,
     QueryMap registered_queries_,
-    QuerySubscriberCountMap registered_query_subscriber_counts,
     const rclcpp::NodeOptions& options)
     : ScheduleNode(
         edition,
         database_,
         registered_queries_,
-        registered_query_subscriber_counts,
         options)
   {
     timer = create_wall_timer(5s, [this]() -> void
@@ -85,7 +83,6 @@ public:
         1, // Bump the node edition by one
         database,
         registered_queries,
-        query_subscriber_counts,
         rclcpp::NodeOptions());
     return node;
   }

--- a/rmf_traffic_ros2/test/mock_schedule_nodes/missing_query_schedule.cpp
+++ b/rmf_traffic_ros2/test/mock_schedule_nodes/missing_query_schedule.cpp
@@ -46,7 +46,7 @@ public:
     ScheduleQueries msg;
 
     bool is_first = true;
-    for (const auto& registered_query: registered_queries)
+    for (const auto& [query_id, info] : registered_queries)
     {
       if (is_first)
       {
@@ -55,15 +55,11 @@ public:
         is_first = false;
         continue;
       }
-      msg.ids.push_back(registered_query.first);
+      msg.ids.push_back(query_id);
 
-      rmf_traffic::schedule::Query original =
-        registered_queries.at(registered_query.first);
+      const rmf_traffic::schedule::Query& original = info.query;
       ScheduleQuery query = rmf_traffic_ros2::convert(original);
       msg.queries.push_back(query);
-
-      const auto& query_topic = mirror_update_topics.find(registered_query.first);
-      msg.subscriber_counts.push_back(query_topic->second.subscriber_count);
     }
     queries_info_pub->publish(msg);
 

--- a/rmf_traffic_ros2/test/mock_schedule_nodes/wrong_query.cpp
+++ b/rmf_traffic_ros2/test/mock_schedule_nodes/wrong_query.cpp
@@ -43,14 +43,6 @@ public:
       const RegisterQuery::Request::SharedPtr request,
       const RegisterQuery::Response::SharedPtr response)
       { this->register_query(request_header, request, response); });
-
-    unregister_query_service =
-      create_service<UnregisterQuery>(
-      rmf_traffic_ros2::UnregisterQueryServiceName,
-      [=](const std::shared_ptr<rmw_request_id_t> request_header,
-      const UnregisterQuery::Request::SharedPtr request,
-      const UnregisterQuery::Response::SharedPtr response)
-      { this->unregister_query(request_header, request, response); });
   }
 
   void register_query(
@@ -66,7 +58,9 @@ public:
       RCLCPP_WARN(
         get_logger(),
         "Fiddling with first query to cause a registered query mismatch");
-      rmf_traffic::schedule::Query query = rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query =
+        rmf_traffic::schedule::make_query({});
+
       auto region = rmf_traffic::Region{"L1", {}};
       const auto circle = rmf_traffic::geometry::Circle(1000);
       const auto final_circle =
@@ -76,7 +70,7 @@ public:
       query.spacetime().regions()->push_back(region);
 
       // Replace the stored query
-      registered_queries.insert_or_assign(response->query_id, query);
+      ScheduleNode::register_query(response->query_id, query);
 
       is_first_query = false;
     }
@@ -89,7 +83,7 @@ int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<WrongQueryScheduleNode>(rclcpp::NodeOptions());
-  node->setup(rmf_traffic_ros2::schedule::ScheduleNode::QuerySubscriberCountMap());
+  node->setup(rmf_traffic_ros2::schedule::ScheduleNode::QueryMap());
   rclcpp::spin(node);
   rclcpp::shutdown();
   return 0;


### PR DESCRIPTION
These changes address some of the feedback I left on #86. Since I needed to do some debugging and tweaking the code to verify my concerns, I thought it would make sense to just make the fixes and push them rather than write about it all at length. This PR depends on https://github.com/open-rmf/rmf_internal_msgs/pull/23

The highlights are:
* We no longer have a service to unregister queries. The manual reference counting was causing some serious problems, and I don't believe there's any robust way to really achieve it. Instead we'll just periodically check if any queries are no longer subscribed to, and clear the ones that aren't being used.
* We're being more conscientious about the node edition value, using and verifying it in more messages.