### PR TITLE
add example rmf_proj usage

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -35,6 +35,7 @@ set(dep_pkgs
   rmf_traffic_ros2
   rmf_battery
   rmf_task
+  rmf_proj
   std_msgs
 )
 foreach(pkg ${dep_pkgs})
@@ -185,12 +186,14 @@ target_link_libraries(full_control
     rmf_fleet_adapter
     ${rmf_fleet_msgs_LIBRARIES}
     ${rmf_task_msgs_LIBRARIES}
+    rmf_proj::rmf_proj
 )
 
 target_include_directories(full_control
   PRIVATE
     ${rmf_fleet_msgs_INCLUDE_DIRS}
     ${rmf_task_msgs_INCLUDE_DIRS}
+    rmf_proj::rmf_proj
 )
 
 # -----------------------------------------------------------------------------

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -24,6 +24,7 @@
   <depend>rmf_traffic_ros2</depend>
   <depend>rmf_battery</depend>
   <depend>rmf_task</depend>
+  <depend>rmf_proj</depend>
   <depend>std_msgs</depend>
   <depend condition="$RMF_ENABLE_FAILOVER == 1">stubborn_buddies</depend>
   <depend condition="$RMF_ENABLE_FAILOVER == 1">stubborn_buddies_msgs</depend>


### PR DESCRIPTION
Example use case for https://github.com/open-rmf/rmf_coordinate_transformations/pull/1 that publishes to `robot_gps_path_request`

Not final.