### PR TITLE
check lift watchdog server and simple logging

### DIFF
--- a/rmf_fleet_adapter/src/experimental_lift_watchdog/main.cpp
+++ b/rmf_fleet_adapter/src/experimental_lift_watchdog/main.cpp
@@ -80,6 +80,9 @@ public:
   void permission_callback(
     const std::shared_ptr<std_msgs::msg::Bool>& msg)
   {
+    RCLCPP_INFO(
+      get_logger(),
+      "Set Lift watchdog permission to [%s]", msg->data ? "true" : "false");
     permission = msg->data;
   }
 


### PR DESCRIPTION
Few liners implementation in the fleet adapter node. Client will check if the `lift_watchdog` server is avail before sending the `LiftClearance` Request.

Added some "not so important" log printout, which can helpful, at least for me when debug https://github.com/open-rmf/rmf_demos/pull/105. Apparently, it was just a misalignment of the srv name :man_facepalming: 