### PR TITLE
Fixes #91 rx-cpp heap-use-after free.

### DIFF
--- a/rmf_fleet_adapter/rmf_rxcpp/RxCpp-4.1.0/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
+++ b/rmf_fleet_adapter/rmf_rxcpp/RxCpp-4.1.0/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
@@ -109,7 +109,8 @@ private:
                         continue;
                     }
                     if (clock_type::now() < peek.when) {
-                        keepAlive->wake.wait_until(guard, peek.when);
+                        auto when = peek.when;
+                        keepAlive->wake.wait_until(guard, when);
                         continue;
                     }
                     auto what = peek.what;


### PR DESCRIPTION
Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>

## Bug fix
### Fixed bug

For context see #91.

Explanation what was going on is the following:

In line 126 of `rmf_newthread.hpp` the scheduler adds items to a queue.
https://github.com/open-rmf/rmf_ros2/blob/25248162b15e249279e5120d7ca8b8482b5b778b/rmf_fleet_adapter/rmf_rxcpp/RxCpp-4.1.0/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp#L132-L137

These items are then serviced by a consumer here:
https://github.com/open-rmf/rmf_ros2/blob/25248162b15e249279e5120d7ca8b8482b5b778b/rmf_fleet_adapter/rmf_rxcpp/RxCpp-4.1.0/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp#L97-L113

Now whats happening is a very interesting phenomenon. When we add an item to a queue, then the `std::vector` backing the queue may be resized. During the resize, we may have a need to reallocate memory to a new location. When this happens the reference to peek in Line 106 gets invalidated causing a :boom: .  On the surface it looks like there's a `std::mutex` and `std::unique_lock` preventing the two from overwriting each other. However, when we wait on the condition variable, we release the `std::mutex` for an extremely short time (see https://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_cond_wait.html, since this is what conditional_variable ultimately uses on sane operating systems). This allows the vector to be resized.

#### Whats the severity of this issue?

The worst thing that can happen is the `peek.when` to be imperceptibly far in the future and the worker does no work for an undefined amount of time. There is no effect on the function called as the locking there is correct.

### Fix applied

Just copy the darn time. There is no need to use references here.

Also, ASAN is awesome.
