### PR TITLE
Update Delivery task factory 

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -209,7 +209,8 @@ void TaskManager::set_queue(
           _context,
           start,
           a.deployment_time(),
-          a.state());
+          a.state(),
+          task_profile.description.delivery);
         task->task_profile(task_profile);
 
         _queue.push_back(task);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -342,7 +342,9 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       return;
     }
 
-    // TODO: Pipe in estimations of waiting time at pickup and ropoff
+    // TODO: We set the waiting duration at the pickup and dropoff locations to
+    // 0s as the cycle time of the dispensers and ingestors are not available.
+    // We should implement a means to lookup these values for each system.
     new_request = rmf_task::requests::Delivery::make(
       pickup_wp->index(),
       rmf_traffic::time::from_seconds(0),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -342,12 +342,12 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       return;
     }
 
+    // TODO: Pipe in estimations of waiting time at pickup and ropoff
     new_request = rmf_task::requests::Delivery::make(
       pickup_wp->index(),
-      delivery.pickup_dispenser,
+      rmf_traffic::time::from_seconds(0),
       dropoff_wp->index(),
-      delivery.dropoff_ingestor,
-      delivery.items,
+      rmf_traffic::time::from_seconds(0),
       id,
       start_time,
       priority);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.cpp
@@ -32,7 +32,8 @@ std::shared_ptr<Task> make_delivery(
   const agv::RobotContextPtr& context,
   const rmf_traffic::agv::Plan::Start pickup_start,
   const rmf_traffic::Time deployment_time,
-  const rmf_task::agv::State finish_state)
+  const rmf_task::agv::State finish_state,
+  const rmf_task_msgs::msg::Delivery delivery_profile)
 {
 
   std::shared_ptr<const rmf_task::requests::Delivery::Description> description =
@@ -56,9 +57,9 @@ std::shared_ptr<Task> make_delivery(
     std::make_unique<phases::DispenseItem::PendingPhase>(
       context,
       request->id(),
-      description->pickup_dispenser(),
+      delivery_profile.pickup_dispenser,
       context->itinerary().description().owner(),
-      description->items()));
+      delivery_profile.items));
 
   const auto dropoff_start = [&]() -> rmf_traffic::agv::Planner::Start
     {
@@ -88,8 +89,8 @@ std::shared_ptr<Task> make_delivery(
       dropoff_waypoint));
 
   std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> ingestor_items;
-  ingestor_items.reserve(description->items().size());
-  for (const auto& dispenser_item : description->items())
+  ingestor_items.reserve(delivery_profile.items.size());
+  for (const auto& dispenser_item : delivery_profile.items)
   {
     rmf_ingestor_msgs::msg::IngestorRequestItem item{};
     item.type_guid = dispenser_item.type_guid;
@@ -102,7 +103,7 @@ std::shared_ptr<Task> make_delivery(
     std::make_unique<phases::IngestItem::PendingPhase>(
       context,
       request->id(),
-      description->dropoff_ingestor(),
+      delivery_profile.dropoff_ingestor,
       context->itinerary().description().owner(),
       ingestor_items));
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.hpp
@@ -23,6 +23,8 @@
 
 #include <rmf_task/requests/Delivery.hpp>
 
+#include <rmf_task_msgs/msg/delivery.hpp>
+
 namespace rmf_fleet_adapter {
 namespace tasks {
 
@@ -32,7 +34,8 @@ std::shared_ptr<Task> make_delivery(
   const agv::RobotContextPtr& context,
   const rmf_traffic::agv::Plan::Start pickup_start,
   const rmf_traffic::Time deployment_time,
-  const rmf_task::agv::State finish_state);
+  const rmf_task::agv::State finish_state,
+  const rmf_task_msgs::msg::Delivery delivery_profile);
 
 } // namespace tasks
 } // namespace rmf_fleet_adapter


### PR DESCRIPTION
PR https://github.com/open-rmf/rmf_task/pull/36 removes artifacts of `rmf_task_msgs::msg::Delivery` that were previously stored within the `rmf_task::requests::Delivery` request. This allows for `rmf_task` to be ROS 2 agnostic. 

The PR here makes relevant changes to the creation of a Delivery Task and should be merged in after https://github.com/open-rmf/rmf_task/pull/36