### PR TITLE
Use ament_cmake_uncrustify

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -42,12 +42,12 @@ foreach(pkg ${dep_pkgs})
 endforeach()
 
 if(BUILD_TESTING)
-  find_package(rmf_cmake_uncrustify REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  rmf_uncrustify(
+  ament_uncrustify(
     include src test rmf_rxcpp/include rmf_rxcpp/src rmf_rxcpp/test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -32,7 +32,7 @@
   <build_depend>yaml-cpp</build_depend>
 
   <test_depend>ament_cmake_catch2</test_depend>
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_fleet_adapter/rmf_rxcpp/CMakeLists.txt
+++ b/rmf_fleet_adapter/rmf_rxcpp/CMakeLists.txt
@@ -28,8 +28,8 @@ if(BUILD_TESTING)
   find_package(ament_cmake_catch2 REQUIRED)
   find_package(rmf_utils REQUIRED)
   find_package(std_msgs REQUIRED)
-  find_package(rmf_cmake_uncrustify REQUIRED)
-  find_file(uncrustify_config_file NAMES 
+  find_package(ament_cmake_uncrustify REQUIRED)
+  find_file(uncrustify_config_file NAMES
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 

--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -47,12 +47,12 @@ ament_export_dependencies(rmf_traffic rmf_task_msgs rclcpp)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_catch2 QUIET)
-  find_package(rmf_cmake_uncrustify REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  rmf_uncrustify(
+  ament_uncrustify(
     ARGN include src test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80

--- a/rmf_task_ros2/package.xml
+++ b/rmf_task_ros2/package.xml
@@ -19,7 +19,7 @@
   <build_depend>eigen</build_depend>
 
   <test_depend>ament_cmake_catch2</test_depend>
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -29,12 +29,12 @@ endif()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_catch2 QUIET)
-  find_package(rmf_cmake_uncrustify REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  rmf_uncrustify(
+  ament_uncrustify(
     ARGN include src examples
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -20,7 +20,7 @@
   <build_depend>eigen</build_depend>
 
   <test_depend>ament_cmake_catch2</test_depend>
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
We currently have the rmf_cmake_uncrustify package that is used for style checking with colcon test. The original reason for having this package and not using ament_cmake_uncrustify was that the latter did not support custom uncrustify configuration files. But this feature was [merged upstream](https://github.com/ament/ament_lint/pull/200) quite a while ago and has been part of `foxy` and `galactic` releases. Hence, switching back to `ament_cmake_uncrustify` for ease of maintenance and distribution.