### PR TITLE
Feature/pybind11 experimental lift entry watchdog

### DIFF
--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -127,7 +127,17 @@ PYBIND11_MODULE(rmf_adapter, m) {
       return self.unstable().get_participant();
     },
     py::return_value_policy::reference_internal,
-    "Experimental API to access the schedule participant");
+    "Experimental API to access the schedule participant")
+  .def("set_unstable_lift_entry_watchdog",
+    [&](agv::RobotUpdateHandle& self,
+        agv::RobotUpdateHandle::Unstable::Watchdog watchdog,
+        rmf_traffic::Duration wait_duration)
+    {
+      self.unstable().set_lift_entry_watchdog(watchdog, wait_duration);
+    },
+    py::arg("watchdog"),
+    py::arg("wait_duration") = std::chrono::seconds(10),
+    "Experimental API to set the lift entry watchdog");
 
   // FLEETUPDATE HANDLE ======================================================
   py::class_<agv::FleetUpdateHandle,

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -139,6 +139,17 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("wait_duration") = std::chrono::seconds(10),
     "Experimental API to set the lift entry watchdog");
 
+  auto m_robot_update_handle = m.def_submodule("robot_update_handle");
+
+  py::enum_<agv::RobotUpdateHandle::Unstable::Decision>(
+    m_robot_update_handle, "Decision")
+  .value("Undefined",
+    agv::RobotUpdateHandle::Unstable::Decision::Undefined)
+  .value("Clear",
+    agv::RobotUpdateHandle::Unstable::Decision::Clear)
+  .value("Crowded",
+    agv::RobotUpdateHandle::Unstable::Decision::Crowded);
+
   // FLEETUPDATE HANDLE ======================================================
   py::class_<agv::FleetUpdateHandle,
     std::shared_ptr<agv::FleetUpdateHandle>>(


### PR DESCRIPTION
## Added some python bindings

Added python binding for C++ function `rmf_fleet_adapter::agv::RobotUpdateHandle::Unstable::set_lift_entry_watchdog`.

Added python binding for C++ enum `rmf_fleet_adapter::agv::RobotUpdateHandle::Unstable::Decision`.