### PR TITLE
increase publish fleet state frequency to 10hz

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -783,7 +783,7 @@ void FleetUpdateHandle::Implementation::fleet_state_publish_period(
   if (value.has_value())
   {
     fleet_state_timer = node->create_wall_timer(
-      std::chrono::seconds(1), [this]() { this->publish_fleet_state(); });
+      std::chrono::milliseconds(100), [this]() { this->publish_fleet_state(); });
   }
   else
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -776,21 +776,6 @@ get_nearest_charger(
   return nearest_charger;
 }
 
-//==============================================================================
-void FleetUpdateHandle::Implementation::fleet_state_publish_period(
-  std::optional<rmf_traffic::Duration> value)
-{
-  if (value.has_value())
-  {
-    fleet_state_timer = node->create_wall_timer(
-      std::chrono::milliseconds(100), [this]() { this->publish_fleet_state(); });
-  }
-  else
-  {
-    fleet_state_timer = nullptr;
-  }
-}
-
 namespace {
 //==============================================================================
 rmf_fleet_msgs::msg::RobotState convert_state(const TaskManager& mgr)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -208,7 +208,7 @@ public:
     handle->_pimpl->fleet_state_pub = handle->_pimpl->node->fleet_state();
     handle->_pimpl->fleet_state_timer =
       handle->_pimpl->node->try_create_wall_timer(
-      std::chrono::seconds(1), [me = handle->weak_from_this()]()
+      std::chrono::milliseconds(100), [me = handle->weak_from_this()]()
       {
         if (const auto self = me.lock())
           self->_pimpl->publish_fleet_state();


### PR DESCRIPTION
### Implemented feature

This PR updates the wall timer inside `fleet_state_publish_period` to 0.1 seconds to increase fleet state publish frequency for smoother visualization. 
This is to support the new demo fleet adapter PR open-rmf/rmf_demos#109.