### PR TITLE
Accommodate finishing task

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -28,6 +28,8 @@
 #include <rmf_battery/DevicePowerSink.hpp>
 #include <rmf_battery/MotionPowerSink.hpp>
 
+#include <rmf_task/RequestFactory.hpp>
+
 namespace rmf_fleet_adapter {
 namespace agv {
 
@@ -106,6 +108,10 @@ public:
   ///   vehicles in this fleet when battery levels fall below the
   ///   recharge_threshold.
   ///
+  /// \param[in] finishing_request
+  ///   A factory for a request that should be performed by each robot in this
+  ///   fleet at the end of its assignments.
+  ///
   /// \return true if task planner parameters were successfully updated.
   bool set_task_planner_params(
     std::shared_ptr<rmf_battery::agv::BatterySystem> battery_system,
@@ -114,7 +120,8 @@ public:
     std::shared_ptr<rmf_battery::DevicePowerSink> tool_sink,
     double recharge_threshold,
     double recharge_soc,
-    bool account_for_battery_drain);
+    bool account_for_battery_drain,
+    rmf_task::ConstRequestFactoryPtr finishing_requst = nullptr);
 
   /// A callback function that evaluates whether a fleet will accept a task
   /// request

--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -16,7 +16,6 @@
   <arg name="angular_acceleration" description="The nominal angular acceleration of the vehicles in this fleet"/>
   <arg name="footprint_radius" description="The radius of the footprint of the vehicles in this fleet"/>
   <arg name="vicinity_radius" description="The radius of the personal vicinity of the vehicles in this fleet"/>
-  <arg name="perform_deliveries" default="false" description="Whether this fleet adapter can perform deliveries"/>
   <arg name="delay_threshold" default="10.0" description="How long to wait before replanning" />
   <arg name="disable_delay_threshold" default="false" description="Disable the delay_threshold behavior" />
   <arg name="retry_wait" default="10.0" description="How long a retry should wait before starting"/>
@@ -25,7 +24,10 @@
   <arg name="output" default="screen"/>
 
   <arg name="perform_loop" default="false" description="Whether this fleet adapter can perform loops"/>
+  <arg name="perform_deliveries" default="false" description="Whether this fleet adapter can perform deliveries"/>
   <arg name="perform_cleaning" default="false" description="Whether this fleet adapter can perform cleaning"/>
+  <arg name="finishing_request_charge_battery" default="false" description="Whether robots in this fleet should perform a ChargeBattery task once all queued tasks are completed"/>
+  <arg name="finishing_request_return_charger" default="false" description="Whether robots in this fleet should return to their chargers once all queued tasks are completed"/>
   <arg name="battery_voltage" description="The nominal voltage(V) of the battery in the vehicles in this fleet"/>
   <arg name="battery_capacity" description="The nominal capacity(Ah) of the battery in the vehicles in this fleet"/>
   <arg name="battery_charging_current" description="The nominal charging current(A) of the battery in the vehicles in this fleet"/>
@@ -61,6 +63,8 @@
     <param name="perform_deliveries" value="$(var perform_deliveries)"/>
     <param name="perform_loop" value="$(var perform_loop)"/>
     <param name="perform_cleaning" value="$(var perform_cleaning)"/>
+    <param name="finishing_request_charge_battery" value="$(var finishing_request_charge_battery)"/>
+    <param name="finishing_request_return_charger" value="$(var finishing_request_return_charger)"/>
 
     <param name="delay_threshold" value="$(var delay_threshold)"/>
     <param name="disable_delay_threshold" value="$(var disable_delay_threshold)"/>
@@ -77,8 +81,8 @@
     <param name="ambient_power_drain" value="$(var ambient_power_drain)"/>
     <param name="tool_power_drain" value="$(var tool_power_drain)"/>
     <param name="drain_battery" value="$(var drain_battery)"/>
-    <param name="recharge_threshold" value="$(var recharge_threshold)"/> 
-    <param name="recharge_soc" value="$(var recharge_soc)"/> 
+    <param name="recharge_threshold" value="$(var recharge_threshold)"/>
+    <param name="recharge_soc" value="$(var recharge_soc)"/>
 
     <param name="experimental_lift_watchdog_service" value="$(var experimental_lift_watchdog_service)"/>
 

--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -27,7 +27,7 @@
   <arg name="perform_deliveries" default="false" description="Whether this fleet adapter can perform deliveries"/>
   <arg name="perform_cleaning" default="false" description="Whether this fleet adapter can perform cleaning"/>
   <arg name="finishing_request_charge_battery" default="false" description="Whether robots in this fleet should perform a ChargeBattery task once all queued tasks are completed"/>
-  <arg name="finishing_request_return_charger" default="false" description="Whether robots in this fleet should return to their chargers once all queued tasks are completed"/>
+  <arg name="finishing_request_park_robot" default="false" description="Whether robots in this fleet should return to their parking spots once all queued tasks are completed"/>
   <arg name="battery_voltage" description="The nominal voltage(V) of the battery in the vehicles in this fleet"/>
   <arg name="battery_capacity" description="The nominal capacity(Ah) of the battery in the vehicles in this fleet"/>
   <arg name="battery_charging_current" description="The nominal charging current(A) of the battery in the vehicles in this fleet"/>
@@ -64,7 +64,7 @@
     <param name="perform_loop" value="$(var perform_loop)"/>
     <param name="perform_cleaning" value="$(var perform_cleaning)"/>
     <param name="finishing_request_charge_battery" value="$(var finishing_request_charge_battery)"/>
-    <param name="finishing_request_return_charger" value="$(var finishing_request_return_charger)"/>
+    <param name="finishing_request_park_robot" value="$(var finishing_request_park_robot)"/>
 
     <param name="delay_threshold" value="$(var delay_threshold)"/>
     <param name="disable_delay_threshold" value="$(var disable_delay_threshold)"/>

--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -26,8 +26,7 @@
   <arg name="perform_loop" default="false" description="Whether this fleet adapter can perform loops"/>
   <arg name="perform_deliveries" default="false" description="Whether this fleet adapter can perform deliveries"/>
   <arg name="perform_cleaning" default="false" description="Whether this fleet adapter can perform cleaning"/>
-  <arg name="finishing_request_charge_battery" default="false" description="Whether robots in this fleet should perform a ChargeBattery task once all queued tasks are completed"/>
-  <arg name="finishing_request_park_robot" default="false" description="Whether robots in this fleet should return to their parking spots once all queued tasks are completed"/>
+  <arg name="finishing_request" default="nothing" description="What should happen when the robot is finished with its tasks? Options: nothing (default), park, charge"/>
   <arg name="battery_voltage" description="The nominal voltage(V) of the battery in the vehicles in this fleet"/>
   <arg name="battery_capacity" description="The nominal capacity(Ah) of the battery in the vehicles in this fleet"/>
   <arg name="battery_charging_current" description="The nominal charging current(A) of the battery in the vehicles in this fleet"/>
@@ -63,8 +62,7 @@
     <param name="perform_deliveries" value="$(var perform_deliveries)"/>
     <param name="perform_loop" value="$(var perform_loop)"/>
     <param name="perform_cleaning" value="$(var perform_cleaning)"/>
-    <param name="finishing_request_charge_battery" value="$(var finishing_request_charge_battery)"/>
-    <param name="finishing_request_park_robot" value="$(var finishing_request_park_robot)"/>
+    <param name="finishing_request" value="$(var finishing_request)"/>
 
     <param name="delay_threshold" value="$(var delay_threshold)"/>
     <param name="disable_delay_threshold" value="$(var disable_delay_threshold)"/>

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -46,8 +46,8 @@
 #include "../rmf_fleet_adapter/estimation.hpp"
 
 // Public rmf_task API headers
-#include <rmf_task/requests/factory/ChargeBatteryFactory.hpp>
-#include <rmf_task/requests/factory/ReturnToChargerFactory.hpp>
+#include <rmf_task/requests/ChargeBatteryFactory.hpp>
+#include <rmf_task/requests/ParkRobotFactory.hpp>
 
 // Public rmf_traffic API headers
 #include <rmf_traffic/agv/Interpolate.hpp>
@@ -942,10 +942,10 @@ std::shared_ptr<Connections> make_fleet(
     *node,
     "finishing_request_charge_battery",
     false);
-  const bool finishing_request_return_charger =
+  const bool finishing_request_park_robot =
     rmf_fleet_adapter::get_parameter_or_default(
     *node,
-    "finishing_request_return_charger",
+    "finishing_request_park_robot",
     false);
   rmf_task::ConstRequestFactoryPtr finishing_request = nullptr;
   if (finishing_request_charge_battery)
@@ -956,13 +956,13 @@ std::shared_ptr<Connections> make_fleet(
       node->get_logger(),
       "Fleet is configured to perform ChargeBattery as finishing request");
   }
-  if (finishing_request_return_charger)
+  if (finishing_request_park_robot)
   {
     finishing_request =
-      std::make_shared<rmf_task::requests::ReturnToChargerFactory>();
+      std::make_shared<rmf_task::requests::ParkRobotFactory>();
     RCLCPP_INFO(
       node->get_logger(),
-      "Fleet is configured to perform ReturnToCharger as finishing request");
+      "Fleet is configured to perform ParkRobot as finishing request");
   }
 
   if (!connections->fleet->set_task_planner_params(

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -969,7 +969,7 @@ std::shared_ptr<Connections> make_fleet(
       "Provided finishing request [%s] is unsupported. The valid "
       "finishing requests are [charge, park, nothing]. The task planner will "
       " default to [nothing].",
-      finishing_request_string);
+      finishing_request_string.c_str());
   }
 
   if (!connections->fleet->set_task_planner_params(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -260,8 +260,7 @@ const std::vector<rmf_task::ConstRequestPtr> TaskManager::requests() const
   requests.reserve(_queue.size());
   for (const auto& task : _queue)
   {
-    if (std::dynamic_pointer_cast<const ChargeBattery::Description>(
-        task->request()->description()))
+    if (task->request()->automatic())
     {
       continue;
     }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -156,11 +156,22 @@ void TaskManager::set_queue(
       const auto request = a.request();
 
       TaskProfileMsg task_profile;
+      bool auto_request = request->automatic();
       const auto it = task_profiles.find(request->id());
       if (it != task_profiles.end())
       {
         task_profile = it->second;
       }
+      else
+      {
+        assert(auto_request);
+        // We may have an auto-generated request
+        task_profile.task_id = request->id();
+        task_profile.submission_time = _context->node()->now();
+        task_profile.description.start_time = rmf_traffic_ros2::convert(
+          request->earliest_start_time());
+      }
+      
 
       using namespace rmf_task::requests;
 
@@ -173,6 +184,21 @@ void TaskManager::set_queue(
           start,
           a.deployment_time(),
           a.state());
+
+         // Populate task_profile for auto-generated Clean request
+        if (auto_request)
+        {
+          std::shared_ptr<const rmf_task::requests::Clean::Description>
+          description =  std::dynamic_pointer_cast<
+            const Clean::Description>(request->description());
+          const auto start_waypoint = description->start_waypoint();
+          const auto waypoint_name =
+            _context->navigation_graph().get_waypoint(start_waypoint).name();
+          task_profile.description.task_type.type =
+            rmf_task_msgs::msg::TaskType::TYPE_CLEAN;
+          task_profile.description.clean.start_waypoint =
+            waypoint_name != nullptr ? *waypoint_name : "";
+        }
         task->task_profile(task_profile);
 
         _queue.push_back(task);
@@ -188,14 +214,12 @@ void TaskManager::set_queue(
           a.deployment_time(),
           a.state());
 
-        // The TaskProfile for auto-generated tasks such as ChargeBattery will
-        // need to be manually constructed
-        task_profile.task_id = request->id();
-        task_profile.submission_time = _context->node()->now();
-        task_profile.description.start_time = rmf_traffic_ros2::convert(
-          request->earliest_start_time());
-        task_profile.description.task_type.type =
-          rmf_task_msgs::msg::TaskType::TYPE_CHARGE_BATTERY;
+        // Populate task_profile for auto-generated ChargeBattery request
+        if (auto_request)
+        {
+          task_profile.description.task_type.type =
+            rmf_task_msgs::msg::TaskType::TYPE_CHARGE_BATTERY;
+        }
         task->task_profile(task_profile);
 
         _queue.push_back(task);
@@ -211,6 +235,27 @@ void TaskManager::set_queue(
           a.deployment_time(),
           a.state(),
           task_profile.description.delivery);
+
+        // Populate task_profile for auto-generated Delivery request
+        if (auto_request)
+        {
+          std::shared_ptr<const rmf_task::requests::Delivery::Description>
+          description =  std::dynamic_pointer_cast<
+            const Delivery::Description>(request->description());
+          const auto& graph = _context->navigation_graph();
+          const auto pickup_waypoint = description->pickup_waypoint();
+          const auto pickup_name =
+            graph.get_waypoint(pickup_waypoint).name();
+          const auto dropoff_waypoint = description->dropoff_waypoint();
+          const auto dropoff_name =
+            graph.get_waypoint(dropoff_waypoint).name();
+          task_profile.description.task_type.type =
+            rmf_task_msgs::msg::TaskType::TYPE_DELIVERY;
+          task_profile.description.delivery.pickup_place_name =
+            pickup_name != nullptr ? *pickup_name : "";
+          task_profile.description.delivery.dropoff_place_name =
+            dropoff_name != nullptr ? *dropoff_name : "";
+        }
         task->task_profile(task_profile);
 
         _queue.push_back(task);
@@ -225,6 +270,28 @@ void TaskManager::set_queue(
           start,
           a.deployment_time(),
           a.state());
+
+        // Populate task_profile for auto-generated Loop request
+        if (auto_request)
+        {
+          std::shared_ptr<const rmf_task::requests::Loop::Description>
+          description = std::dynamic_pointer_cast<
+            const Loop::Description>(request->description());
+          const auto& graph = _context->navigation_graph();
+          const auto start_waypoint = description->start_waypoint();
+          const auto start_name =
+            graph.get_waypoint(start_waypoint).name();
+          const auto finish_waypoint = description->finish_waypoint();
+          const auto finish_name =
+            graph.get_waypoint(finish_waypoint).name();
+          task_profile.description.loop.num_loops = description->num_loops();
+          task_profile.description.task_type.type =
+            rmf_task_msgs::msg::TaskType::TYPE_LOOP;
+          task_profile.description.loop.start_name =
+            start_name != nullptr ? *start_name : "";
+          task_profile.description.loop.finish_name =
+            finish_name != nullptr ? *finish_name : "";
+        }
         task->task_profile(task_profile);
 
         _queue.push_back(task);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -171,7 +171,6 @@ void TaskManager::set_queue(
         task_profile.description.start_time = rmf_traffic_ros2::convert(
           request->earliest_start_time());
       }
-      
 
       using namespace rmf_task::requests;
 
@@ -185,11 +184,11 @@ void TaskManager::set_queue(
           a.deployment_time(),
           a.state());
 
-         // Populate task_profile for auto-generated Clean request
+        // Populate task_profile for auto-generated Clean request
         if (auto_request)
         {
           std::shared_ptr<const rmf_task::requests::Clean::Description>
-          description =  std::dynamic_pointer_cast<
+          description = std::dynamic_pointer_cast<
             const Clean::Description>(request->description());
           const auto start_waypoint = description->start_waypoint();
           const auto waypoint_name =
@@ -240,7 +239,7 @@ void TaskManager::set_queue(
         if (auto_request)
         {
           std::shared_ptr<const rmf_task::requests::Delivery::Description>
-          description =  std::dynamic_pointer_cast<
+          description = std::dynamic_pointer_cast<
             const Delivery::Description>(request->description());
           const auto& graph = _context->navigation_graph();
           const auto pickup_waypoint = description->pickup_waypoint();

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -918,7 +918,8 @@ auto FleetUpdateHandle::Implementation::allocate_tasks(
     rmf_traffic_ros2::convert(node->now()),
     states,
     pending_requests,
-    nullptr);
+    nullptr,
+    finishing_request);
 
   auto assignments_ptr = std::get_if<
     rmf_task::agv::TaskPlanner::Assignments>(&result);
@@ -1222,7 +1223,8 @@ bool FleetUpdateHandle::set_task_planner_params(
   std::shared_ptr<rmf_battery::DevicePowerSink> tool_sink,
   double recharge_threshold,
   double recharge_soc,
-  bool account_for_battery_drain)
+  bool account_for_battery_drain,
+  rmf_task::ConstRequestFactoryPtr finishing_request)
 {
   if (battery_system &&
     motion_sink &&
@@ -1254,6 +1256,8 @@ bool FleetUpdateHandle::set_task_planner_params(
     // task planner here is updated.
     for (const auto& t : _pimpl->task_managers)
       t.first->task_planner(_pimpl->task_planner);
+
+    _pimpl->finishing_request = std::move(finishing_request);
 
     return true;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -142,7 +142,6 @@ public:
   std::shared_ptr<rmf_task::CostCalculator> cost_calculator =
     rmf_task::BinaryPriorityScheme::make_cost_calculator();
   std::shared_ptr<rmf_task::agv::TaskPlanner> task_planner = nullptr;
-  rmf_task::ConstRequestFactoryPtr finishing_request = nullptr;
 
   rmf_utils::optional<rmf_traffic::Duration> default_maximum_delay =
     std::chrono::nanoseconds(std::chrono::seconds(10));

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -142,6 +142,7 @@ public:
   std::shared_ptr<rmf_task::CostCalculator> cost_calculator =
     rmf_task::BinaryPriorityScheme::make_cost_calculator();
   std::shared_ptr<rmf_task::agv::TaskPlanner> task_planner = nullptr;
+  rmf_task::ConstRequestFactoryPtr finishing_request = nullptr;
 
   rmf_utils::optional<rmf_traffic::Duration> default_maximum_delay =
     std::chrono::nanoseconds(std::chrono::seconds(10));


### PR DESCRIPTION
PR https://github.com/open-rmf/rmf_task/pull/28 allows for a `RequestFactory` to be supplied when task allocation planning. The request generated by the `RequestFactory` is automatically appended to the end of the task queue for all agents. This is very useful when you want robots in a fleet to always perform a certain task after finishing other requested tasks. For example, if we do not want robots to remain idle after their last performed task and instead want them to recharge their batteries, we can supply the `ChargeBatteryFactory` to the task planner which will automatically append a `ChargeBattery` task to the end of the robot's task queues.

This PR:
* Update `FleetUpdateHandle::set_task_planner_params()` to optionally accept a `RequestFactory`
* Updates `full_control` launch file and src to allow users to set the fleet adapter's task planner with either `ChargeBatteryFactory` or `ParkRobotFactory`