### PR TITLE
Add speed limit publishing to full control fleet adapter

### DIFF
--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -214,7 +214,7 @@ public:
       location.yaw = p.z();
 
       // The speed limit is set as the minimum of all the approach lanes' limits
-      std::optional<double> speed_limit;
+      std::optional<double> speed_limit = std::nullopt;
       for (const auto& lane_idx : wp.approach_lanes())
       {
         const auto& lane = _travel_info.graph->get_lane(lane_idx);
@@ -227,7 +227,15 @@ public:
             speed_limit = lane_limit.value();
         }
       }
-      location.approach_speed = speed_limit.has_value() ? speed_limit.value() : 0.0;
+      if (speed_limit.has_value())
+      {
+        location.obey_approach_speed_limit = true;
+        location.approach_speed_limit = speed_limit.value();
+      }
+      else
+      {
+        location.obey_approach_speed_limit = false;
+      }
 
       // Note: if the waypoint is not on a graph index, then we'll just leave
       // the level_name blank. That information isn't likely to get used by the

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -227,6 +227,7 @@ public:
             speed_limit = lane_limit.value();
         }
       }
+      location.approach_speed = speed_limit.has_value() ? speed_limit.value() : 0.0;
 
       // Note: if the waypoint is not on a graph index, then we'll just leave
       // the level_name blank. That information isn't likely to get used by the

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -213,6 +213,21 @@ public:
       location.y = p.y();
       location.yaw = p.z();
 
+      // The speed limit is set as the minimum of all the approach lanes' limits
+      std::optional<double> speed_limit;
+      for (const auto& lane_idx : wp.approach_lanes())
+      {
+        const auto& lane = _travel_info.graph->get_lane(lane_idx);
+        const auto& lane_limit = lane.properties().speed_limit();
+        if (lane_limit.has_value())
+        {
+          if (speed_limit.has_value())
+            speed_limit = std::min(speed_limit.value(), lane_limit.value());
+          else
+            speed_limit = lane_limit.value();
+        }
+      }
+
       // Note: if the waypoint is not on a graph index, then we'll just leave
       // the level_name blank. That information isn't likely to get used by the
       // fleet driver anyway.

--- a/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
+++ b/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
@@ -59,6 +59,8 @@ rmf_fleet_msgs::msg::Location make_location(
   return rmf_fleet_msgs::build<rmf_fleet_msgs::msg::Location>()
     .t(t)
     .x(p[0]).y(p[1]).yaw(p[2])
+    // TODO(anyone) add speed limit support
+    .approach_speed(0.0)
     .level_name(map_name)
     .index(index);
 }

--- a/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
+++ b/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
@@ -54,13 +54,14 @@ rmf_fleet_msgs::msg::Location make_location(
   rclcpp::Time t,
   const Eigen::Vector3d& p,
   const std::string& map_name,
-  const std::size_t index)
+  const std::size_t index,
+  const std::optional<double>& speed_limit)
 {
   return rmf_fleet_msgs::build<rmf_fleet_msgs::msg::Location>()
     .t(t)
     .x(p[0]).y(p[1]).yaw(p[2])
-    // TODO(anyone) add speed limit support
-    .approach_speed(0.0)
+    .obey_approach_speed_limit(speed_limit.has_value())
+    .approach_speed_limit(*speed_limit)
     .level_name(map_name)
     .index(index);
 }
@@ -477,12 +478,14 @@ private:
       };
 
     std::vector<rmf_fleet_adapter::agv::Waypoint> new_path;
+    std::vector<std::optional<double>> speed_limits;
     new_path.reserve(waypoints.size());
 
 
     for (std::size_t i = 0; i < waypoints.size(); ++i)
     {
       const auto& wp = waypoints[i];
+      std::optional<double> speed_limit = std::nullopt;
       if (i > 0)
       {
         const auto last_x = new_path.back().position().x();
@@ -493,10 +496,26 @@ private:
 
         if (delta < 0.01)
           continue;
+
+        // Populate speed limits vector based on the minimum speed limit of
+        // the lanes approaching this waypoint
+        for (const auto& lane_idx : wp.approach_lanes())
+        {
+          const auto& lane = _travel_info.graph->get_lane(lane_idx);
+          const auto& lane_limit = lane.properties().speed_limit();
+          if (lane_limit.has_value())
+          {
+            if (speed_limit.has_value())
+              speed_limit = std::min(speed_limit.value(), lane_limit.value());
+            else
+              speed_limit = lane_limit.value();
+          }
+        }
       }
 
       const auto p = wp.position();
       const auto map_name = get_map_name(wp.graph_index());
+      speed_limits.push_back(speed_limit);
       new_path.emplace_back(map_name, p);
     }
 
@@ -507,7 +526,7 @@ private:
     {
       const auto& wp = new_path[i];
       _current_path_request.path.push_back(
-        make_location(now, wp.position(), wp.map_name(), i));
+        make_location(now, wp.position(), wp.map_name(), i, speed_limits[i]));
     }
 
     RCLCPP_INFO(

--- a/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
+++ b/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
@@ -57,11 +57,13 @@ rmf_fleet_msgs::msg::Location make_location(
   const std::size_t index,
   const std::optional<double>& speed_limit)
 {
+  const double approach_speed_limit = speed_limit.has_value() ?
+    speed_limit.value() : 0.0;
   return rmf_fleet_msgs::build<rmf_fleet_msgs::msg::Location>()
     .t(t)
     .x(p[0]).y(p[1]).yaw(p[2])
     .obey_approach_speed_limit(speed_limit.has_value())
-    .approach_speed_limit(*speed_limit)
+    .approach_speed_limit(approach_speed_limit)
     .level_name(map_name)
     .index(index);
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -818,7 +818,8 @@ rmf_fleet_msgs::msg::RobotState convert_state(const TaskManager& mgr)
         .x(p.x())
         .y(p.y())
         .yaw(l.orientation())
-        .approach_speed(0.0)
+        .obey_approach_speed_limit(false)
+        .approach_speed_limit(0.0)
         .level_name(wp.get_map_name())
         // NOTE(MXG): This field is only used by the fleet drivers. For now, we
         // will just fill it with a zero.

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -818,6 +818,7 @@ rmf_fleet_msgs::msg::RobotState convert_state(const TaskManager& mgr)
         .x(p.x())
         .y(p.y())
         .yaw(l.orientation())
+        .approach_speed(0.0)
         .level_name(wp.get_map_name())
         // NOTE(MXG): This field is only used by the fleet drivers. For now, we
         // will just fill it with a zero.

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
@@ -1693,6 +1693,7 @@ TrafficLight::UpdateHandle::Implementation::Data::publish_fleet_state() const
     .x(p.x())
     .y(p.y())
     .yaw(p[2])
+    .approach_speed(0.0)
     .level_name(map)
     .index(0);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
@@ -1693,7 +1693,8 @@ TrafficLight::UpdateHandle::Implementation::Data::publish_fleet_state() const
     .x(p.x())
     .y(p.y())
     .yaw(p[2])
-    .approach_speed(0.0)
+    .obey_approach_speed_limit(false)
+    .approach_speed_limit(0.0)
     .level_name(map)
     .index(0);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/parse_graph.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/parse_graph.cpp
@@ -294,7 +294,8 @@ rmf_traffic::agv::Graph parse_graph(
       if (const YAML::Node speed_limit_option = options["speed_limit"])
       {
         const double speed_limit = speed_limit_option.as<double>();
-        graph_lane.properties().speed_limit(speed_limit);
+        if (speed_limit > 0.0)
+          graph_lane.properties().speed_limit(speed_limit);
       }
     }
     vnum += vnum_temp;


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Requires https://github.com/open-rmf/rmf_internal_msgs/pull/28 Add publishing of lane level speed limit to full_control adapter.

### Implementation description

This PR parses the graph and publishes the speed_limit if one was found when reading the navgraph so the downstream simulated robots can respect it.