### PR TITLE
Feature/pybind11 planner

### DIFF
--- a/rmf_fleet_adapter_python/src/planner/planner.cpp
+++ b/rmf_fleet_adapter_python/src/planner/planner.cpp
@@ -142,6 +142,8 @@ void bind_plan(py::module& m)
     })
   .def_property_readonly("graph_index",
     &Plan::Waypoint::graph_index)
+  .def_property_readonly("approach_lanes",
+    &Plan::Waypoint::approach_lanes)
   .def_property_readonly("event",
     &Plan::Waypoint::event);
 

--- a/rmf_fleet_adapter_python/src/planner/planner.cpp
+++ b/rmf_fleet_adapter_python/src/planner/planner.cpp
@@ -146,6 +146,8 @@ void bind_plan(py::module& m)
     &Plan::Waypoint::approach_lanes)
   .def_property_readonly("itinerary_index",
     &Plan::Waypoint::itinerary_index)
+  .def_property_readonly("trajectory_index",
+    &Plan::Waypoint::trajectory_index)
   .def_property_readonly("event",
     &Plan::Waypoint::event);
 

--- a/rmf_fleet_adapter_python/src/planner/planner.cpp
+++ b/rmf_fleet_adapter_python/src/planner/planner.cpp
@@ -144,6 +144,8 @@ void bind_plan(py::module& m)
     &Plan::Waypoint::graph_index)
   .def_property_readonly("approach_lanes",
     &Plan::Waypoint::approach_lanes)
+  .def_property_readonly("itinerary_index",
+    &Plan::Waypoint::itinerary_index)
   .def_property_readonly("event",
     &Plan::Waypoint::event);
 


### PR DESCRIPTION
## Exposed Some C++ Read-Only Property to Python

Added `rmf_traffic::agv::Plan::Waypoint::approach_lanes`.

Added `rmf_traffic::agv::Plan::Waypoint::itinerary_index`.

Added `rmf_traffic::agv::Plan::Waypoint::trajectory_index`.

The `approach_lanes` property might be useful for those who want their fleet adapters to deal with lane closures.

I don't need the `itinerary_index` and `trajectory_index`.  But, since it's a public interface in C++, I thought it might be useful to others who might need that.   