### PR TITLE
remove unnecessary copy of desc in pybind

### DIFF
--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -279,14 +279,12 @@ PYBIND11_MODULE(rmf_adapter, m) {
           [consider_pickup = std::move(consider_pickup)](
             const nlohmann::json &description, Confirmation &confirm)
           {
-            nlohmann::json desc = description;
-            confirm = consider_pickup(desc); // confirm is returned by user
+            confirm = consider_pickup(description); // confirm is returned by user
           },
           [consider_dropoff = std::move(consider_dropoff)](
             const nlohmann::json &description, Confirmation &confirm)
           {
-            nlohmann::json desc = description;
-            confirm = consider_dropoff(desc); // confirm is returned by user
+            confirm = consider_dropoff(description); // confirm is returned by user
           }
         );
     },
@@ -300,8 +298,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
           [consider = std::move(consider)](
             const nlohmann::json &description, Confirmation &confirm)
           {
-            nlohmann::json desc = description;
-            confirm = consider(desc); // confirm is returned by user
+            confirm = consider(description); // confirm is returned by user
           }
         );
     },
@@ -314,8 +311,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
           [consider = std::move(consider)](
             const nlohmann::json &description, Confirmation &confirm)
           {
-            nlohmann::json desc = description;
-            confirm = consider(desc); // confirm is returned by user
+ //           nlohmann::json desc = description;
+            confirm = consider(description); // confirm is returned by user
           }
         );
     },
@@ -328,8 +325,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
           [consider = std::move(consider)](
             const nlohmann::json &description, Confirmation &confirm)
           {
-            nlohmann::json desc = description;
-            confirm = consider(desc); // confirm is returned by user
+            confirm = consider(description); // confirm is returned by user
           }
         );
     },
@@ -344,8 +340,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
           [consider = std::move(consider)](
             const nlohmann::json &description, Confirmation &confirm)
           {
-            nlohmann::json desc = description;
-            confirm = consider(desc); // confirm is returned by user
+            confirm = consider(description); // confirm is returned by user
           }
         );
     },

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -311,7 +311,6 @@ PYBIND11_MODULE(rmf_adapter, m) {
           [consider = std::move(consider)](
             const nlohmann::json &description, Confirmation &confirm)
           {
- //           nlohmann::json desc = description;
             confirm = consider(description); // confirm is returned by user
           }
         );


### PR DESCRIPTION
in `rmf_fleet_adapter_python`, remove unnecessary copies of `nlohmann::json desc` objects.