### PR TITLE
Remove unused fleet_state_publish_period fn

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -776,20 +776,6 @@ get_nearest_charger(
   return nearest_charger;
 }
 
-//==============================================================================
-void FleetUpdateHandle::Implementation::fleet_state_publish_period(
-  std::optional<rmf_traffic::Duration> value)
-{
-  if (value.has_value())
-  {
-    fleet_state_timer = node->create_wall_timer(
-      std::chrono::seconds(1), [this]() { this->publish_fleet_state(); });
-  }
-  else
-  {
-    fleet_state_timer = nullptr;
-  }
-}
 
 namespace {
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -302,9 +302,6 @@ public:
     return *fleet._pimpl;
   }
 
-  void fleet_state_publish_period(
-    std::optional<rmf_traffic::Duration> value);
-
   void publish_fleet_state() const;
 };
 


### PR DESCRIPTION
When reviewing https://github.com/open-rmf/rmf_ros2/pull/147 pr, noticed a duplicated and unused `fleet_state_publish_period()` function within the internal implementation of `FleetUpdateHandle`. Merely removing it since it is unused.