### PR TITLE
Feature/pybind11 fleet update handle

### DIFF
--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -155,6 +155,9 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def("close_lanes",
     &agv::FleetUpdateHandle::close_lanes,
     py::arg("lane_indices"))
+  .def("open_lanes",
+    &agv::FleetUpdateHandle::open_lanes,
+    py::arg("lane_indices"))
   .def("set_task_planner_params",
     [&](agv::FleetUpdateHandle& self,
     battery::BatterySystem& b_sys,

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -152,6 +152,9 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("profile"),
     py::arg("start"),
     py::arg("handle_cb"))
+  .def("close_lanes",
+    &agv::FleetUpdateHandle::close_lanes,
+    py::arg("lane_indices"))
   .def("set_task_planner_params",
     [&](agv::FleetUpdateHandle& self,
     battery::BatterySystem& b_sys,


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Added Some C++ Interfaces to Python

Exposed ```rmf_fleet_adapter::agv::FleetUpdateHandle::close_lanes``` and ```rmf_fleet_adapter::agv::FleetUpdateHandle::open_lanes```.

This might be useful for those who want to handle lane closures in their python-based fleet adapters.

<!-- ### Implemented feature -->

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

<!-- ### Implementation description -->

<!-- Describe the approach taken to implement the feature.
Provide a link to a detailed design document and discussion of that design.
Implementations without design documentation will not be accepted until design documentation has been provided and discussed.
Usually this is done via the feature request issue. -->
