### PR TITLE
Support PerformAction event in composed tasks

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -189,7 +189,16 @@ public:
   /// category which may be present in sequence event.
   ///
   /// \param[in] category
-  FleetUpdateHandle& add_performable_action(const std::string& category);
+  ///   A string that categorizes the action. This value should be used when
+  ///   filling out the category field in event_description_PerformAction.json
+  ///   schema.
+  ///
+  /// \param[in] consider
+  ///   Decide whether to accept the action based on the description field in
+  ///   event_description_PerformAction.json schema.
+  FleetUpdateHandle& add_performable_action(
+    const std::string& category,
+    ConsiderRequest consider);
 
   /// Specify a set of lanes that should be closed.
   void close_lanes(std::vector<std::size_t> lane_indices);

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -185,6 +185,12 @@ public:
   ///   robots before triggering this callback.
   FleetUpdateHandle& consider_composed_requests(ConsiderRequest consider);
 
+  /// Allow this fleet adapter to execute a PerformAction activity of specified
+  /// category which may be present in sequence event.
+  ///
+  /// \param[in] category
+  FleetUpdateHandle& add_performable_action(const std::string& category);
+
   /// Specify a set of lanes that should be closed.
   void close_lanes(std::vector<std::size_t> lane_indices);
 

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -128,6 +128,7 @@ public:
     // TODO: Consider giving access to the participant schedule and
     // traffic negotiation
 
+    // The desctructor will trigger finished() if it has not already been called
     ~ActionExecution();
 
     class Implementation;

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -128,11 +128,7 @@ public:
     // TODO: Consider giving access to the participant schedule and
     // traffic negotiation
 
-    ~ActionExecution()
-    {
-      // Automatically trigger finished when this object dies
-      finished();
-    }
+    ~ActionExecution();
 
     class Implementation;
   private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -122,12 +122,8 @@ public:
     // Trigger this when the action is finished
     void finished();
 
-    // Allow the action performer to report directly to the schedule.
-    // This returns nullptr after `finished()` has been triggered.
-    rmf_traffic::schedule::Participant* schedule();
-    const rmf_traffic::schedule::Participant* schedule() const;
-
-    // TODO: Consider giving access to the traffic negotiation
+    // TODO: Consider giving access to the participant schedule and
+    // traffic negotiation
 
     ~ActionExecution()
     {
@@ -138,10 +134,8 @@ public:
     class Implementation;
   private:
     ActionExecution();
-    rmf_utils::unique_impl_ptr<Implementation> _pimpl;
+    rmf_utils::impl_ptr<Implementation> _pimpl;
   };
-
-  using ActionExecutionPtr = std::shared_ptr<ActionExecution>;
 
   /// Signature for a callback to request the robot to perform an action
   ///
@@ -151,13 +145,13 @@ public:
   /// \param[in] description
   ///   A description of the action to be performed
   ///
-  /// \param[in] completed
+  /// \param[in] execution
   ///   An ActionExecution object that will be provided to the user for
-  ///   managing the state of the action.
+  ///   updating the state of the action.
   using ActionExecutor = std::function<void(
     const std::string& category,
     const nlohmann::json& description,
-    ActionExecutionPtr execution)>;
+    ActionExecution execution)>;
 
   /// Set the ActionExecutor for this robot
   void set_action_executor(ActionExecutor action_executor);

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -110,6 +110,11 @@ public:
   /// value that was given to the setter.
   rmf_utils::optional<rmf_traffic::Duration> maximum_delay() const;
 
+  /// Update the estimate of the time remaining for the action that the robot
+  /// may be performing
+  void update_action_remaining_time(
+  const rmf_traffic::Duration remaining_time_estimate);
+
   class Implementation;
 
   /// This API is experimental and will not be supported in the future. Users

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -122,6 +122,9 @@ public:
     // Trigger this when the action is finished
     void finished();
 
+    // Returns false if the Action has been killed or cancelled
+    bool okay() const;
+
     // TODO: Consider giving access to the participant schedule and
     // traffic negotiation
 

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -117,7 +117,10 @@ public:
 
   /// Signature for a callback to request the robot to perform an action
   ///
-  /// \param[in] action
+  /// \param[in] category
+  ///   A category of the action to be performed
+  ///
+  /// \param[in] description
   ///   A description of the action to be performed
   ///
   /// \param[in] completed
@@ -125,8 +128,9 @@ public:
   ///   robot has completed the action
   using ActionExecutor =
     std::function<void(
-      const nlohmann::json& action,
-      const ActionCompleted& completed)
+      const std::string& category,
+      const nlohmann::json& description,
+      ActionCompleted completed)
     >;
 
   /// Set the ActionExecutor for this robot

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -25,6 +25,7 @@
 #include <rmf_traffic/schedule/Participant.hpp>
 
 #include <Eigen/Geometry>
+#include <nlohmann/json.hpp>
 
 #include <vector>
 #include <memory>
@@ -109,6 +110,27 @@ public:
   /// it may take some time for the return value of this getter to match the
   /// value that was given to the setter.
   rmf_utils::optional<rmf_traffic::Duration> maximum_delay() const;
+
+  /// Signature for a callback to be executed to let the fleet adapter know that
+  /// the robot has completed the requested action
+  using ActionCompleted = std::function<void()>;
+
+  /// Signature for a callback to request the robot to perform an action
+  ///
+  /// \param[in] action
+  ///   A description of the action to be performed
+  ///
+  /// \param[in] completed
+  ///   An ActionCompleted callback that should be called by the user when the
+  ///   robot has completed the action
+  using ActionExecutor =
+    std::function<void(
+      const nlohmann::json& action,
+      const ActionCompleted& completed)
+    >;
+
+  /// Set the ActionExecutor for this robot
+  void set_action_executor(ActionExecutor action_executor);
 
   /// Update the estimate of the time remaining for the action that the robot
   /// may be performing

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -139,7 +139,7 @@ public:
   /// Update the estimate of the time remaining for the action that the robot
   /// may be performing
   void update_action_remaining_time(
-  const rmf_traffic::Duration remaining_time_estimate);
+    const rmf_traffic::Duration remaining_time_estimate);
 
   class Implementation;
 

--- a/rmf_fleet_adapter/schemas/event_description_PerformAction.json
+++ b/rmf_fleet_adapter/schemas/event_description_PerformAction.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/open-rmf/rmf_ros2/main/rmf_fleet_adapter/schemas/event_description_PerformAction.json",
   "title": "PerformAction event Description",
-  "description": "Have the robot perform a custom action",
+  "description": "Description schema for the perform_action category",
   "type": "object",
   "properties": {
     "category": {
@@ -14,7 +14,7 @@
       "type": "object"
     },
     "unix_millis_action_duration_estimate": {
-      "description": "(Optional) The estimated duration for this action",
+      "description": "(Recommended) The estimated duration for this action",
       "type": "integer"
     },
     "use_tool_sink": {

--- a/rmf_fleet_adapter/schemas/event_description_PerformAction.json
+++ b/rmf_fleet_adapter/schemas/event_description_PerformAction.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_ros2/main/rmf_fleet_adapter/schemas/event_description_PerformAction.json",
+  "title": "PerformAction event Description",
+  "description": "Have the robot perform a custom action",
+  "type": "object",
+  "properties": {
+    "action": {
+      "description": "A string that can be deserialized into a JSON description of the action",
+      "type": "string"
+    },
+    "unix_millis_action_duration_estimate": {
+      "description": "(Optional) The estimated duration for this action",
+      "type": "integer"
+    },
+    "use_tool_sink": {
+      "description": "(Optional) Whether the tool on the robot will be powered during the action. Default to false",
+      "type": "boolean"
+    },
+    "expected_finish_location": {
+      "description": "(Optional) A place that the robot will end up after the action. Default to last known location",
+      "$ref": "Place.json"
+    }
+  },
+  "required": ["action"]
+}

--- a/rmf_fleet_adapter/schemas/event_description_PerformAction.json
+++ b/rmf_fleet_adapter/schemas/event_description_PerformAction.json
@@ -5,9 +5,13 @@
   "description": "Have the robot perform a custom action",
   "type": "object",
   "properties": {
-    "action": {
-      "description": "A string that can be deserialized into a JSON description of the action",
+    "category": {
+      "description": "A string that describes the nature of this action. It should match that passed into FleetUpdateHandle::add_performable_action()",
       "type": "string"
+    },
+    "description": {
+      "description": "A dictionary describing the action to be performed.",
+      "type": "object"
     },
     "unix_millis_action_duration_estimate": {
       "description": "(Optional) The estimated duration for this action",
@@ -22,5 +26,5 @@
       "$ref": "Place.json"
     }
   },
-  "required": ["action"]
+  "required": ["category", "description"]
 }

--- a/rmf_fleet_adapter/schemas/event_description_PerformAction.json
+++ b/rmf_fleet_adapter/schemas/event_description_PerformAction.json
@@ -10,8 +10,7 @@
       "type": "string"
     },
     "description": {
-      "description": "A dictionary describing the action to be performed.",
-      "type": "object"
+      "description": "Additional information that will be passed along to the action executor."
     },
     "unix_millis_action_duration_estimate": {
       "description": "(Recommended) The estimated duration for this action",

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -164,7 +164,7 @@ public:
     rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr;
 
   using ActionExecution =
-    rmf_fleet_adapter::agv::RobotUpdateHandle::ActionExecutionPtr;
+    rmf_fleet_adapter::agv::RobotUpdateHandle::ActionExecution;
 
   FleetDriverRobotCommandHandle(
     rclcpp::Node& node,
@@ -595,11 +595,11 @@ void set_action_execution(ActionExecution action_execution)
 
 void complete_robot_action()
 {
-  if (_action_execution == nullptr)
+  if (!_action_execution.has_value())
     return;
 
   _action_execution->finished();
-  _action_execution = nullptr;
+  _action_execution = std::nullopt;
 
   RCLCPP_INFO(
   _node->get_logger(),
@@ -631,7 +631,7 @@ private:
   std::mutex _mutex;
 
   // ActionExecution for managing teleop action
-  ActionExecution _action_execution = nullptr;
+  std::optional<ActionExecution> _action_execution = std::nullopt;
 
   std::unique_lock<std::mutex> _lock()
   {

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -1141,7 +1141,7 @@ std::shared_ptr<Connections> make_fleet(
     });
 
   const auto consider =
-    [](const nlohmann::json& description,
+    [](const nlohmann::json& /*description*/,
       rmf_fleet_adapter::agv::FleetUpdateHandle::Confirmation& confirm)
     {
       // We accept all actions since full_control may be used for different

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -58,6 +58,8 @@
 #include <rmf_battery/agv/SimpleDevicePowerSink.hpp>
 
 #include <Eigen/Geometry>
+#include <nlohmann/json.hpp>
+
 #include <unordered_set>
 #include <optional>
 
@@ -150,7 +152,8 @@ std::optional<DistanceFromGraph> distance_from_graph(
 
 //==============================================================================
 class FleetDriverRobotCommandHandle
-  : public rmf_fleet_adapter::agv::RobotCommandHandle
+  : public rmf_fleet_adapter::agv::RobotCommandHandle,
+    public std::enable_shared_from_this<FleetDriverRobotCommandHandle>
 {
 public:
 
@@ -159,6 +162,9 @@ public:
 
   using ModeRequestPub =
     rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr;
+
+  using ActionCompleted =
+    rmf_fleet_adapter::agv::RobotUpdateHandle::ActionCompleted;
 
   FleetDriverRobotCommandHandle(
     rclcpp::Node& node,
@@ -481,6 +487,21 @@ public:
   void set_updater(rmf_fleet_adapter::agv::RobotUpdateHandlePtr updater)
   {
     _travel_info.updater = std::move(updater);
+    // Set the action_executor for the robot
+    const auto teleop_executioner =
+      [w = weak_from_this()](const std::string& category,
+        const nlohmann::json& description,
+        ActionCompleted completed)
+      {
+        // We do not do anything here. The user can can move the robot by
+        // sending PathRequest msgs. Instead we simply store the completed
+        // callback which will be called when we receive a RobotModeRequest.
+        const auto self = w.lock();
+        if (!self)
+          return;
+        self->set_action_completed(completed);
+      };
+    _travel_info.updater->set_action_executor(teleop_executioner);
   }
 
   void newly_closed_lanes(const std::unordered_set<std::size_t>& closed_lanes)
@@ -567,6 +588,25 @@ public:
       _travel_info.updater->interrupted();
   }
 
+void set_action_completed(ActionCompleted action_completed)
+{
+  _action_completed = action_completed;
+}
+
+void complete_robot_action()
+{
+  if (_action_completed == nullptr)
+    return;
+
+  _action_completed();
+  _action_completed == nullptr;
+
+  RCLCPP_INFO(
+  _node->get_logger(),
+  "Robot [%s] has completed the action it was performing",
+  _travel_info.robot_name.c_str());
+}
+
 private:
 
   rclcpp::Node* _node;
@@ -589,6 +629,9 @@ private:
   uint32_t _current_task_id = 0;
 
   std::mutex _mutex;
+
+  // Callback for ending PerformAction events
+  ActionCompleted _action_completed = nullptr;
 
   std::unique_lock<std::mutex> _lock()
   {
@@ -639,6 +682,10 @@ struct Connections : public std::enable_shared_from_this<Connections>
   /// The publisher for sending out mode requests
   rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr
     mode_request_pub;
+
+  /// The topic subscription for ending teleop actions
+  rclcpp::Subscription<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr
+    mode_request_sub;
 
   /// The client for listening to whether there is clearance in a lift
   rclcpp::Client<rmf_fleet_msgs::srv::LiftClearance>::SharedPtr
@@ -907,6 +954,34 @@ std::shared_ptr<Connections> make_fleet(
       connections->closed_lanes_pub->publish(state_msg);
     });
 
+    connections->mode_request_sub =
+      adapter->node()->create_subscription<rmf_fleet_msgs::msg::ModeRequest>(
+      "/action_completed_notice",
+      rclcpp::SystemDefaultsQoS(),
+      [w = connections->weak_from_this(), fleet_name](
+      rmf_fleet_msgs::msg::ModeRequest::UniquePtr msg)
+      {
+        if (msg->fleet_name.empty() ||
+          msg->fleet_name != fleet_name ||
+          msg->robot_name.empty())
+        {
+          return;
+        }
+
+        if (msg->mode.mode == msg->mode.MODE_IDLE)
+        {
+          const auto self = w.lock();
+          if (!self)
+            return;
+
+          const auto command_it = self->robots.find(msg->robot_name);
+          if (command_it == self->robots.end())
+            return;
+
+          command_it->second->complete_robot_action();
+        }
+      });
+
   // Parameters required for task planner
   // Battery system
   auto battery_system_optional = rmf_fleet_adapter::get_battery_system(
@@ -1064,6 +1139,20 @@ std::shared_ptr<Connections> make_fleet(
 
       return false;
     });
+
+  const auto consider =
+    [](const nlohmann::json& description,
+      rmf_fleet_adapter::agv::FleetUpdateHandle::Confirmation& confirm)
+    {
+      // We accept all actions since full_control may be used for different
+      // types of robots.
+      confirm.accept();
+    };
+
+  // Configure this fleet to perform any kind of teleop action
+  connections->fleet->add_performable_action(
+    "teleop",
+    consider);
 
   if (node->declare_parameter<bool>("disable_delay_threshold", false))
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -424,7 +424,6 @@ void TaskManager::ActiveTask::publish_task_state(TaskManager& mgr)
 
   const auto& booking = *_task->tag()->booking();
   copy_booking_data(_state_msg["booking"], booking);
-
   const auto& header = _task->tag()->header();
   _state_msg["category"] = header.category();
   _state_msg["detail"] = header.detail();
@@ -436,7 +435,6 @@ void TaskManager::ActiveTask::publish_task_state(TaskManager& mgr)
   copy_assignment(_state_msg["assigned_to"], *mgr._context);
   _state_msg["status"] =
     status_to_string(_task->status_overview());
-
   auto& phases = _state_msg["phases"];
 
   nlohmann::json task_logs;
@@ -450,7 +448,6 @@ void TaskManager::ActiveTask::publish_task_state(TaskManager& mgr)
     const auto& snapshot = completed->snapshot();
     auto& phase = copy_phase_data(
       phases, *snapshot, mgr._log_reader, phase_logs);
-
     phase["unix_millis_start_time"] =
       completed->start_time().time_since_epoch().count();
 
@@ -462,8 +459,9 @@ void TaskManager::ActiveTask::publish_task_state(TaskManager& mgr)
   _state_msg["completed"] = std::move(completed_ids);
 
   const auto active_phase = _task->active_phase();
+  if (active_phase == nullptr)
+    return;
   copy_phase_data(phases, *active_phase, mgr._log_reader, phase_logs);
-
   _state_msg["active"] = active_phase->tag()->id();
 
   std::vector<uint64_t> pending_ids;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1064,7 +1064,8 @@ FleetUpdateHandle& FleetUpdateHandle::add_performable_action(
       }
     };
 
-  _pimpl->deserialization.event->add(category, validator, deserializer);
+  _pimpl->deserialization.event->add(
+    "perform_action", validator, deserializer);
 
   return *this;
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -918,9 +918,9 @@ PlaceDeserializer make_place_deserializer(
 
       if (msg.is_object())
       {
-        const auto& ori_json = msg["orientation"];
-        if (ori_json)
-          place->orientation(ori_json.get<double>());
+        const auto& ori_it = msg.find("orientation");
+        if (ori_it != msg.end())
+          place->orientation(ori_it->get<double>());
       }
 
       return {place, {}};

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -283,8 +283,8 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
 
   std::vector<std::string> errors;
 
-  rmf_traffic::Time earliest_start_time =
-    rmf_traffic::Time(rmf_traffic::Duration::min());
+  rmf_traffic::Time earliest_start_time = rmf_traffic_ros2::convert(
+    node->get_clock()->now());
   const auto t_it = request_msg.find("unix_millis_earliest_start_time");
   if (t_it != request_msg.end())
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -408,6 +408,20 @@ const
 }
 
 //==============================================================================
+void RobotContext::action_executor(
+  RobotUpdateHandle::ActionExecutor action_executor)
+{
+  if (action_executor != nullptr)
+    _action_executor = action_executor;
+}
+
+//==============================================================================
+RobotUpdateHandle::ActionExecutor RobotContext::action_executor() const
+{
+  return _action_executor;
+}
+
+//==============================================================================
 RobotContext::RobotContext(
   std::shared_ptr<RobotCommandHandle> command_handle,
   std::vector<rmf_traffic::agv::Plan::Start> _initial_location,
@@ -449,6 +463,8 @@ RobotContext::RobotContext(
   _current_mode = rmf_fleet_msgs::msg::RobotMode::MODE_IDLE;
 
   _action_remaining_time = std::nullopt;
+
+  _action_executor = nullptr;
 }
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -394,20 +394,6 @@ uint32_t RobotContext::current_mode() const
 }
 
 //==============================================================================
-void RobotContext::action_remaining_time(
-  const rmf_traffic::Duration remaining_time)
-{
-  _action_remaining_time = remaining_time;
-}
-
-//==============================================================================
-std::optional<rmf_traffic::Duration> RobotContext::action_remaining_time()
-const
-{
-  return _action_remaining_time;
-}
-
-//==============================================================================
 void RobotContext::action_executor(
   RobotUpdateHandle::ActionExecutor action_executor)
 {
@@ -461,8 +447,6 @@ RobotContext::RobotContext(
   _battery_soc_obs = _battery_soc_publisher.get_observable();
 
   _current_mode = rmf_fleet_msgs::msg::RobotMode::MODE_IDLE;
-
-  _action_remaining_time = std::nullopt;
 
   _action_executor = nullptr;
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -394,6 +394,20 @@ uint32_t RobotContext::current_mode() const
 }
 
 //==============================================================================
+void RobotContext::action_remaining_time(
+  const rmf_traffic::Duration remaining_time)
+{
+  _action_remaining_time = remaining_time;
+}
+
+//==============================================================================
+std::optional<rmf_traffic::Duration> RobotContext::action_remaining_time()
+const
+{
+  return _action_remaining_time;
+}
+
+//==============================================================================
 RobotContext::RobotContext(
   std::shared_ptr<RobotCommandHandle> command_handle,
   std::vector<rmf_traffic::agv::Plan::Start> _initial_location,
@@ -433,6 +447,8 @@ RobotContext::RobotContext(
   _battery_soc_obs = _battery_soc_publisher.get_observable();
 
   _current_mode = rmf_fleet_msgs::msg::RobotMode::MODE_IDLE;
+
+  _action_remaining_time = std::nullopt;
 }
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -397,8 +397,16 @@ uint32_t RobotContext::current_mode() const
 void RobotContext::action_executor(
   RobotUpdateHandle::ActionExecutor action_executor)
 {
-  if (action_executor != nullptr)
-    _action_executor = action_executor;
+  if (action_executor == nullptr)
+  {
+    RCLCPP_WARN(
+      _node->get_logger(),
+      "ActionExecutor set to nullptr for robot [%s]. If this robot needs to "
+      "perform an action as part of a task, a critical task error will be "
+      "thrown.",
+      this->name().c_str());
+  }
+  _action_executor = action_executor;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -187,11 +187,21 @@ public:
   /// Return the current mode of the robot
   uint32_t current_mode() const;
 
-  /// Update the estimated time remaining for the action that the robot may be
+  /// Set the estimated time remaining for the action that the robot may be
   /// performing
   void action_remaining_time(const rmf_traffic::Duration time_remaining);
 
+  /// Get the estimated time remaining for the action that the robot may be
+  /// performing
   std::optional<rmf_traffic::Duration> action_remaining_time() const;
+
+  /// Set the action executor for requesting this robot to execute a
+  /// PerformAction activity
+  void action_executor(RobotUpdateHandle::ActionExecutor action_executor);
+
+  /// Get the action executor for requesting this robot to execute a
+  /// PerformAction activity
+  RobotUpdateHandle::ActionExecutor action_executor() const;
 
 private:
   friend class FleetUpdateHandle;
@@ -248,6 +258,7 @@ private:
   // Mode value for RobotMode message
   uint32_t _current_mode;
 
+  RobotUpdateHandle::ActionExecutor _action_executor;
   std::optional<rmf_traffic::Duration> _action_remaining_time;
 };
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -187,6 +187,12 @@ public:
   /// Return the current mode of the robot
   uint32_t current_mode() const;
 
+  /// Update the estimated time remaining for the action that the robot may be
+  /// performing
+  void action_remaining_time(const rmf_traffic::Duration time_remaining);
+
+  std::optional<rmf_traffic::Duration> action_remaining_time() const;
+
 private:
   friend class FleetUpdateHandle;
   friend class RobotUpdateHandle;
@@ -241,6 +247,8 @@ private:
 
   // Mode value for RobotMode message
   uint32_t _current_mode;
+
+  std::optional<rmf_traffic::Duration> _action_remaining_time;
 };
 
 using RobotContextPtr = std::shared_ptr<RobotContext>;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -187,14 +187,6 @@ public:
   /// Return the current mode of the robot
   uint32_t current_mode() const;
 
-  /// Set the estimated time remaining for the action that the robot may be
-  /// performing
-  void action_remaining_time(const rmf_traffic::Duration time_remaining);
-
-  /// Get the estimated time remaining for the action that the robot may be
-  /// performing
-  std::optional<rmf_traffic::Duration> action_remaining_time() const;
-
   /// Set the action executor for requesting this robot to execute a
   /// PerformAction activity
   void action_executor(RobotUpdateHandle::ActionExecutor action_executor);
@@ -259,7 +251,6 @@ private:
   uint32_t _current_mode;
 
   RobotUpdateHandle::ActionExecutor _action_executor;
-  std::optional<rmf_traffic::Duration> _action_remaining_time;
 };
 
 using RobotContextPtr = std::shared_ptr<RobotContext>;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -202,6 +202,20 @@ void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 }
 
 //==============================================================================
+void RobotUpdateHandle::update_action_remaining_time(
+  const rmf_traffic::Duration remaining_time_estimate)
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->worker().schedule(
+      [context, remaining_time_estimate](const auto&)
+      {
+        context->action_remaining_time(remaining_time_estimate);
+      });
+  }
+}
+
+//==============================================================================
 RobotUpdateHandle& RobotUpdateHandle::maximum_delay(
   rmf_utils::optional<rmf_traffic::Duration> value)
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -311,5 +311,13 @@ RobotUpdateHandle::ActionExecution::ActionExecution()
   // Do nothing
 }
 
+//==============================================================================
+RobotUpdateHandle::ActionExecution::~ActionExecution()
+{
+  // Automatically trigger finished when this object dies
+  _pimpl->data->finished();
+}
+
+
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -216,20 +216,6 @@ void RobotUpdateHandle::set_action_executor(
 }
 
 //==============================================================================
-void RobotUpdateHandle::update_action_remaining_time(
-  const rmf_traffic::Duration remaining_time_estimate)
-{
-  if (const auto context = _pimpl->get_context())
-  {
-    context->worker().schedule(
-      [context, remaining_time_estimate](const auto&)
-      {
-        context->action_remaining_time(remaining_time_estimate);
-      });
-  }
-}
-
-//==============================================================================
 RobotUpdateHandle& RobotUpdateHandle::maximum_delay(
   rmf_utils::optional<rmf_traffic::Duration> value)
 {
@@ -298,6 +284,55 @@ void RobotUpdateHandle::Unstable::set_lift_entry_watchdog(
         context->set_lift_entry_watchdog(watchdog, wait_duration);
       });
   }
+}
+
+//==============================================================================
+void RobotUpdateHandle::ActionExecution::update_remaining_time(
+    rmf_traffic::Duration remaining_time_estimate)
+{
+  if (auto context = _pimpl->context.lock())
+  {
+    context->action_remaining_time(remaining_time_estimate);
+  }
+  return;
+}
+
+//==============================================================================
+void RobotUpdateHandle::ActionExecution::finished()
+{
+  _pimpl->finished();
+}
+
+//==============================================================================
+rmf_traffic::schedule::Participant *
+RobotUpdateHandle::ActionExecution::schedule()
+{
+  if (const auto c = _pimpl->context.lock())
+  {
+    auto &itinerary = c->itinerary();
+    return &itinerary;
+  }
+
+  return nullptr;
+}
+
+//==============================================================================
+const rmf_traffic::schedule::Participant *
+RobotUpdateHandle::ActionExecution::schedule() const
+{
+  if (const auto c = _pimpl->context.lock())
+  {
+    const auto &itinerary = c->itinerary();
+    return &itinerary;
+  }
+
+  return nullptr;
+}
+
+//==============================================================================
+RobotUpdateHandle::ActionExecution::ActionExecution()
+{
+  // Do nothing
 }
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -202,6 +202,20 @@ void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 }
 
 //==============================================================================
+void RobotUpdateHandle::set_action_executor(
+  RobotUpdateHandle::ActionExecutor action_executor)
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->worker().schedule(
+      [context, action_executor](const auto&)
+      {
+        context->action_executor(action_executor);
+      });
+  }
+}
+
+//==============================================================================
 void RobotUpdateHandle::update_action_remaining_time(
   const rmf_traffic::Duration remaining_time_estimate)
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -296,7 +296,11 @@ void RobotUpdateHandle::ActionExecution::update_remaining_time(
 //==============================================================================
 void RobotUpdateHandle::ActionExecution::finished()
 {
+  if (!_pimpl->data->finished)
+    return;
+
   _pimpl->data->finished();
+  _pimpl->data->finished = nullptr;
 }
 
 //==============================================================================
@@ -315,7 +319,8 @@ RobotUpdateHandle::ActionExecution::ActionExecution()
 RobotUpdateHandle::ActionExecution::~ActionExecution()
 {
   // Automatically trigger finished when this object dies
-  _pimpl->data->finished();
+  if (_pimpl->data->finished)
+    _pimpl->data->finished();
 }
 
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -290,43 +290,13 @@ void RobotUpdateHandle::Unstable::set_lift_entry_watchdog(
 void RobotUpdateHandle::ActionExecution::update_remaining_time(
     rmf_traffic::Duration remaining_time_estimate)
 {
-  if (auto context = _pimpl->context.lock())
-  {
-    context->action_remaining_time(remaining_time_estimate);
-  }
-  return;
+  _pimpl->data->remaining_time = remaining_time_estimate;
 }
 
 //==============================================================================
 void RobotUpdateHandle::ActionExecution::finished()
 {
-  _pimpl->finished();
-}
-
-//==============================================================================
-rmf_traffic::schedule::Participant *
-RobotUpdateHandle::ActionExecution::schedule()
-{
-  if (const auto c = _pimpl->context.lock())
-  {
-    auto &itinerary = c->itinerary();
-    return &itinerary;
-  }
-
-  return nullptr;
-}
-
-//==============================================================================
-const rmf_traffic::schedule::Participant *
-RobotUpdateHandle::ActionExecution::schedule() const
-{
-  if (const auto c = _pimpl->context.lock())
-  {
-    const auto &itinerary = c->itinerary();
-    return &itinerary;
-  }
-
-  return nullptr;
+  _pimpl->data->finished();
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -300,6 +300,12 @@ void RobotUpdateHandle::ActionExecution::finished()
 }
 
 //==============================================================================
+bool RobotUpdateHandle::ActionExecution::okay() const
+{
+  return _pimpl->data->okay;
+}
+
+//==============================================================================
 RobotUpdateHandle::ActionExecution::ActionExecution()
 {
   // Do nothing

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -33,6 +33,7 @@
 #include <rmf_task_sequence/Task.hpp>
 #include <rmf_task_sequence/Phase.hpp>
 #include <rmf_task_sequence/Event.hpp>
+#include <rmf_task_sequence/events/PerformAction.hpp>
 
 #include <rmf_fleet_msgs/msg/dock_summary.hpp>
 
@@ -61,6 +62,7 @@
 #include <rmf_api_msgs/schemas/robot_state.hpp>
 #include <rmf_api_msgs/schemas/location_2D.hpp>
 
+#include <rmf_fleet_adapter/schemas/event_description_PerformAction.hpp>
 
 #include <iostream>
 #include <unordered_set>
@@ -398,6 +400,82 @@ public:
         handle->_pimpl->server_uri.value(),
         handle->weak_from_this());
     }
+
+    // Add PerformAction event to deserialization
+    auto validator = handle->_pimpl->deserialization.make_validator_shared(
+      schemas::event_description_PerformAction);
+
+    const auto deserializer =
+      [validator,
+      place = handle->_pimpl->deserialization.place,
+      consider_actions = handle->_pimpl->deserialization.consider_actions](
+        const nlohmann::json& msg) -> DeserializedEvent
+      {
+        validator->validate(msg);
+        try
+        {
+          const std::string& category = msg["category"].get<std::string>();
+          const auto consider_action_it = consider_actions->find(category);
+          if (consider_action_it == consider_actions->end())
+          {
+            return {nullptr, {"Fleet not configured to perform this action"}};
+          }
+          Confirmation confirm;
+          const auto& consider = consider_action_it->second;
+          consider(msg, confirm);
+          if (!confirm.is_accepted())
+          {
+            return {nullptr, confirm.errors()};
+          }
+
+          const nlohmann::json desc = msg["description"];
+          rmf_traffic::Duration duration_estimate = rmf_traffic::Duration(0);
+          bool use_tool_sink = false;
+          std::optional<rmf_traffic::agv::Planner::Goal> finish_location =
+            std::nullopt;
+          auto it = msg.find("unix_millis_action_duration_estimate");
+          if (it != msg.end())
+          {
+            duration_estimate =
+              rmf_traffic::Duration(
+              std::chrono::milliseconds(it->get<uint64_t>()));
+          }
+          it = msg.find("use_tool_sink");
+          if (it != msg.end())
+          {
+            use_tool_sink = it->get<bool>();
+          }
+          it = msg.find("expected_finish_location");
+          if (it != msg.end())
+          {
+            auto deser_place =
+              place(msg["expected_finish_location"]);
+            if (!deser_place.description.has_value())
+            {
+              return {nullptr, deser_place.errors};
+            }
+            finish_location = deser_place.description.value();
+          }
+
+          const auto description =
+            rmf_task_sequence::events::PerformAction::Description::make(
+              category,
+              desc,
+              duration_estimate,
+              use_tool_sink,
+              finish_location);
+
+          std::vector<std::string> errors = {};
+          return {description, errors};
+        }
+        catch(const std::exception& e)
+        {
+          return {nullptr, {e.what()}};
+        }
+      };
+
+    handle->_pimpl->deserialization.event->add(
+      "perform_action", validator, deserializer);
 
     return handle;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -134,6 +134,9 @@ struct TaskDeserialization
   std::shared_ptr<FleetUpdateHandle::ConsiderRequest> consider_clean;
   std::shared_ptr<FleetUpdateHandle::ConsiderRequest> consider_patrol;
   std::shared_ptr<FleetUpdateHandle::ConsiderRequest> consider_composed;
+  // Map category string to its ConsiderRequest for PerformAction events
+  std::shared_ptr<std::unordered_map<
+    std::string, FleetUpdateHandle::ConsiderRequest>> consider_actions;
 
   void add_schema(const nlohmann::json& schema);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -25,10 +25,27 @@ namespace rmf_fleet_adapter {
 namespace agv {
 
 //==============================================================================
+class RobotUpdateHandle::ActionExecution::Implementation
+{
+public:
+  template<typename... Args>
+  static ActionExecutionPtr make(Args&& ...args)
+  {
+    auto execution = std::shared_ptr<ActionExecution>(new ActionExecution);
+    execution->_pimpl = rmf_utils::make_unique_impl<Implementation>(
+        Implementation{std::forward<Args>(args)...});
+
+    return execution;
+  }
+
+  std::weak_ptr<RobotContext> context;
+  std::function<void()> finished;
+};
+
+//==============================================================================
 class RobotUpdateHandle::Implementation
 {
 public:
-
   std::weak_ptr<RobotContext> context;
   std::string name;
   RobotUpdateHandle::Unstable unstable = RobotUpdateHandle::Unstable();
@@ -40,18 +57,18 @@ public:
 
     RobotUpdateHandle handle;
     handle._pimpl = rmf_utils::make_impl<Implementation>(
-      Implementation{std::move(context), std::move(name)});
+        Implementation{std::move(context), std::move(name)});
     handle._pimpl->unstable._pimpl =
-      &RobotUpdateHandle::Implementation::get(handle);
+        &RobotUpdateHandle::Implementation::get(handle);
     return std::make_shared<RobotUpdateHandle>(std::move(handle));
   }
 
-  static Implementation& get(RobotUpdateHandle& handle)
+  static Implementation &get(RobotUpdateHandle &handle)
   {
     return *handle._pimpl;
   }
 
-  static const Implementation& get(const RobotUpdateHandle& handle)
+  static const Implementation &get(const RobotUpdateHandle &handle)
   {
     return *handle._pimpl;
   }
@@ -59,7 +76,6 @@ public:
   std::shared_ptr<RobotContext> get_context();
 
   std::shared_ptr<const RobotContext> get_context() const;
-
 };
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -28,18 +28,32 @@ namespace agv {
 class RobotUpdateHandle::ActionExecution::Implementation
 {
 public:
-  template<typename... Args>
-  static ActionExecutionPtr make(Args&& ...args)
+
+  struct Data
   {
-    auto execution = std::shared_ptr<ActionExecution>(new ActionExecution);
-    execution->_pimpl = rmf_utils::make_unique_impl<Implementation>(
-        Implementation{std::forward<Args>(args)...});
+
+    std::function<void()> finished;
+    std::optional<rmf_traffic::Duration> remaining_time;
+
+    Data(
+      std::function<void()> finished_,
+      std::optional<rmf_traffic::Duration> remaining_time_ = std::nullopt)
+    {
+      finished = std::move(finished_);
+      remaining_time = remaining_time_;
+    }
+  };
+
+  static ActionExecution make(std::shared_ptr<Data> data)
+  {
+    ActionExecution execution;
+    execution._pimpl = rmf_utils::make_impl<Implementation>(
+        Implementation{std::move(data)});
 
     return execution;
   }
 
-  std::weak_ptr<RobotContext> context;
-  std::function<void()> finished;
+  std::shared_ptr<Data> data;
 };
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -51,7 +51,7 @@ public:
   {
     ActionExecution execution;
     execution._pimpl = rmf_utils::make_impl<Implementation>(
-        Implementation{std::move(data)});
+      Implementation{std::move(data)});
 
     return execution;
   }
@@ -74,18 +74,18 @@ public:
 
     RobotUpdateHandle handle;
     handle._pimpl = rmf_utils::make_impl<Implementation>(
-        Implementation{std::move(context), std::move(name)});
+      Implementation{std::move(context), std::move(name)});
     handle._pimpl->unstable._pimpl =
-        &RobotUpdateHandle::Implementation::get(handle);
+      &RobotUpdateHandle::Implementation::get(handle);
     return std::make_shared<RobotUpdateHandle>(std::move(handle));
   }
 
-  static Implementation &get(RobotUpdateHandle &handle)
+  static Implementation& get(RobotUpdateHandle& handle)
   {
     return *handle._pimpl;
   }
 
-  static const Implementation &get(const RobotUpdateHandle &handle)
+  static const Implementation& get(const RobotUpdateHandle& handle)
   {
     return *handle._pimpl;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -34,6 +34,8 @@ public:
 
     std::function<void()> finished;
     std::optional<rmf_traffic::Duration> remaining_time;
+    bool okay;
+    // TODO: Consider adding a mutex to lock read/write
 
     Data(
       std::function<void()> finished_,
@@ -41,6 +43,7 @@ public:
     {
       finished = std::move(finished_);
       remaining_time = remaining_time_;
+      okay = true;
     }
   };
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
@@ -23,7 +23,7 @@ namespace rmf_fleet_adapter {
 namespace events {
 
 //==============================================================================
-void GoToPlace::add(rmf_task_sequence::Event::Initializer &initializer)
+void GoToPlace::add(rmf_task_sequence::Event::Initializer& initializer)
 {
   initializer.add<Description>(
     [](

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -224,6 +224,8 @@ void PerformAction::Active::cancel()
   _state->update_status(Status::Canceled);
   _state->update_log().info("Received signal to cancel");
   _finished();
+  if (auto data = _execution_data.lock())
+    data->okay = false;
 }
 
 //==============================================================================
@@ -232,6 +234,8 @@ void PerformAction::Active::kill()
   _state->update_status(Status::Killed);
   _state->update_log().info("Received signal to kill");
   _finished();
+  if (auto data = _execution_data.lock())
+    data->okay = false;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -110,7 +110,8 @@ auto PerformAction::Standby::begin(
     _active = Active::make(
       _assign_id,
       _context,
-      _description.action(),
+      _description.category(),
+      _description.description(),
       _time_estimate,
       _state,
       _update,
@@ -124,14 +125,15 @@ auto PerformAction::Standby::begin(
 auto PerformAction::Active::make(
   const AssignIDPtr& id,
   agv::RobotContextPtr context,
-  nlohmann::json action,
+  const std::string& category,
+  nlohmann::json desc,
   rmf_traffic::Duration time_estimate,
   rmf_task::events::SimpleEventStatePtr state,
   std::function<void()> update,
   std::function<void()> finished) -> std::shared_ptr<Active>
 {
   auto active = std::make_shared<Active>(
-    Active(std::move(action), time_estimate));
+    Active(std::move(category), std::move(desc), time_estimate));
   active->_assign_id = id;
   active->_context = std::move(context);
   active->_update = std::move(update);
@@ -145,9 +147,11 @@ auto PerformAction::Active::make(
 
 //==============================================================================
 PerformAction::Active::Active(
-  nlohmann::json action,
+  const std::string& category,
+  nlohmann::json desc,
   rmf_traffic::Duration time_estimate)
-: _action(std::move(action)),
+: _action_category(std::move(category)),
+  _action_description(std::move(desc)),
   _time_estimate(std::move(time_estimate))
 {
   // Do nothing
@@ -237,7 +241,7 @@ void PerformAction::Active::_execute_action()
     return;
   }
 
-  action_executor(_action, _finished);
+  action_executor(_action_category, _action_description, _finished);
 }
 
 } // namespace events

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -173,13 +173,18 @@ rmf_traffic::Duration PerformAction::Active::remaining_time_estimate() const
 
   // If an estimate is not provided we compute one based on the expected finish
   // time
-  return _expected_finish_time - _context->now();
+  const auto estimate =
+    std::max(rmf_traffic::Duration(0),
+      _expected_finish_time - _context->now());
+  return estimate;
 }
 
 //==============================================================================
 auto PerformAction::Active::backup() const -> Backup
 {
-  // PerformAction doesn't need to be backed up
+  // TODO: Consider adding a function to ActionExecution that allows the
+  // system integrator to periodically send in backup messages. For now, we
+  // do not generate backup messages.
   return Backup::make(0, nlohmann::json());
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -17,6 +17,8 @@
 
 #include "PerformAction.hpp"
 
+#include "../agv/internal_RobotUpdateHandle.hpp"
+
 #include <rmf_traffic_ros2/Time.hpp>
 
 namespace rmf_fleet_adapter {
@@ -246,7 +248,12 @@ void PerformAction::Active::_execute_action()
     return;
   }
 
-  action_executor(_action_category, _action_description, _finished);
+  auto action_execution =
+    agv::RobotUpdateHandle::ActionExecution::Implementation::make(
+    _context,
+    _finished);
+
+  action_executor(_action_category, _action_description, action_execution);
 }
 
 } // namespace events

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -248,7 +248,7 @@ void PerformAction::Active::_execute_action()
     _state->update_status(Status::Error);
     const std::string msg = "ActionExecutor not set via RobotUpdateHandle. "
       "Unable to perform the requested action.";
-    _state->update_log().info(msg);
+    _state->update_log().error(msg);
     _finished();
     return;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "PerformAction.hpp"
+
+#include <rmf_traffic/schedule/StubbornNegotiator.hpp>
+
+#include <rmf_traffic_ros2/Time.hpp>
+
+namespace rmf_fleet_adapter {
+namespace events {
+
+//==============================================================================
+void PerformAction::add(rmf_task_sequence::Event::Initializer& initializer)
+{
+  initializer.add<Description>(
+    [](
+      const AssignIDPtr& id,
+      const std::function<rmf_task::State()>& get_state,
+      const rmf_task::ConstParametersPtr& parameters,
+      const Description& description,
+      std::function<void()> update) -> StandbyPtr
+    {
+      return Standby::make(
+        id, get_state, parameters, description, std::move(update));
+    },
+    [](
+      const AssignIDPtr& id,
+      const std::function<rmf_task::State()>& get_state,
+      const rmf_task::ConstParametersPtr& parameters,
+      const Description& description,
+      const nlohmann::json&,
+      std::function<void()> update,
+      std::function<void()> checkpoint,
+      std::function<void()> finished) -> ActivePtr
+    {
+      return Standby::make(
+        id, get_state, parameters, description, std::move(update))
+        ->begin(std::move(checkpoint), std::move(finished));
+    });
+}
+
+//==============================================================================
+auto PerformAction::Standby::make(
+  const AssignIDPtr& id,
+  const std::function<rmf_task::State()>& get_state,
+  const rmf_task::ConstParametersPtr& parameters,
+  const DescriptionPtr& description,
+  std::function<void()> update)
+-> std::shared_ptr<Standby>
+{
+  const auto state = get_state();
+  const auto context = state.get<agv::GetContext>()->value;
+  const auto header = description->generate_header(state, *parameters);
+
+  auto standby = std::make_shared<Standby>(Standby{description});
+  standby->_assign_id = id;
+  standby->_context = context;
+  standby->_time_estimate = header.original_duration_estimate();
+  standby->_update = std::move(update);
+  standby->_state = rmf_task::events::SimpleEventState::make(
+    id->assign(),
+    header.category(),
+    header.detail(),
+    rmf_task::Event::Status::Standby,
+    {},
+    context->clock());
+
+  return standby;
+}
+
+//==============================================================================
+PerformAction::Standby::Standby(Standby::DescriptionPtr description)
+: _description(std::move(description))
+{
+  // Do nothing
+}
+
+//==============================================================================
+auto PerformAction::Standby::state() const -> ConstStatePtr
+{
+  return _state;
+}
+
+//==============================================================================
+rmf_traffic::Duration PerformAction::Standby::duration_estimate() const
+{
+  return _time_estimate;
+}
+
+//==============================================================================
+auto PerformAction::Standby::begin(
+  std::function<void()>,
+  std::function<void()> finished) -> ActivePtr
+{
+  if (!_active)
+  {
+    _active = Active::make(
+      _assign_id,
+      _context,
+      _description->action(),
+      _time_estimate,
+      _state,
+      _update,
+      std::move(finished));
+  }
+
+  return _active;
+}
+
+//==============================================================================
+auto PerformAction::Active::make(
+  const AssignIDPtr& id,
+  agv::RobotContextPtr context,
+  nlohmann::json action,
+  rmf_traffic::Duration time_estimate,
+  rmf_task::events::SimpleEventStatePtr state,
+  std::function<void()> update,
+  std::function<void()> finished) -> std::shared_ptr<Active>
+{
+  auto active = std::make_shared<Active>(
+    Active(std::move(action), std::move(_time_estimate)));
+  active->_assign_id = id;
+  active->_context = std::move(context);
+  active->_update = std::move(update);
+  active->_finished = std::move(finished);
+  active->_state = std::move(state);
+  active->_execute_action();
+  active->_expected_finish_time =
+    active->_context->now() + action->_time_estimate;
+  return active;
+}
+
+//==============================================================================
+PerformAction::Active::Active(
+  nlohmann::json action,
+  rmf_traffic::Duration time_estimate)
+: _action(std::move(action)),
+  _time_estimate(std::move(time_estimate))
+{
+  // Do nothing
+}
+
+//==============================================================================
+auto PerformAction::Active::state() const -> ConstStatePtr
+{
+  return _state;
+}
+
+//==============================================================================
+rmf_traffic::Duration PerformAction::Active::remaining_time_estimate() const
+{
+  if (_context->action_time_remaining().has_value())
+  {
+    return _context->action_time_remaining().value();
+  }
+
+  // If an estimate is not provided we compute one based on the expected finish
+  // time
+  return _expected_finish_time - _context->now();
+}
+
+//==============================================================================
+auto PerformAction::Active::backup() const -> Backup
+{
+  // PerformAction doesn't need to be backed up
+  return Backup::make(0, nlohmann::json());
+}
+
+//==============================================================================
+auto PerformAction::Active::interrupt(
+  std::function<void()> task_is_interrupted) -> Resume
+{
+  _negotiator->clear_license();
+
+  _state->update_status(Status::Standby);
+  _state->update_log().info("Going into standby for an interruption");
+  _state->update_dependencies({});
+
+  _context->worker().schedule(
+    [task_is_interrupted](const auto&)
+    {
+      task_is_interrupted();
+    });
+
+  // TODO(YV): Currently we will ask the robot to perform the action again when
+  // resumed. Future work can be to receive a callback from RobotUpdateHandle
+  // which can be used to ask the robot to resume from its interrupted state.
+  return Resume::make(
+    [w = weak_from_this()]()
+    {
+      if (const auto self = w.lock())
+      {
+        self->_execute_action();
+      }
+    });
+}
+
+//==============================================================================
+void PerformAction::Active::cancel()
+{
+  _state->update_status(Status::Canceled);
+  _state->update_log().info("Received signal to cancel");
+  _finished();
+}
+
+//==============================================================================
+void PerformAction::Active::kill()
+{
+  _state->update_status(Status::Killed);
+  _state->update_log().info("Received signal to kill");
+  _finished();
+}

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.hpp
@@ -18,6 +18,7 @@
 #ifndef SRC__RMF_FLEET_ADAPTER__EVENTS__PERFORMACTION_HPP
 #define SRC__RMF_FLEET_ADAPTER__EVENTS__PERFORMACTION_HPP
 
+#include "../agv/internal_RobotUpdateHandle.hpp"
 #include "../agv/RobotContext.hpp"
 
 #include <rmf_task_sequence/Event.hpp>
@@ -79,6 +80,9 @@ public:
   {
   public:
 
+    using ExecutionData =
+      agv::RobotUpdateHandle::ActionExecution::Implementation::Data;
+
     static std::shared_ptr<Active> make(
       const AssignIDPtr& id,
       agv::RobotContextPtr context,
@@ -120,6 +124,7 @@ public:
     rmf_task::events::SimpleEventStatePtr _state;
     rmf_traffic::Time _expected_finish_time;
     std::shared_ptr<void> _be_stubborn;
+    std::weak_ptr<ExecutionData> _execution_data;
   };
 };
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.hpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__EVENTS__PERFORMACTION_HPP
+#define SRC__RMF_FLEET_ADAPTER__EVENTS__PERFORMACTION_HPP
+
+#include "../agv/RobotContext.hpp"
+
+#include <rmf_task_sequence/Event.hpp>
+#include <rmf_task_sequence/events/PerformAction.hpp>
+#include <rmf_task/events/SimpleEventState.hpp>
+
+#include <nlohmann/json.hpp>
+
+namespace rmf_fleet_adapter {
+namespace events {
+
+//==============================================================================
+class PerformAction : public rmf_task_sequence::Event
+{
+public:
+
+  using DescriptionPtr =
+    rmf_task_sequence::events::PerformAction::DescriptionPtr;
+
+  static void add(rmf_task_sequence::Event::Initializer& initializer);
+
+  class Standby : public rmf_task_sequence::Event::Standby
+  {
+  public:
+
+    static std::shared_ptr<Standby> make(
+      const AssignIDPtr& id,
+      const std::function<rmf_task::State()>& get_state,
+      const rmf_task::ConstParametersPtr& parameters,
+      const DescriptionPtr& description,
+      std::function<void()> update);
+
+    /// Documentation inherited
+    ConstStatePtr state() const final;
+
+    /// Documentation inherited
+    rmf_traffic::Duration duration_estimate() const final;
+
+    /// Documentation inherited
+    ActivePtr begin(
+      std::function<void()> checkpoint,
+      std::function<void()> finished) final;
+
+  private:
+
+    Standby(DescriptionPtr description);
+
+    DescriptionPtr _description;
+    AssignIDPtr _assign_id;
+    agv::RobotContextPtr _context;
+    rmf_traffic::Duration _time_estimate;
+    std::function<void()> _update;
+    rmf_task::events::SimpleEventStatePtr _state;
+    ActivePtr _active = nullptr;
+  };
+
+  class Active
+    : public rmf_task_sequence::Event::Active,
+      public std::enable_shared_from_this<Active>
+  {
+  public:
+
+    static std::shared_ptr<Active> make(
+      const AssignIDPtr& id,
+      agv::RobotContextPtr context,
+      nlohmann::json action,
+      rmf_traffic::Duration _time_estimate,
+      rmf_task::events::SimpleEventStatePtr state,
+      std::function<void()> update,
+      std::function<void()> finished);
+
+    ConstStatePtr state() const final;
+
+    rmf_traffic::Duration remaining_time_estimate() const final;
+
+    Backup backup() const final;
+
+    Resume interrupt(std::function<void()> task_is_interrupted) final;
+
+    void cancel() final;
+
+    void kill() final;
+
+  private:
+
+    Active(
+      nlohmann::json action,
+      rmf_traffic::Duration time_estimate);
+
+    void _execute_action();
+
+    AssignIDPtr _assign_id;
+    agv::RobotContextPtr _context;
+    nlohmann::json _action;
+    rmf_traffic::Duration _time_estimate;
+    std::function<void()> _update;
+    std::function<void()> _finished;
+    rmf_task::events::SimpleEventStatePtr _state;
+    rmf_traffic::Time _expected_finish_time;
+    std::shared_ptr<void> _be_stubborn;
+  };
+};
+
+} // namespace events
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__EVENTS__PERFORMACTION_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.hpp
@@ -34,8 +34,7 @@ class PerformAction : public rmf_task_sequence::Event
 {
 public:
 
-  using DescriptionPtr =
-    rmf_task_sequence::events::PerformAction::DescriptionPtr;
+  using Description = rmf_task_sequence::events::PerformAction::Description;
 
   static void add(rmf_task_sequence::Event::Initializer& initializer);
 
@@ -47,7 +46,7 @@ public:
       const AssignIDPtr& id,
       const std::function<rmf_task::State()>& get_state,
       const rmf_task::ConstParametersPtr& parameters,
-      const DescriptionPtr& description,
+      const rmf_task_sequence::events::PerformAction::Description& description,
       std::function<void()> update);
 
     /// Documentation inherited
@@ -63,9 +62,9 @@ public:
 
   private:
 
-    Standby(DescriptionPtr description);
+    Standby(rmf_task_sequence::events::PerformAction::Description description);
 
-    DescriptionPtr _description;
+    rmf_task_sequence::events::PerformAction::Description _description;
     AssignIDPtr _assign_id;
     agv::RobotContextPtr _context;
     rmf_traffic::Duration _time_estimate;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.hpp
@@ -82,7 +82,8 @@ public:
     static std::shared_ptr<Active> make(
       const AssignIDPtr& id,
       agv::RobotContextPtr context,
-      nlohmann::json action,
+      const std::string& action_category,
+      nlohmann::json action_description,
       rmf_traffic::Duration _time_estimate,
       rmf_task::events::SimpleEventStatePtr state,
       std::function<void()> update,
@@ -103,14 +104,16 @@ public:
   private:
 
     Active(
-      nlohmann::json action,
+      const std::string& action_category,
+      nlohmann::json action_description,
       rmf_traffic::Duration time_estimate);
 
     void _execute_action();
 
     AssignIDPtr _assign_id;
     agv::RobotContextPtr _context;
-    nlohmann::json _action;
+    std::string _action_category;
+    nlohmann::json _action_description;
     rmf_traffic::Duration _time_estimate;
     std::function<void()> _update;
     std::function<void()> _finished;

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -720,6 +720,18 @@ public:
       if (on_change_fn)
         on_change_fn(*dispatch_state);
 
+      // Print the errors
+      std::size_t error_count = 1;
+      for (const auto& error : errors)
+      {
+        RCLCPP_ERROR(
+          node->get_logger(),
+          "No submission error[%d]: %s",
+          error_count,
+          error.c_str());
+        ++error_count;
+      }
+
       return;
     }
 


### PR DESCRIPTION
This PR aims to introduce support for `PerformAction` event. Changes
1) JSON schema for `PerformAction` event description
2) `FleetUpdateHandle::add_performable_action(const std::string& category) API: Set the category of actions that robots in this fleet can perform.`
3) `RobotUpdateHandle::set_action_executor(ActionExecutor action_executor)` API: Set the executor which can be used by the fleet adapter to request a robot to perform an action and `RobotUpdateHandle::update_action_remaining_time(rmf_traffic::Duration duration)` to update the estimate of the time remaining for the action.
4) `Standby` and `Active` definitions for `PerformAction`

This PR requires https://github.com/open-rmf/rmf_task/pull/49