### PR TITLE
Scheduler node for tasks. Addresses #103

### DIFF
--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rmf_traffic REQUIRED)
 find_package(rmf_traffic_ros2 REQUIRED)
 find_package(rmf_task_msgs REQUIRED)
+find_package(rmf_task_scheduler_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(rclcpp REQUIRED)
 
@@ -28,6 +29,7 @@ target_link_libraries(rmf_task_ros2
     rmf_traffic::rmf_traffic
     rmf_traffic_ros2::rmf_traffic_ros2
     ${rmf_task_msgs_LIBRARIES}
+    ${rmf_task_scheduler_msgs_LIBRARIES}
     ${rclcpp_LIBRARIES}
 )
 
@@ -37,6 +39,7 @@ target_include_directories(rmf_task_ros2
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     ${rmf_traffic_ros2_INCLUDE_DIRS}
     ${rmf_task_msgs_INCLUDE_DIRS}
+    ${rmf_task_scheduler_msgs_INCLUDE_DIRS}
     ${rclcpp_INCLUDE_DIRS}
 )
 

--- a/rmf_task_ros2/include/rmf_task_ros2/Scheduler.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/Scheduler.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_TASK_ROS2__SCHEDULER_HPP
+#define RMF_TASK_ROS2__SCHEDULER_HPP
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rmf_utils/impl_ptr.hpp>
+#include <rmf_utils/optional.hpp>
+
+namespace rmf_task_ros2 {
+
+class Scheduler
+{
+public:
+  static std::unique_ptr<Scheduler> make(
+    const std::shared_ptr<rclcpp::Node>& node);
+
+  class Implementation;
+
+private:
+  Scheduler();
+  rmf_utils::unique_impl_ptr<Implementation> _pimpl;
+}
+}
+
+#endif

--- a/rmf_task_ros2/include/rmf_task_ros2/Scheduler.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/Scheduler.hpp
@@ -34,9 +34,8 @@ public:
   class Implementation;
 
 private:
-  Scheduler();
   rmf_utils::unique_impl_ptr<Implementation> _pimpl;
-}
+};
 }
 
 #endif

--- a/rmf_task_ros2/include/rmf_task_ros2/StandardNames.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/StandardNames.hpp
@@ -36,9 +36,9 @@ const std::string TaskStatusTopicName = "task_summaries";
 const std::string ActiveTasksTopicName = "dispatcher_ongoing_tasks";
 
 const std::string TaskScheduleRequests = Prefix + "schedule_request";
-const std::string TaskScheduleRequests = Prefix + "schedule_responses";
-const std::string TaskScheduleRequests = Prefix + "schedule_cancel";
-const std::string TaskScheduleRequests = Prefix + "schedule_state";
+const std::string TaskScheduleResponses = Prefix + "schedule_responses";
+const std::string TaskScheduleCancel = Prefix + "schedule_cancel";
+const std::string TaskScheduleState = Prefix + "schedule_state";
 } // namespace rmf_task_ros2
 
 #endif // RMF_TASK_ROS2__STANDARDNAMES_HPP

--- a/rmf_task_ros2/include/rmf_task_ros2/StandardNames.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/StandardNames.hpp
@@ -35,6 +35,10 @@ const std::string TaskAckTopicName = Prefix + "dispatch_ack";
 const std::string TaskStatusTopicName = "task_summaries";
 const std::string ActiveTasksTopicName = "dispatcher_ongoing_tasks";
 
+const std::string TaskScheduleRequests = Prefix + "schedule_request";
+const std::string TaskScheduleRequests = Prefix + "schedule_responses";
+const std::string TaskScheduleRequests = Prefix + "schedule_cancel";
+const std::string TaskScheduleRequests = Prefix + "schedule_state";
 } // namespace rmf_task_ros2
 
 #endif // RMF_TASK_ROS2__STANDARDNAMES_HPP

--- a/rmf_task_ros2/package.xml
+++ b/rmf_task_ros2/package.xml
@@ -12,6 +12,7 @@
 
   <depend>rmf_utils</depend>
   <depend>rmf_traffic</depend>
+  <depend>rmf_task_scheduler_msgs</depend>
   <depend>rmf_traffic_ros2</depend>
   <depend>rmf_task_msgs</depend>
   <depend>rclcpp</depend>

--- a/rmf_task_ros2/package.xml
+++ b/rmf_task_ros2/package.xml
@@ -16,6 +16,7 @@
   <depend>rmf_traffic_ros2</depend>
   <depend>rmf_task_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>yaml-cpp</depend>
 
   <build_depend>eigen</build_depend>
 

--- a/rmf_task_ros2/src/rmf_task_ros2/Scheduler.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Scheduler.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_task_scheduler_msgs/msg/task_schedule_cancel.hpp>
+#include <rmf_task_scheduler_msgs/msg/task_schedule_request.hpp>
+#include <rmf_task_scheduler_msgs/msg/task_schedule_response.hpp>
+#include <rmf_task_scheduler_msgs/msg/task_schedule_rules.hpp>
+
+#include <rmf_task_ros2/Scheduler.hpp>
+#include <rmf_task_ros2/StandardNames.hpp>
+
+using namespace rmf_task_ros2;
+
+class Scheduler::Implementation
+{
+using TaskCancelMsg = rmf_task_scheduler_msgs::msg::TaskScheduleCancel;
+using TaskRequestMsg = rmf_task_scheduler_msgs::msg::TaskScheduleRequest;
+using TaskResponseMsg = rmf_task_scheduler_msgs::msg::TaskScheduleResponse;
+using TaskRuleMsg = rmf_task_scheduler_msgs::msg::TaskScheduleRule;
+using TaskRulesMsg = rmf_task_scheduler_msgs::msg::TaskScheduleRules;
+
+public:
+std::shared_ptr<rclcpp::Publisher<TaskRulesMsg>> _status_pub;
+
+std::shared_ptr<rclcpp::Publisher<TaskResponseMsg>> _response_pub;
+
+std::shared_ptr<rclcpp::Subscription<TaskRequestMsg>> _request_sub;
+
+std::shared_ptr<rclcpp::Subscription<TaskCancelMsg>> _cancel_sub;
+
+void on_cancel_request(const TaskCancelMsg::SharedPtr msg)
+{
+
+}
+
+void on_receive_request(const TaskRequestMsg::SharedPtr msg)
+{
+
+} 
+
+Implementation(const std::share_ptr<rclcpp::Node>& node)
+{
+  _cancel_sub = /*node->create_subscription()*/;
+}
+};
+
+static std::unique_ptr<Scheduler> Scheduler::make(
+  const std::share_ptr<rclcpp::Node>& node)
+{
+  auto pimpl = rmf_utils::make_impl<Implementation>(node);
+
+}
+
+Scheduler::Scheduler()
+{
+
+}

--- a/rmf_task_ros2/src/rmf_task_ros2/Scheduler.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Scheduler.cpp
@@ -52,14 +52,14 @@ void on_receive_request(const TaskRequestMsg::SharedPtr msg)
 
 } 
 
-Implementation(const std::share_ptr<rclcpp::Node>& node)
+Implementation(const std::shared_ptr<rclcpp::Node>& node)
 {
   _cancel_sub =
-    node->create_subscription<TaskCancelMsgs>(TaskScheduleCancel, 10,
-      std::bind(&Scheduler::Implementation::on_cancel_request, this, _1));
+    node->create_subscription<TaskCancelMsg>(TaskScheduleCancel, 10,
+      std::bind(&Scheduler::Implementation::on_cancel_request, this, std::placeholders::_1));
   _request_sub =
-    node->create_subscription<TaskRequestMsgs>(TaskScheduleRequests, 10,
-      std::bind(&Scheduler::Implementation::on_receive_request, this, _1));
+    node->create_subscription<TaskRequestMsg>(TaskScheduleRequests, 10,
+      std::bind(&Scheduler::Implementation::on_receive_request, this, std::placeholders::_1));
 
   _status_pub =
     node->create_publisher<TaskRulesMsg>(TaskScheduleState, 10);
@@ -68,17 +68,12 @@ Implementation(const std::share_ptr<rclcpp::Node>& node)
 }
 };
 
-static std::unique_ptr<Scheduler> Scheduler::make(
-  const std::share_ptr<rclcpp::Node>& node)
+std::unique_ptr<Scheduler> Scheduler::make(
+  const std::shared_ptr<rclcpp::Node>& node)
 {
   auto pimpl = rmf_utils::make_impl<Implementation>(node);
-  std::unique_ptr<Scheduler> sched;
+  auto sched = std::make_unique<Scheduler>();
   sched->_pimpl = std::move(pimpl);
 
   return sched;
-}
-
-Scheduler::Scheduler()
-{
-
 }

--- a/rmf_task_ros2/src/rmf_task_ros2/Scheduler.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Scheduler.cpp
@@ -54,7 +54,17 @@ void on_receive_request(const TaskRequestMsg::SharedPtr msg)
 
 Implementation(const std::share_ptr<rclcpp::Node>& node)
 {
-  _cancel_sub = /*node->create_subscription()*/;
+  _cancel_sub =
+    node->create_subscription<TaskCancelMsgs>(TaskScheduleCancel, 10,
+      std::bind(&Scheduler::Implementation::on_cancel_request, this, _1));
+  _request_sub =
+    node->create_subscription<TaskRequestMsgs>(TaskScheduleRequests, 10,
+      std::bind(&Scheduler::Implementation::on_receive_request, this, _1));
+
+  _status_pub =
+    node->create_publisher<TaskRulesMsg>(TaskScheduleState, 10);
+  _response_pub =
+    node->create_publisher<TaskResponseMsg>(TaskScheduleResponses, 10);
 }
 };
 
@@ -62,7 +72,10 @@ static std::unique_ptr<Scheduler> Scheduler::make(
   const std::share_ptr<rclcpp::Node>& node)
 {
   auto pimpl = rmf_utils::make_impl<Implementation>(node);
+  std::unique_ptr<Scheduler> sched;
+  sched->_pimpl = std::move(pimpl);
 
+  return sched;
 }
 
 Scheduler::Scheduler()

--- a/rmf_task_ros2/src/rmf_task_ros2/Scheduler.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Scheduler.cpp
@@ -23,6 +23,8 @@
 #include <rmf_task_ros2/Scheduler.hpp>
 #include <rmf_task_ros2/StandardNames.hpp>
 
+#include "scheduler/internal_ScheduleQueue.hpp"
+
 using namespace rmf_task_ros2;
 
 class Scheduler::Implementation
@@ -42,9 +44,11 @@ std::shared_ptr<rclcpp::Subscription<TaskRequestMsg>> _request_sub;
 
 std::shared_ptr<rclcpp::Subscription<TaskCancelMsg>> _cancel_sub;
 
+SimpleSchedulerQueue _queue;
+
 void on_cancel_request(const TaskCancelMsg::SharedPtr msg)
 {
-
+  
 }
 
 void on_receive_request(const TaskRequestMsg::SharedPtr msg)

--- a/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_ScheduleQueue.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_ScheduleQueue.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "internal_ScheduleQueue.hpp"
+
+using namespace rmf_task_ros2;
+
+uint32_t SimpleSchedulerQueue::enqueue_request(const TaskRequest& request)
+{
+  uint32_t request_id = _increment_id;
+  _increment_id++;
+  _request_table[request_id] = request;
+  _priority_queue.insert({request._start_time, request_id})
+
+  return request_id;
+}
+
+
+void SimpleSchedulerQueue::cancel_request(const uint32_t request)
+{
+  _to_be_deleted.insert(request);
+}
+
+std::vector<TaskRequest> 
+  SimpleSchedulerQueue::check_and_deque(const rclcpp::Time time)
+{
+  std::vector<TaskRequest> to_be_submitted;
+  while(
+    !_priority_queue.empty() && 
+    time > _priority_queue.top()._time)
+  {
+    if (_to_be_deleted.count(_priority_queue.top()._request_index) != 0)
+    {
+      _priority_queue.pop();
+      _request_table.erase(request);
+      _to_be_deleted.erase(request);
+      continue;
+    }
+
+    auto req_idx = _priority_queue.top()._request_index;
+    auto req = _request_table[req_idx];
+    auto time_of_execution = _priority_queue.top()._time;
+    to_be_submitted.push_back(req);
+    _priority_queue.pop();
+
+    if (req._repeat_interval.has_value())
+    {
+      auto next_time_of_exec =
+          req._repeat_interval.value() + time_of_execution;
+      if (req._end_time.has_value()
+      && next_time_of_exec > req._end_time.value())
+      {
+        _request_table.erase(req_idx);
+        continue;
+      }
+    }
+  }
+
+  return to_be_submitted;
+}

--- a/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_ScheduleQueue.hpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_ScheduleQueue.hpp
@@ -34,7 +34,8 @@ public:
 
   virtual void cancel_request(const uint32_t request) = 0;
 
-  virtual std::unordered_map<uint32_t, TaskRequest> get_queued() = 0 const;
+  // TODO: Change to some type of Custom View to make it more efficient
+  virtual std::unordered_map<uint32_t, TaskRequest> get_queued() const = 0;
 
   virtual ~AbstractSchedulerQueue() { };
 };

--- a/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_ScheduleQueue.hpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_ScheduleQueue.hpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_TASK_ROS2_SCHEDULER_INTERNAL_SCHEDULE_QUEUE_H
+#define RMF_TASK_ROS2_SCHEDULER_INTERNAL_SCHEDULE_QUEUE_H
+
+#include "internal_TaskRequest.hpp"
+
+#include <chrono>
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace rmf_task_ros2 {
+
+class AbstractSchedulerQueue
+{
+public:
+  virtual uint32_t enqueue_request(const TaskRequest& request) = 0;
+
+  virtual void cancel_request(const uint32_t request) = 0;
+
+  virtual std::unordered_map<uint32_t, TaskRequest> get_queued() = 0 const;
+
+  virtual ~AbstractSchedulerQueue() { };
+};
+
+
+class SimpleSchedulerQueue : AbstractSchedulerQueue
+{
+public:
+  uint32_t enqueue_request(const TaskRequest& request) override;
+
+  void cancel_request(const uint32_t request) override;
+
+  std::unordered_map<uint32_t, TaskRequest> get_queued() const override;
+
+  std::vector<TaskRequest> check_and_deque(const rclcpp::Time time);
+
+private:
+  uint32_t _increment_id;
+  
+  std::unordered_map<uint32_t, TaskRequest> _request_table;
+  std::unordered_set<uint32_t> _to_be_deleted;
+
+  struct QueueElement
+  {
+    rclcpp::Time _time;
+    uint32_t _request_index;
+
+    bool operator<(const QueueElement& element) const
+    {
+      // purposely flip so earlier time comes first
+      return this->_time > element._time;
+    }
+  };
+
+  std::priority_queue<QueueElement> _priority_queue;
+};
+
+}
+
+#endif

--- a/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_TaskRequest.hpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_TaskRequest.hpp
@@ -45,7 +45,7 @@ public:
     request._name = req.name;
     request._start_time = req.start_time;
 
-    if (req.has_end_time)request.
+    if (req.has_end_time)
     {
       request._end_time = {req.end_time};
     }

--- a/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_TaskRequest.hpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_TaskRequest.hpp
@@ -64,9 +64,15 @@ public:
     }
 
     request._task_type = req.task_type;
-    request._args = req.args; 
+    request._args = req.task_description; 
 
     return request;
+  }
+
+  rmf_task_msgs::msg::TaskDescription to_description()
+  {
+    rmf_task_msgs::msg::TaskDescription description;
+    
   }
 };
 }

--- a/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_TaskRequest.hpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/scheduler/internal_TaskRequest.hpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_TASK_ROS2_SCHEDULER_INTERNAL_TASK_REQUEST_H
+#define RMF_TASK_ROS2_SCHEDULER_INTERNAL_TASK_REQUEST_H
+
+#include <string>
+#include <vector>
+
+#include <rmf_task_scheduler_msgs/msg/task_schedule_request.hpp>
+#include <rmf_task_msgs/msg/task_description.hpp>
+#include <rclcpp/time.hpp> 
+#include <rclcpp/duration.hpp> 
+
+namespace rmf_task_ros2 {
+
+class TaskRequest
+{
+public:
+  std::string _name;
+  rclcpp::Time _start_time;
+  std::optional<rclcpp::Time> _end_time;
+  std::optional<rclcpp::Duration> _repeat_interval;
+  std::string _task_type;
+  std::string _args;
+
+  static TaskRequest Make(
+    const rmf_task_scheduler_msgs::msg::TaskScheduleRequest& req)
+  {
+    TaskRequest request;
+    request._name = req.name;
+    request._start_time = req.start_time;
+
+    if (req.has_end_time)request.
+    {
+      request._end_time = {req.end_time};
+    }
+    else
+    {
+      request._end_time = std::nullopt;
+    }
+
+    if (req.has_repeat_interval)
+    {
+      request._repeat_interval = {req.repeat_interval};
+    }
+    else
+    {
+      request._repeat_interval = std::nullopt;
+    }
+
+    request._task_type = req.task_type;
+    request._args = req.args; 
+
+    return request;
+  }
+};
+}
+#endif

--- a/rmf_task_ros2/test/scheduler/test_ScheduleQueue.cpp
+++ b/rmf_task_ros2/test/scheduler/test_ScheduleQueue.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "../../src/rmf_task_ros2/scheduler/internal_ScheduleQueue.hpp"
+#include <rmf_utils/catch.hpp>
+
+using namespace rmf_task_ros2;
+
+//==============================================================================
+rclcpp::Duration operator*(const int num, const rclcpp::Duration dur)
+{
+  // LAZY HACK!!
+  rclcpp::Duration result(0,0);
+  for(int i = 0; i < num; i++)
+  {
+    result = result + dur;
+  }
+  return result;
+}
+
+//==============================================================================
+SCENARIO("Enqueue one task with fixed time scale that repeats every second")
+{
+  SimpleSchedulerQueue queue;
+
+  auto time_start = rclcpp::Time();
+
+  auto seconds = rclcpp::Duration(1,0);
+  
+  TaskRequest task_request1;
+  task_request1._start_time = time_start + 10*seconds;
+  task_request1._end_time = time_start + 13*seconds;
+  task_request1._repeat_interval = seconds;
+
+  auto id = queue.enqueue_request(task_request1);
+
+  WHEN("we step through the first time step")
+  {
+    auto pending = queue.check_and_deque(time_start);
+    THEN("Nothing should be returned")
+    {
+      REQUIRE(pending.size() == 0);
+    }
+  }
+
+  WHEN("we step through to T+11")
+  {
+    auto pending = queue.check_and_deque(time_start+11*seconds);
+    THEN("There should be one pending task")
+    {
+      REQUIRE(pending.size() == 1);
+      REQUIRE(queue.get_queued().size() == 1);
+    }
+  }
+
+  WHEN("we step through to T+12")
+  {
+    auto pending = queue.check_and_deque(time_start+12*seconds);
+    THEN("There should be two pending tasks")
+    {
+      REQUIRE(queue.get_queued().size() == 1);
+      REQUIRE(pending.size() == 2);
+    }
+  }
+
+  WHEN("we step through to T+15")
+  {
+    auto pending = queue.check_and_deque(time_start+15*seconds);
+    THEN("There should be 3 pending tasks and no tasks queued")
+    {
+      REQUIRE(queue.get_queued().size() == 0);
+      REQUIRE(pending.size() == 3);
+    }
+  }
+
+  WHEN("we step through T+11 and T+12")
+  {
+    auto pending1 = queue.check_and_deque(time_start+11*seconds);
+    auto pending2 = queue.check_and_deque(time_start+12*seconds);
+    THEN("There should be one pending task")
+    {
+      REQUIRE(pending1.size() == 1);
+      REQUIRE(pending2.size() == 1);
+    }
+  }
+
+  WHEN("We cancel before dequeing")
+  {
+    queue.cancel_request(id);
+    THEN("State should immediately be updated")
+    {
+      REQUIRE(queue.get_queued().size() == 0);
+    }
+    auto pending1 = queue.check_and_deque(time_start+11*seconds);
+    THEN("There should be no pending tasks")
+    {
+      REQUIRE(pending1.size() == 0);
+      REQUIRE(queue.get_queued().size() == 0);
+    }
+  }
+
+  WHEN("we cancel after T+11")
+  {
+    auto pending1 = queue.check_and_deque(time_start+11*seconds);
+    queue.cancel_request(id);
+    auto pending2 = queue.check_and_deque(time_start+12*seconds);
+    THEN("There should be one pending task")
+    {
+      REQUIRE(pending1.size() == 1);
+      REQUIRE(pending2.size() == 0);
+    }
+  }
+}
+
+//==============================================================================
+SCENARIO(
+  "Enqueue one task with fixed time scale that repeats every second and never ends")
+{
+  SimpleSchedulerQueue queue;
+
+  auto time_start = rclcpp::Time();
+
+  auto seconds = rclcpp::Duration(1,0);
+  
+  TaskRequest task_request1;
+  task_request1._start_time = time_start + 10*seconds;
+  task_request1._repeat_interval = seconds;
+
+  auto id = queue.enqueue_request(task_request1);
+
+  WHEN("we step through the first time step")
+  {
+    auto pending = queue.check_and_deque(time_start);
+    THEN("Nothing should be returned")
+    {
+      REQUIRE(pending.size() == 0);
+    }
+  }
+
+  WHEN("we step through to T+11")
+  {
+    auto pending = queue.check_and_deque(time_start+11*seconds);
+    THEN("There should be one pending task")
+    {
+      REQUIRE(pending.size() == 1);
+      REQUIRE(queue.get_queued().size() == 1);
+    }
+  }
+
+  WHEN("we step through to T+12")
+  {
+    auto pending = queue.check_and_deque(time_start+12*seconds);
+    THEN("There should be two pending tasks")
+    {
+      REQUIRE(queue.get_queued().size() == 1);
+      REQUIRE(pending.size() == 2);
+    }
+  }
+
+  WHEN("we step through to T+15")
+  {
+    auto pending = queue.check_and_deque(time_start+15*seconds);
+    THEN("There should be 3 pending tasks and no tasks queued")
+    {
+      REQUIRE(queue.get_queued().size() == 1);
+      REQUIRE(pending.size() == 5);
+    }
+  }
+
+  WHEN("we step through T+11 and T+12")
+  {
+    auto pending1 = queue.check_and_deque(time_start+11*seconds);
+    auto pending2 = queue.check_and_deque(time_start+12*seconds);
+    THEN("There should be one pending task")
+    {
+      REQUIRE(pending1.size() == 1);
+      REQUIRE(pending2.size() == 1);
+    }
+  }
+
+  WHEN("We cancel before dequeing")
+  {
+    queue.cancel_request(id);
+    THEN("State should immediately be updated")
+    {
+      REQUIRE(queue.get_queued().size() == 0);
+    }
+    auto pending1 = queue.check_and_deque(time_start+11*seconds);
+    THEN("There should be no pending tasks")
+    {
+      REQUIRE(pending1.size() == 0);
+      REQUIRE(queue.get_queued().size() == 0);
+    }
+  }
+}
+
+//==============================================================================
+SCENARIO(
+  "Enqueue one task with fixed time scale that does not repeat")
+{
+  SimpleSchedulerQueue queue;
+
+  auto time_start = rclcpp::Time();
+
+  auto seconds = rclcpp::Duration(1,0);
+  
+  TaskRequest task_request1;
+  task_request1._start_time = time_start + 10*seconds;
+  task_request1._repeat_interval = std::nullopt;
+
+  auto id = queue.enqueue_request(task_request1);
+
+  WHEN("we step through the first time step")
+  {
+    auto pending = queue.check_and_deque(time_start);
+    THEN("Nothing should be returned")
+    {
+      REQUIRE(pending.size() == 0);
+    }
+  }
+
+  WHEN("we step through to T+11")
+  {
+    auto pending = queue.check_and_deque(time_start+11*seconds);
+    THEN("There should be one pending task")
+    {
+      REQUIRE(pending.size() == 1);
+      REQUIRE(queue.get_queued().size() == 1);
+    }
+  }
+
+  WHEN("we step through to T+12")
+  {
+    auto pending = queue.check_and_deque(time_start+12*seconds);
+    THEN("There should be two pending tasks")
+    {
+      REQUIRE(queue.get_queued().size() == 1);
+      REQUIRE(pending.size() == 1);
+    }
+  }
+
+  WHEN("we step through to T+15")
+  {
+    auto pending = queue.check_and_deque(time_start+15*seconds);
+    THEN("There should be 3 pending tasks and no tasks queued")
+    {
+      REQUIRE(queue.get_queued().size() == 1);
+      REQUIRE(pending.size() == 1);
+    }
+  }
+
+  WHEN("we step through T+11 and T+12")
+  {
+    auto pending1 = queue.check_and_deque(time_start+11*seconds);
+    auto pending2 = queue.check_and_deque(time_start+12*seconds);
+    THEN("There should be one pending task")
+    {
+      REQUIRE(pending1.size() == 1);
+      REQUIRE(pending2.size() == 0);
+    }
+  }
+
+  WHEN("We cancel before dequeing")
+  {
+    queue.cancel_request(id);
+    THEN("State should immediately be updated")
+    {
+      REQUIRE(queue.get_queued().size() == 0);
+    }
+    auto pending1 = queue.check_and_deque(time_start+11*seconds);
+    THEN("There should be no pending tasks")
+    {
+      REQUIRE(pending1.size() == 0);
+      REQUIRE(queue.get_queued().size() == 0);
+    }
+  }
+}
+
+//==============================================================================
+SCENARIO("Empty Queue")
+{
+  SimpleSchedulerQueue queue;
+  WHEN("getting queued elements")
+  {
+    THEN("returned queue is empty")
+    {
+      auto state = queue.get_queued();
+
+      REQUIRE(state.size() == 0);
+    }
+  }
+
+  WHEN("Checking and dequeueing")
+  {
+    THEN("return empty list")
+    {
+      auto time_start = rclcpp::Time();
+      auto queued = queue.check_and_deque(time_start);
+
+      REQUIRE(queued.size() == 0);
+    }
+  }
+}


### PR DESCRIPTION
## New feature implementation

As per #103 we need a way to schedule recurring tasks at a later date for submission to the dispatcher node.

### Implemented feature

This PR depends on the pr open-rmf/rmf_api_msgs#1 .
TODO: Write description

### Implementation description

TODO: Write docs,
