### PR TITLE
Safely capture the SearchForPath object

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
@@ -1012,7 +1012,7 @@ bool TrafficLight::UpdateHandle::Implementation::Data::valid_plan(
 //==============================================================================
 void TrafficLight::UpdateHandle::Implementation::Data::update_location(
   const std::size_t path_version,
-  const std::size_t plan_version,
+  const std::size_t,
   const std::vector<rmf_traffic::agv::Plan::Waypoint>& waypoints,
   const Eigen::Vector3d location,
   const std::size_t checkpoint_index)


### PR DESCRIPTION
There was a lingering `[this]` capture hiding in the source code. This PR fixes it by capturing a `weak_ptr` of the object and locking+checking it before usage.

This bug may explain https://github.com/open-rmf/rmf_ros2/issues/137