### PR TITLE
Feature: Direct Task Assignment

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -821,6 +821,13 @@ void TaskManager::set_queue(
   // function that is called at the end of this function.
   {
     std::lock_guard<std::mutex> guard(_mutex);
+    // Do not remove automatic task if assignments is empty. See Issue #138
+    if (assignments.empty() &&
+      _queue.size() == 1 &&
+      _queue.front().request()->booking()->automatic())
+    {
+      return;
+    }
     _queue = assignments;
     _publish_task_queue();
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -69,7 +69,7 @@ namespace rmf_fleet_adapter {
 //==============================================================================
 TaskManagerPtr TaskManager::make(
   agv::RobotContextPtr context,
-  std::weak_ptr<BroadcastClient> broadcast_client,
+  std::optional<std::weak_ptr<BroadcastClient>> broadcast_client,
   std::weak_ptr<agv::FleetUpdateHandle> fleet_handle)
 {
   auto mgr = TaskManagerPtr(
@@ -219,7 +219,7 @@ TaskManagerPtr TaskManager::make(
 //==============================================================================
 TaskManager::TaskManager(
   agv::RobotContextPtr context,
-  std::weak_ptr<BroadcastClient> broadcast_client,
+  std::optional<std::weak_ptr<BroadcastClient>> broadcast_client,
   std::weak_ptr<agv::FleetUpdateHandle> fleet_handle)
 : _context(std::move(context)),
   _broadcast_client(std::move(broadcast_client)),
@@ -812,7 +812,8 @@ agv::ConstRobotContextPtr TaskManager::context() const
 }
 
 //==============================================================================
-std::weak_ptr<BroadcastClient> TaskManager::broadcast_client() const
+std::optional<std::weak_ptr<BroadcastClient>> TaskManager::broadcast_client()
+const
 {
   return _broadcast_client;
 }
@@ -1291,7 +1292,10 @@ void TaskManager::_validate_and_publish_websocket(
     return;
   }
 
-  const auto client = _broadcast_client.lock();
+  if (!_broadcast_client.has_value())
+    return;
+
+  const auto client = _broadcast_client->lock();
   if (!client)
   {
     RCLCPP_ERROR(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -918,7 +918,7 @@ void TaskManager::_begin_next_task()
   }
 
   // The next task should one in the direct assignment queue if present
-  const bool is_next_task_direct = _direct_queue.empty() ? false : true;
+  const bool is_next_task_direct = !_direct_queue.empty();
   const auto assignment = is_next_task_direct ?
     _direct_queue.begin()->assignment :
     _queue.front();
@@ -952,9 +952,9 @@ void TaskManager::_begin_next_task()
       _task_finished(id));
 
     if (is_next_task_direct)
-       _direct_queue.erase(_direct_queue.begin());
+      _direct_queue.erase(_direct_queue.begin());
    else
-    _queue.erase(_queue.begin());
+      _queue.erase(_queue.begin());
 
     if (!_active_task)
     {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1181,7 +1181,14 @@ void TaskManager::retreat_to_charger()
       finish.value().finish_state(),
       current_state.time().value());
 
-    set_queue({charging_assignment});
+    const DirectAssignment assignment = DirectAssignment{
+      _next_sequence_number,
+      charging_assignment};
+    ++_next_sequence_number;
+    {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _direct_queue.insert(assignment);
+    }
 
     RCLCPP_INFO(
       _context->node()->get_logger(),
@@ -1806,7 +1813,7 @@ void TaskManager::_handle_direct_request(
     deployment_time = estimate.value().wait_until();
   }
 
-  DirectAssignment assignment = DirectAssignment{
+  const DirectAssignment assignment = DirectAssignment{
     _next_sequence_number,
     Assignment(
         new_request,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -256,7 +256,7 @@ private:
   // TODO: Eliminate the need for a mutex by redesigning the use of the task
   // manager so that modifications of shared data only happen on designated
   // rxcpp worker
-  std::mutex _mutex;
+  mutable std::mutex _mutex;
   rclcpp::TimerBase::SharedPtr _task_timer;
   rclcpp::TimerBase::SharedPtr _retreat_timer;
   rclcpp::TimerBase::SharedPtr _update_timer;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -52,7 +52,7 @@ public:
 
   static std::shared_ptr<TaskManager> make(
     agv::RobotContextPtr context,
-    std::weak_ptr<BroadcastClient> broadcast_client,
+    std::optional<std::weak_ptr<BroadcastClient>> broadcast_client,
     std::weak_ptr<agv::FleetUpdateHandle> fleet_handle);
 
   using Start = rmf_traffic::agv::Plan::Start;
@@ -107,7 +107,7 @@ public:
 
   agv::ConstRobotContextPtr context() const;
 
-  std::weak_ptr<BroadcastClient> broadcast_client() const;
+  std::optional<std::weak_ptr<BroadcastClient>> broadcast_client() const;
 
   /// Set the queue for this task manager with assignments generated from the
   /// task planner
@@ -147,7 +147,7 @@ private:
 
   TaskManager(
     agv::RobotContextPtr context,
-    std::weak_ptr<BroadcastClient> broadcast_client,
+    std::optional<std::weak_ptr<BroadcastClient>> broadcast_client,
     std::weak_ptr<agv::FleetUpdateHandle>);
 
   class ActiveTask
@@ -231,7 +231,7 @@ private:
   friend class ActiveTask;
 
   agv::RobotContextPtr _context;
-  std::weak_ptr<BroadcastClient> _broadcast_client;
+  std::optional<std::weak_ptr<BroadcastClient>> _broadcast_client;
   std::weak_ptr<agv::FleetUpdateHandle> _fleet_handle;
   rmf_task::ConstActivatorPtr _task_activator;
   ActiveTask _active_task;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -196,7 +196,10 @@ private:
   bool _emergency_active = false;
   std::optional<std::string> _emergency_pullover_interrupt_token;
   rmf_task_sequence::Event::ActivePtr _emergency_pullover;
+  // Queue for dispatched tasks
   std::vector<Assignment> _queue;
+  // Queue for directly assigned tasks
+  std::vector<Assignment> _direct_queue;
   rmf_utils::optional<Start> _expected_finish_location;
   rxcpp::subscription _task_sub;
   rxcpp::subscription _emergency_sub;
@@ -358,6 +361,10 @@ private:
 
   void _handle_request(
     const std::string& request_msg,
+    const std::string& request_id);
+
+  void _handle_direct_request(
+    const nlohmann::json& request_json,
     const std::string& request_id);
 
   void _handle_cancel_request(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -51,7 +51,8 @@ public:
 
   static std::shared_ptr<TaskManager> make(
     agv::RobotContextPtr context,
-    std::weak_ptr<BroadcastClient> broadcast_client);
+    std::weak_ptr<BroadcastClient> broadcast_client,
+    std::weak_ptr<agv::FleetUpdateHandle> fleet_handle);
 
   using Start = rmf_traffic::agv::Plan::Start;
   using StartSet = rmf_traffic::agv::Plan::StartSet;
@@ -107,7 +108,8 @@ private:
 
   TaskManager(
     agv::RobotContextPtr context,
-    std::weak_ptr<BroadcastClient> broadcast_client);
+    std::weak_ptr<BroadcastClient> broadcast_client,
+    std::weak_ptr<agv::FleetUpdateHandle>);
 
   class ActiveTask
   {
@@ -191,6 +193,7 @@ private:
 
   agv::RobotContextPtr _context;
   std::weak_ptr<BroadcastClient> _broadcast_client;
+  std::weak_ptr<agv::FleetUpdateHandle> _fleet_handle;
   rmf_task::ConstActivatorPtr _task_activator;
   ActiveTask _active_task;
   bool _emergency_active = false;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -63,10 +63,6 @@ public:
   using TaskProfiles = std::unordered_map<std::string, TaskProfileMsg>;
   using TaskSummaryMsg = rmf_task_msgs::msg::TaskSummary;
 
-  /// The location where we expect this robot to be at the end of its current
-  /// task queue.
-  StartSet expected_finish_location() const;
-
   const agv::RobotContextPtr& context();
 
   agv::ConstRobotContextPtr context() const;
@@ -89,7 +85,7 @@ public:
   std::string robot_status() const;
 
   /// The state of the robot.
-  State expected_finish_state() const;
+  State expected_finish_state(bool for_direct_assignment = false) const;
 
   /// Callback for the retreat timer. Appends a charging task to the task queue
   /// when robot is idle and battery level drops below a retreat threshold.

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -167,14 +167,14 @@ std::string FleetUpdateHandle::Implementation::make_error_str(
 std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
   const std::string& task_id,
   const nlohmann::json& request_msg,
-  std::vector<std::string>* errors) const
+  std::vector<std::string>& errors) const
 {
   const auto& category = request_msg["category"].get<std::string>();
 
   const auto task_deser_it = deserialization.task->handlers.find(category);
   if (task_deser_it == deserialization.task->handlers.end())
   {
-    errors->push_back(make_error_str(
+    errors.push_back(make_error_str(
       4, "Unsupported type",
       "Fleet [" + name + "] does not support task category ["
       + category + "]"));
@@ -198,7 +198,7 @@ std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
       e.what(),
       description_msg.dump(2, ' ').c_str());
 
-    errors->push_back(make_error_str(5, "Invalid request format", e.what()));
+    errors.push_back(make_error_str(5, "Invalid request format", e.what()));
     return nullptr;
   }
 
@@ -207,7 +207,7 @@ std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
 
   if (!deserialized_task.description)
   {
-    *errors = deserialized_task.errors;
+    errors = deserialized_task.errors;
     return nullptr;
   }
 
@@ -240,7 +240,7 @@ std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
 
     if (!priority)
     {
-      errors->push_back(
+      errors.push_back(
         make_error_str(
           4, "Unsupported type",
           "Fleet [" + name + "] does not support priority request: " + p_it->dump()
@@ -326,7 +326,7 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
   }
 
   std::vector<std::string> errors = {};
-  const auto new_request = convert(task_id, request_msg, &errors);
+  const auto new_request = convert(task_id, request_msg, errors);
   if (!new_request)
   {
     return respond(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1281,10 +1281,15 @@ void FleetUpdateHandle::add_robot(
             return;
           }
 
+          std::optional<std::weak_ptr<BroadcastClient>> broadcast_client =
+            std::nullopt;
+          if (fleet->_pimpl->broadcast_client)
+            broadcast_client = fleet->_pimpl->broadcast_client;
+
           fleet->_pimpl->task_managers.insert({context,
             TaskManager::make(
               context,
-              fleet->_pimpl->broadcast_client,
+              broadcast_client,
               std::weak_ptr<FleetUpdateHandle>(fleet))});
         });
     });

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -151,10 +151,9 @@ void FleetUpdateHandle::Implementation::dock_summary_cb(
   return;
 }
 
-namespace {
 //==============================================================================
-std::string make_error_str(
-  uint64_t code, std::string category, std::string detail)
+std::string FleetUpdateHandle::Implementation::make_error_str(
+  uint64_t code, std::string category, std::string detail) const
 {
   nlohmann::json error;
   error["code"] = code;
@@ -163,13 +162,111 @@ std::string make_error_str(
 
   return error.dump();
 }
-} // anonymous namespace
+
+//==============================================================================
+std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
+  const std::string& task_id,
+  const nlohmann::json& request_msg,
+  std::vector<std::string>& errors)
+{
+  const auto& category = request_msg["category"].get<std::string>();
+
+  const auto task_deser_it = deserialization.task->handlers.find(category);
+  if (task_deser_it == deserialization.task->handlers.end())
+  {
+    errors.push_back(make_error_str(
+      4, "Unsupported type",
+      "Fleet [" + name + "] does not support task category ["
+      + category + "]"));
+    return nullptr;
+  }
+
+  const auto& description_msg = request_msg["description"];
+  const auto& task_deser_handler = task_deser_it->second;
+
+  try
+  {
+    task_deser_handler.validator->validate(description_msg);
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Received a request description for [%s] with an invalid format. "
+      "Error: %s\nRequest:\n%s",
+      category.c_str(),
+      e.what(),
+      description_msg.dump(2, ' ').c_str());
+
+    errors.push_back(make_error_str(5, "Invalid request format", e.what()));
+    return nullptr;
+  }
+
+  const auto deserialized_task =
+    task_deser_handler.deserializer(description_msg);
+
+  if (!deserialized_task.description)
+  {
+    errors = deserialized_task.errors;
+    return nullptr;
+  }
+
+  rmf_traffic::Time earliest_start_time = rmf_traffic_ros2::convert(
+    node->get_clock()->now());
+  const auto t_it = request_msg.find("unix_millis_earliest_start_time");
+  if (t_it != request_msg.end())
+  {
+    earliest_start_time =
+      rmf_traffic::Time(std::chrono::milliseconds(t_it->get<uint64_t>()));
+  }
+
+  rmf_task::ConstPriorityPtr priority;
+  const auto p_it = request_msg.find("priority");
+  if (p_it != request_msg.end())
+  {
+    // TODO(YV): Validate with priority_description_Binary.json
+    const auto& p_type = (*p_it)["type"];
+    if (p_type.is_string() && p_type.get<std::string>() == "binary")
+    {
+      const auto& p_value = (*p_it)["value"];
+      if (p_value.is_number_integer())
+      {
+        if (p_value.is_number_integer() && p_value.get<uint64_t>() > 0)
+          priority = rmf_task::BinaryPriorityScheme::make_high_priority();
+      }
+
+      priority = rmf_task::BinaryPriorityScheme::make_low_priority();
+    }
+
+    if (!priority)
+    {
+      errors.push_back(
+        make_error_str(
+          4, "Unsupported type",
+          "Fleet [" + name + "] does not support priority request: " + p_it->dump()
+          + "\nDefaulting to low binary priority."));
+    }
+  }
+
+  if (!priority)
+    priority = rmf_task::BinaryPriorityScheme::make_low_priority();
+
+  const auto new_request =
+    std::make_shared<rmf_task::Request>(
+      task_id,
+      earliest_start_time,
+      priority,
+      deserialized_task.description);
+
+  return new_request;
+}
 
 //==============================================================================
 void FleetUpdateHandle::Implementation::bid_notice_cb(
   const BidNoticeMsg& bid_notice,
   rmf_task_ros2::bidding::AsyncBidder::Respond respond)
 {
+  // TODO(YV): Consider moving these checks into convert()
   const auto& task_id = bid_notice.task_id;
   if (task_managers.empty())
   {
@@ -228,104 +325,16 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       });
   }
 
-  const auto& category = request_msg["category"].get<std::string>();
-
-  const auto task_deser_it = deserialization.task->handlers.find(category);
-  if (task_deser_it == deserialization.task->handlers.end())
+  std::vector<std::string> errors = {};
+  const auto new_request = convert(task_id, request_msg, errors);
+  if (!new_request)
   {
     return respond(
       {
         std::nullopt,
-        {make_error_str(
-          4, "Unsupported type",
-          "Fleet [" + name + "] does not support task category ["
-          + category + "]")}
+        errors
       });
   }
-
-  const auto& description_msg = request_msg["description"];
-  const auto& task_deser_handler = task_deser_it->second;
-
-  try
-  {
-    task_deser_handler.validator->validate(description_msg);
-  }
-  catch (const std::exception& e)
-  {
-    RCLCPP_ERROR(
-      node->get_logger(),
-      "Received a request description for [%s] with an invalid format. "
-      "Error: %s\nRequest:\n%s",
-      category.c_str(),
-      e.what(),
-      description_msg.dump(2, ' ').c_str());
-
-    return respond(
-      rmf_task_ros2::bidding::Response{
-        std::nullopt,
-        {make_error_str(5, "Invalid request format", e.what())}
-      });
-  }
-
-  const auto deserialized_task =
-    task_deser_handler.deserializer(description_msg);
-
-  if (!deserialized_task.description)
-  {
-    return respond(
-      {
-        std::nullopt,
-        deserialized_task.errors
-      });
-  }
-
-  std::vector<std::string> errors;
-
-  rmf_traffic::Time earliest_start_time = rmf_traffic_ros2::convert(
-    node->get_clock()->now());
-  const auto t_it = request_msg.find("unix_millis_earliest_start_time");
-  if (t_it != request_msg.end())
-  {
-    earliest_start_time =
-      rmf_traffic::Time(std::chrono::milliseconds(t_it->get<uint64_t>()));
-  }
-
-  rmf_task::ConstPriorityPtr priority;
-  const auto p_it = request_msg.find("priority");
-  if (p_it != request_msg.end())
-  {
-    const auto& p_type = (*p_it)["type"];
-    if (p_type.is_string() && p_type.get<std::string>() == "binary")
-    {
-      const auto& p_value = (*p_it)["value"];
-      if (p_value.is_number_integer())
-      {
-        if (p_value.is_number_integer() && p_value.get<uint64_t>() > 0)
-          priority = rmf_task::BinaryPriorityScheme::make_high_priority();
-      }
-
-      priority = rmf_task::BinaryPriorityScheme::make_low_priority();
-    }
-
-    if (!priority)
-    {
-      errors.push_back(
-        make_error_str(
-          4, "Unsupported type",
-          "Fleet [" + name + "] does not support priority request: " + p_it->dump()
-          + "\nDefaulting to low binary priority."));
-    }
-  }
-
-  if (!priority)
-    priority = rmf_task::BinaryPriorityScheme::make_low_priority();
-
-  const auto new_request =
-    std::make_shared<rmf_task::Request>(
-      task_id,
-      earliest_start_time,
-      priority,
-      deserialized_task.description);
 
   // TODO(MXG): Make the task planning asynchronous. The worker should schedule
   // a job to perform the planning which should then spawn a job to save the
@@ -1018,11 +1027,13 @@ auto FleetUpdateHandle::Implementation::aggregate_expectations() const
 //==============================================================================
 auto FleetUpdateHandle::Implementation::allocate_tasks(
   rmf_task::ConstRequestPtr new_request,
-  std::vector<std::string>* errors) const -> std::optional<Assignments>
+  std::vector<std::string>* errors,
+  std::optional<Expectations> expectations = std::nullopt) const -> std::optional<Assignments>
 {
   // Collate robot states, constraints and combine new requestptr with
   // requestptr of non-charging tasks in task manager queues
-  auto expect = aggregate_expectations();
+  auto expect = expectations.has_value() ? expectations.value() :
+    aggregate_expectations();
   std::string id = "";
 
   if (new_request)
@@ -1271,7 +1282,10 @@ void FleetUpdateHandle::add_robot(
           }
 
           fleet->_pimpl->task_managers.insert({context,
-            TaskManager::make(context, fleet->_pimpl->broadcast_client)});
+            TaskManager::make(
+              context,
+              fleet->_pimpl->broadcast_client,
+              std::weak_ptr<FleetUpdateHandle>(fleet))});
         });
     });
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -167,14 +167,14 @@ std::string FleetUpdateHandle::Implementation::make_error_str(
 std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
   const std::string& task_id,
   const nlohmann::json& request_msg,
-  std::vector<std::string>& errors)
+  std::vector<std::string>* errors) const
 {
   const auto& category = request_msg["category"].get<std::string>();
 
   const auto task_deser_it = deserialization.task->handlers.find(category);
   if (task_deser_it == deserialization.task->handlers.end())
   {
-    errors.push_back(make_error_str(
+    errors->push_back(make_error_str(
       4, "Unsupported type",
       "Fleet [" + name + "] does not support task category ["
       + category + "]"));
@@ -198,7 +198,7 @@ std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
       e.what(),
       description_msg.dump(2, ' ').c_str());
 
-    errors.push_back(make_error_str(5, "Invalid request format", e.what()));
+    errors->push_back(make_error_str(5, "Invalid request format", e.what()));
     return nullptr;
   }
 
@@ -207,7 +207,7 @@ std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
 
   if (!deserialized_task.description)
   {
-    errors = deserialized_task.errors;
+    *errors = deserialized_task.errors;
     return nullptr;
   }
 
@@ -240,7 +240,7 @@ std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
 
     if (!priority)
     {
-      errors.push_back(
+      errors->push_back(
         make_error_str(
           4, "Unsupported type",
           "Fleet [" + name + "] does not support priority request: " + p_it->dump()
@@ -326,7 +326,7 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
   }
 
   std::vector<std::string> errors = {};
-  const auto new_request = convert(task_id, request_msg, errors);
+  const auto new_request = convert(task_id, request_msg, &errors);
   if (!new_request)
   {
     return respond(
@@ -1028,7 +1028,7 @@ auto FleetUpdateHandle::Implementation::aggregate_expectations() const
 auto FleetUpdateHandle::Implementation::allocate_tasks(
   rmf_task::ConstRequestPtr new_request,
   std::vector<std::string>* errors,
-  std::optional<Expectations> expectations = std::nullopt) const -> std::optional<Assignments>
+  std::optional<Expectations> expectations) const -> std::optional<Assignments>
 {
   // Collate robot states, constraints and combine new requestptr with
   // requestptr of non-charging tasks in task manager queues

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -504,7 +504,8 @@ public:
   /// new request and while optionally ignoring a specific request.
   std::optional<Assignments> allocate_tasks(
     rmf_task::ConstRequestPtr new_request = nullptr,
-    std::vector<std::string>* errors = nullptr) const;
+    std::vector<std::string>* errors = nullptr,
+    std::optional<Expectations> expectations = std::nullopt) const;
 
   /// Helper function to check if assignments are valid. An assignment set is
   /// invalid if one of the assignments has already begun execution.
@@ -532,7 +533,7 @@ public:
   std::shared_ptr<rmf_task::Request> convert(
     const std::string& task_id,
     const nlohmann::json& request_msg,
-    std::vector<std::string>& errors);
+    std::vector<std::string>* errors) const;
 };
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -525,6 +525,14 @@ public:
   void update_fleet_state() const;
 
   void add_standard_tasks();
+
+  std::string make_error_str(
+    uint64_t code, std::string category, std::string detail) const;
+
+  std::shared_ptr<rmf_task::Request> convert(
+    const std::string& task_id,
+    const nlohmann::json& request_msg,
+    std::vector<std::string>& errors);
 };
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -533,7 +533,7 @@ public:
   std::shared_ptr<rmf_task::Request> convert(
     const std::string& task_id,
     const nlohmann::json& request_msg,
-    std::vector<std::string>* errors) const;
+    std::vector<std::string>& errors) const;
 };
 
 } // namespace agv


### PR DESCRIPTION
This PR introduces the ability to directly assign a task to a robot in a fleet, thereby bypassing the bidding system. Users can publish an `rmf_task_msgs::msg::ApiRequest`  msg with `json_msg` field following the schema introduced in https://github.com/open-rmf/rmf_api_msgs/pull/15 over the topic `/task_api_requests`

The implementation adds a `_direct_queue` in `TaskManager` which maintains the assignments for direct tasks. One point about this appraoch:
* Maintaining `_queue` and `_direct_queue` introduces the complexity of checking which queue to process in several functions including `_begin_next_task()`, `expected_finish_state()`, `remove_task_from_queue()`. I think things could be a lot more elegant if we just maintained a single `_queue`. We could do this if the Task Planner was capable of generating assignments where direct tasks are assigned before dispatched ones. One way of doing this would be to introduce a new priority scheme which also incorporates the existing binary scheme. Direct tasks would be automatically assigned a "high" priority such that they are assigned before dispatched ones. And the binary high/low priority could till apply within the dispatched and assigned tasks. Another advantage of this would be that the planner's time segmentation would allow for a natural distribution of the dispatch and direct tasks. So there wouldn't be a confusion on whether to begin a dispatch or direct task next.


But right now, I'm trying to make things work with the separate queues and have the following questions:
    1) Initially I thought the direct assignments should be in order that they were received. But if that is the case, it could be troublesome if a user submitted a direct task to begin one hour from now first and then another direct task to begin immediately. But given this sequence, the first task will be at the top of the queue and the second one will only begin after this one completes- which is unproductive. Hence, i'm currently replanning with all the task in `_direct_queue` as this would naturally time segment the assignments. 
    2) Decision on which task to begin: Say we have tasks queued in both `_queue` and `_direct_queue`. The top of the `direct_queue` has a deployment time in the future while the one in `_queue` is ready to be deployed. Should we start the one in `_queue` or always complete all the `_direct_queue` tasks before commencing the dispatch ones? This could happen in a scenario where the fleet has already been awarded a dispatch task (which is now queued) and then receives a direct task request after. 
    
A lot of these problems can be solved trivially if we have a configuration option for the fleet adapter to respond to either `dispatch` or `direct` task requests but not both. Mixing the two capabilities is tricky as the behaviour may favour one deployment scenario but not the other.

Please let me know your thoughts @mxgrey  @cnboonhan 