### PR TITLE
Fix some broken test cases

### DIFF
--- a/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
+++ b/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
@@ -188,7 +188,7 @@ SCENARIO_METHOD(MockAdapterFixture, "request lift phase", "[phases]")
         std::unique_lock<std::mutex> lk(test->m);
         test->received_requests_cv.wait(lk, [&]()
           {
-            if (!test->received_requests.empty())
+            if (test->received_requests.empty())
               return false;
             return test->received_requests.back().request_type == LiftRequest::REQUEST_END_SESSION;
           });

--- a/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
+++ b/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
@@ -161,6 +161,8 @@ SCENARIO_METHOD(MockAdapterFixture, "request lift phase", "[phases]")
           lk, std::chrono::milliseconds(1000),
           [&]()
           {
+            if(test->status_updates.empty())
+              return false;
             const auto& state = test->status_updates.back().state;
             return state == Task::StatusMsg::STATE_COMPLETED;
           });
@@ -186,6 +188,8 @@ SCENARIO_METHOD(MockAdapterFixture, "request lift phase", "[phases]")
         std::unique_lock<std::mutex> lk(test->m);
         test->received_requests_cv.wait(lk, [&]()
           {
+            if (!test->received_requests.empty())
+              return false;
             return test->received_requests.back().request_type == LiftRequest::REQUEST_END_SESSION;
           });
       }

--- a/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
+++ b/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
@@ -161,7 +161,7 @@ SCENARIO_METHOD(MockAdapterFixture, "request lift phase", "[phases]")
           lk, std::chrono::milliseconds(1000),
           [&]()
           {
-            if(test->status_updates.empty())
+            if (test->status_updates.empty())
               return false;
             const auto& state = test->status_updates.back().state;
             return state == Task::StatusMsg::STATE_COMPLETED;

--- a/rmf_traffic_ros2/test/unit/test_ParticipantRegistry.cpp
+++ b/rmf_traffic_ros2/test/unit/test_ParticipantRegistry.cpp
@@ -49,28 +49,34 @@ SCENARIO("Test idempotency of shape type")
   REQUIRE_THROWS(shape_type(node["type"]));
 }
 
-
-bool operator==(const rmf_traffic::Profile p1, const rmf_traffic::Profile p2)
+namespace rmf_traffic {
+bool operator==(const Profile p1, const Profile p2)
 {
   return rmf_traffic_ros2::convert(p1) == rmf_traffic_ros2::convert(p2);
 }
-
+namespace schedule {
 bool operator==(
-  const rmf_traffic::schedule::ParticipantDescription desc1,
-  const rmf_traffic::schedule::ParticipantDescription desc2)
+  const ParticipantDescription desc1,
+  const ParticipantDescription desc2)
 {
   return desc1.name() == desc2.name()
     && desc1.owner() == desc2.owner()
     && desc1.responsiveness() ==  desc2.responsiveness()
     && desc1.profile() == desc2.profile();
 }
+}
+}
 
+namespace rmf_traffic_ros2 {
+namespace schedule {
 bool operator==(
   const AtomicOperation op1,
   const AtomicOperation op2)
 {
   return op1.operation == op2.operation
     && op1.description == op2.description;
+}
+}
 }
 
 SCENARIO("Test idempotency of ParticipantDescription.")

--- a/rmf_traffic_ros2/test/unit/test_ParticipantRegistry.cpp
+++ b/rmf_traffic_ros2/test/unit/test_ParticipantRegistry.cpp
@@ -50,11 +50,14 @@ SCENARIO("Test idempotency of shape type")
 }
 
 namespace rmf_traffic {
+
 bool operator==(const Profile p1, const Profile p2)
 {
   return rmf_traffic_ros2::convert(p1) == rmf_traffic_ros2::convert(p2);
 }
+
 namespace schedule {
+
 bool operator==(
   const ParticipantDescription desc1,
   const ParticipantDescription desc2)
@@ -64,11 +67,13 @@ bool operator==(
     && desc1.responsiveness() ==  desc2.responsiveness()
     && desc1.profile() == desc2.profile();
 }
+
 }
 }
 
 namespace rmf_traffic_ros2 {
 namespace schedule {
+
 bool operator==(
   const AtomicOperation op1,
   const AtomicOperation op2)
@@ -76,6 +81,7 @@ bool operator==(
   return op1.operation == op2.operation
     && op1.description == op2.description;
 }
+
 }
 }
 


### PR DESCRIPTION

## Bug fix

### Fixed bug
The test cases had the following issues:
* `test_ParticipantRegistry.cpp` was not building against clang due to some issues with namespacing of operators.
* `test_RequestLift.cpp` has a potential buffer overflow/invalid memory access issue. (Thanks @mxgrey for suggesting the fixes).