### PR TITLE
Add graph conversion function from rmf_building_map_msgs to rmf_traffic

### DIFF
--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -16,6 +16,7 @@ include(GNUInstallDirs)
 find_package(ament_cmake REQUIRED)
 find_package(rmf_traffic REQUIRED)
 find_package(rmf_traffic_msgs REQUIRED)
+find_package(rmf_building_map_msgs REQUIRED)
 find_package(rmf_fleet_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -120,6 +121,7 @@ target_link_libraries(rmf_traffic_ros2
   PUBLIC
     rmf_traffic::rmf_traffic
     ${rmf_traffic_msgs_LIBRARIES}
+    ${rmf_building_map_msgs_LIBRARIES}
     ${rclcpp_LIBRARIES}
     yaml-cpp
 )
@@ -129,6 +131,7 @@ target_include_directories(rmf_traffic_ros2
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     ${rmf_traffic_msgs_INCLUDE_DIRS}
+    ${rmf_building_map_msgs_INCLUDE_DIRS}
     ${rclcpp_INCLUDE_DIRS}
 )
 
@@ -138,6 +141,7 @@ ament_export_dependencies(
   rmf_traffic
   rmf_traffic_msgs
   rmf_fleet_msgs
+  rmf_building_map_msgs
   Eigen3
   rclcpp
   yaml-cpp

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/agv/Graph.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/agv/Graph.hpp
@@ -23,6 +23,6 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::agv::Graph convert(const rmf_building_map_msgs::msg::Graph& from,
-    int waypoint_offset = 0);
+  int waypoint_offset = 0);
 
 } // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/agv/Graph.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/agv/Graph.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_traffic/agv/Graph.hpp>
+
+#include <rmf_building_map_msgs/msg/graph.hpp>
+
+namespace rmf_traffic_ros2 {
+
+//==============================================================================
+rmf_traffic::agv::Graph convert(const rmf_building_map_msgs::msg::Graph& from,
+    int waypoint_offset = 0);
+
+} // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -13,6 +13,7 @@
   <depend>rmf_utils</depend>
   <depend>rmf_traffic</depend>
   <depend>rmf_traffic_msgs</depend>
+  <depend>rmf_building_map_msgs</depend>
   <depend>rmf_fleet_msgs</depend>
   <depend>rclcpp</depend>
   <depend>yaml-cpp</depend>

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Graph.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Graph.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_traffic_ros2/agv/Graph.hpp>
+
+namespace rmf_traffic_ros2 {
+
+//==============================================================================
+rmf_traffic::agv::Graph convert(const rmf_building_map_msgs::msg::Graph& from,
+    int waypoint_offset)
+{
+  rmf_traffic::agv::Graph graph;
+  // Iterate over vertices / waypoints
+  // Graph params are not used for now
+  for (const auto& vertex : from.vertices)
+  {
+    const Eigen::Vector2d location{
+      vertex.x, vertex.y};
+    auto wp = graph.add_waypoint(from.name, location);
+    // Add waypoint name if in the message
+    if (vertex.name.size() > 0 && !graph.add_key(vertex.name, wp.index()))
+    {
+      throw std::runtime_error(
+        "Duplicated waypoint name [" + vertex.name + "]");
+    }
+    for (const auto& param : vertex.params)
+    {
+      if (param.name == "is_parking_spot")
+        wp.set_parking_spot(param.value_bool);
+      else if (param.name == "is_holding_point")
+        wp.set_holding_point(param.value_bool);
+      else if (param.name == "is_passthrough_point")
+        wp.set_passthrough_point(param.value_bool);
+      else if (param.name == "is_charger")
+        wp.set_charger(param.value_bool);
+    }
+  }
+  // Iterate over edges / lanes
+  for (const auto& edge : from.edges)
+  {
+    using Lane = rmf_traffic::agv::Graph::Lane;
+    using Event = Lane::Event;
+    // TODO(LDV) Add remaining functionality, lifts, doors, docking points
+    // events, orientation constraints
+    rmf_utils::clone_ptr<Event> entry_event;
+    rmf_utils::clone_ptr<Event> exit_event;
+    // Waypoint offset is applied to ensure unique IDs when multiple levels
+    // are present
+    const int start_wp = edge.v1_idx + waypoint_offset;
+    const int end_wp = edge.v2_idx + waypoint_offset;
+    graph.add_lane({start_wp, entry_event}, {end_wp, exit_event});
+    if (edge.edge_type == edge.EDGE_TYPE_BIDIRECTIONAL)
+      graph.add_lane({end_wp, entry_event}, {start_wp, exit_event});
+  }
+  return graph;
+}
+
+} // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Graph.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Graph.cpp
@@ -54,17 +54,27 @@ rmf_traffic::agv::Graph convert(const rmf_building_map_msgs::msg::Graph& from,
   {
     using Lane = rmf_traffic::agv::Graph::Lane;
     using Event = Lane::Event;
-    // TODO(luca) Add remaining functionality, lifts, doors, docking points
-    // events, orientation constraints
+    // TODO(luca) Add lifts, doors, orientation constraints
     rmf_utils::clone_ptr<Event> entry_event;
     rmf_utils::clone_ptr<Event> exit_event;
     // Waypoint offset is applied to ensure unique IDs when multiple levels
     // are present
     const std::size_t start_wp = edge.v1_idx + waypoint_offset;
     const std::size_t end_wp = edge.v2_idx + waypoint_offset;
-    graph.add_lane({start_wp, entry_event}, {end_wp, exit_event});
+    std::string dock_name;
+    for (const auto& param : edge.params)
+    {
+      if (param.name == "dock_name")
+        dock_name = param.value_string;
+    }
+    // dock_name is only applied to the lane going to the waypoint, not exiting
     if (edge.edge_type == edge.EDGE_TYPE_BIDIRECTIONAL)
       graph.add_lane({end_wp, entry_event}, {start_wp, exit_event});
+
+    const rmf_traffic::Duration duration = std::chrono::seconds(5);
+    entry_event = Event::make(Lane::Dock(dock_name, duration));
+    graph.add_lane({start_wp, entry_event},
+      {end_wp, exit_event});
   }
   return graph;
 }

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Graph.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Graph.cpp
@@ -21,7 +21,7 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::agv::Graph convert(const rmf_building_map_msgs::msg::Graph& from,
-    int waypoint_offset)
+  int waypoint_offset)
 {
   rmf_traffic::agv::Graph graph;
   // Iterate over vertices / waypoints
@@ -30,12 +30,12 @@ rmf_traffic::agv::Graph convert(const rmf_building_map_msgs::msg::Graph& from,
   {
     const Eigen::Vector2d location{
       vertex.x, vertex.y};
-    auto wp = graph.add_waypoint(from.name, location);
+    auto& wp = graph.add_waypoint(from.name, location);
     // Add waypoint name if in the message
     if (vertex.name.size() > 0 && !graph.add_key(vertex.name, wp.index()))
     {
       throw std::runtime_error(
-        "Duplicated waypoint name [" + vertex.name + "]");
+              "Duplicated waypoint name [" + vertex.name + "]");
     }
     for (const auto& param : vertex.params)
     {
@@ -54,14 +54,14 @@ rmf_traffic::agv::Graph convert(const rmf_building_map_msgs::msg::Graph& from,
   {
     using Lane = rmf_traffic::agv::Graph::Lane;
     using Event = Lane::Event;
-    // TODO(LDV) Add remaining functionality, lifts, doors, docking points
+    // TODO(luca) Add remaining functionality, lifts, doors, docking points
     // events, orientation constraints
     rmf_utils::clone_ptr<Event> entry_event;
     rmf_utils::clone_ptr<Event> exit_event;
     // Waypoint offset is applied to ensure unique IDs when multiple levels
     // are present
-    const int start_wp = edge.v1_idx + waypoint_offset;
-    const int end_wp = edge.v2_idx + waypoint_offset;
+    const std::size_t start_wp = edge.v1_idx + waypoint_offset;
+    const std::size_t end_wp = edge.v2_idx + waypoint_offset;
     graph.add_lane({start_wp, entry_event}, {end_wp, exit_event});
     if (edge.edge_type == edge.EDGE_TYPE_BIDIRECTIONAL)
       graph.add_lane({end_wp, entry_event}, {start_wp, exit_event});

--- a/rmf_traffic_ros2/test/unit/test_convert_Graph.cpp
+++ b/rmf_traffic_ros2/test/unit/test_convert_Graph.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_utils/catch.hpp>
+
+#include <rmf_traffic_ros2/agv/Graph.hpp>
+#include <rmf_traffic_ros2/schedule/ParticipantRegistry.hpp>
+
+static auto make_graph_node(const double x, const double y,
+  const std::string& name,
+  const std::vector<rmf_building_map_msgs::msg::Param>& params)
+{
+  rmf_building_map_msgs::msg::GraphNode node;
+  node.x = x;
+  node.y = y;
+  node.name = name;
+  for (const auto& param : params)
+    node.params.push_back(param);
+  return node;
+}
+
+static auto make_bool_param(const std::string& name, const bool val)
+{
+  rmf_building_map_msgs::msg::Param param;
+  param.name = name;
+  param.type = param.TYPE_BOOL;
+  param.value_bool = val;
+  return param;
+} 
+
+SCENARIO("Test conversion from rmf_building_map_msgs to rmf_traffic")
+{
+  GIVEN("a graph with two nodes")
+  {
+    rmf_building_map_msgs::msg::Graph input_msg;
+    // Populate input graph
+    input_msg.name = "test_graph";
+    rmf_building_map_msgs::msg::GraphNode node;
+    input_msg.vertices.push_back(
+      make_graph_node(10, 20, "wp_0", {
+        make_bool_param("is_parking_spot", true),
+        make_bool_param("is_holding_point", true)
+      }));
+    input_msg.vertices.push_back(
+      make_graph_node(30, 40, "wp_1", {
+        make_bool_param("is_passthrough_point", true),
+        make_bool_param("is_charger", true)
+      }));
+    // A node without a key
+    input_msg.vertices.push_back(
+      make_graph_node(50, 60, "", {}));
+    rmf_building_map_msgs::msg::GraphEdge edge;
+    edge.v1_idx = 0;
+    edge.v2_idx = 1;
+      WHEN("the lane is not bidirectional")
+      {
+        THEN("graph has only one lane")
+        {
+          edge.edge_type = edge.EDGE_TYPE_UNIDIRECTIONAL;
+          input_msg.edges = {edge};
+          auto res = rmf_traffic_ros2::convert(input_msg);
+          REQUIRE(res.num_lanes() == 1);
+          auto lane = res.get_lane(0);
+          CHECK(lane.entry().waypoint_index() == 0);
+          CHECK(lane.exit().waypoint_index() == 1);
+        }
+      }
+      WHEN("the lane is bidirectional")
+      {
+
+        THEN("graph has two lanes")
+        {
+          edge.edge_type = edge.EDGE_TYPE_BIDIRECTIONAL;
+          input_msg.edges = {edge};
+          auto res = rmf_traffic_ros2::convert(input_msg);
+          REQUIRE(res.num_lanes() == 2);
+          auto lane = res.get_lane(0);
+          CHECK(lane.entry().waypoint_index() == 0);
+          CHECK(lane.exit().waypoint_index() == 1);
+          lane = res.get_lane(1);
+          CHECK(lane.entry().waypoint_index() == 1);
+          CHECK(lane.exit().waypoint_index() == 0);
+        }
+      }
+    THEN("output graph has two nodes with right properties")
+    {
+      auto res = rmf_traffic_ros2::convert(input_msg);
+      auto keys = res.keys();
+      // Only two nodes had a key but three nodes
+      CHECK(keys.size() == 2);
+      CHECK(res.num_waypoints() == 3);
+      // Check the nodes properties
+      REQUIRE(res.find_waypoint("wp_0") != nullptr);
+      REQUIRE(res.find_waypoint("wp_1") != nullptr);
+      REQUIRE(res.find_waypoint("wp_2") == nullptr);
+      auto wp = res.find_waypoint("wp_0");
+      CHECK(wp->is_parking_spot() == true);
+      CHECK(wp->is_holding_point() == true);
+      CHECK(wp->is_passthrough_point() == false);
+      CHECK(wp->is_charger() == false);
+      wp = res.find_waypoint("wp_1");
+      CHECK(wp->is_parking_spot() == false);
+      CHECK(wp->is_holding_point() == false);
+      CHECK(wp->is_passthrough_point() == true);
+      CHECK(wp->is_charger() == true);
+    }
+  }
+}


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR is to work towards #117, it adds a function in `rmf_traffic_ros2` to convert from the [Graph](https://github.com/open-rmf/rmf_building_map_msgs/blob/main/rmf_building_map_msgs/msg/Graph.msg) implementation in `rmf_building_map_msgs` to the [Graph](https://github.com/open-rmf/rmf_traffic/blob/main/rmf_traffic/include/rmf_traffic/agv/Graph.hpp) in `rmf_traffic::agv`

### Implementation description

The implementation is simple for now and it only implements waypoints without infrastructure.
Also, unlike the [implementation in parse_graph](https://github.com/open-rmf/rmf_ros2/blob/main/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/parse_graph.cpp#L26-L29) it doesn't implement `orientation_constraints`. I couldn't find any place where those are used in the demos and it is unclear in the case of pure conversion between message formats where the `VehicleTraits` information would come from.
If we wanted support for doors / lifts it would be more complicated and probably not in the scope of `Graph` conversion since those are contained in the top level Building message and not in the graph itself.

In the scope of #117, the intended use for this PR is to allow users to subscribe to maps, select the graph that they want to use for their fleet, then use the newly introduced `convert` function to convert it to a `rmf_traffic::agv::Graph` that can be assigned to a planner.

I also added unit tests to verify that all the functionality works as intended (which helped me catch a sneaky `auto` instead of `auto&`. All the parts that are currently unimplemented are documented in the code but, as mentioned above, they might not be in the scope of a Graph conversion function.