### PR TITLE
Trigger stop callback during interrupt

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -47,6 +47,11 @@ public:
   /// latest position of the robot before calling this function.
   void interrupted();
 
+  /// Store the stop callback in RobotContext to command the robot to stop when
+  /// interrupt is triggered
+  void set_stop_callback(
+    std::function<void(std::string)> stop);
+
   /// Update the current position of the robot by specifying the waypoint that
   /// the robot is on and its orientation.
   void update_position(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -180,6 +180,7 @@ RobotContext::observe_interrupt() const
 //==============================================================================
 void RobotContext::trigger_interrupt()
 {
+  this->_stop(this->name());
   _interrupt_publisher.get_subscriber().on_next(Empty{});
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -173,6 +173,7 @@ private:
 
   std::weak_ptr<RobotCommandHandle> _command_handle;
   std::vector<rmf_traffic::agv::Plan::Start> _location;
+  std::function<void(std::string)> _stop;
   rmf_traffic::schedule::Participant _itinerary;
   std::shared_ptr<const Snappable> _schedule;
   std::shared_ptr<std::shared_ptr<const rmf_traffic::agv::Planner>> _planner;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -58,6 +58,16 @@ void RobotUpdateHandle::interrupted()
 }
 
 //==============================================================================
+void RobotUpdateHandle::set_stop_callback(
+  std::function<void(std::string)> stop)
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->_stop = stop;
+  }
+}
+
+//==============================================================================
 void RobotUpdateHandle::update_position(
   std::size_t waypoint,
   double orientation)

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -140,7 +140,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
       return self.unstable().get_participant();
     },
     py::return_value_policy::reference_internal,
-    "Experimental API to access the schedule participant");
+    "Experimental API to access the schedule participant")
+  .def("set_stop_callback",
+    &agv::RobotUpdateHandle::set_stop_callback,
+    py::arg("stop"));
 
   // FLEETUPDATE HANDLE ======================================================
   py::class_<agv::FleetUpdateHandle,


### PR DESCRIPTION
This PR aims to avoid backtracking when a new path is provided for robots after replanning relevant to #163. THe RobotUpdateHandle accepts a stop callback and stores it in RobotContext. The function gets called when inside `RobotContext::trigger_interrupt()`, stopping the robot so that its current position is more accurate for replanning waypoints. 

Currently only used to store the stop callback in demo fleet adapter.