### PR TITLE
changed message type for /robot_gps_path_requests to GeoPathRequest

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -26,6 +26,7 @@ const std::string FleetStateTopicName = "/fleet_states";
 const std::string DestinationRequestTopicName = "destination_requests";
 const std::string ModeRequestTopicName = "robot_mode_requests";
 const std::string PathRequestTopicName = "robot_path_requests";
+const std::string GeoPathRequestTopicName = "robot_gps_path_requests";
 const std::string PauseRequestTopicName = "robot_pause_requests";
 
 const std::string FinalDoorRequestTopicName = "door_requests";


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Working off #126, changed message type for published topic to GeoPathRequest

Works with the following pull requests:
- rmf_proj library: open-rmf/rmf_coordinate_transformations#1
- main implementation in slotcar: open-rmf/rmf_simulation#58
- added GeoPathRequest msg: open-rmf/rmf_internal_msgs#29
- added sdf tags in demos: open-rmf/rmf_demos#102