### PR TITLE
Feature for reporting issues and logs related to robots

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -204,6 +204,63 @@ public:
     std::vector<std::string> labels,
     std::function<void()> robot_is_interrupted);
 
+  enum class Tier
+  {
+    /// General status information, does not require special attention
+    Info,
+
+    /// Something unusual that might require attention
+    Warning,
+
+    /// A critical failure that requires immediate operator attention
+    Error
+  };
+
+  /// An object to maintain an issue that is happening with the robot. When this
+  /// object is destroyed without calling resolve(), the issue will be
+  /// "dropped", which issues a warning to the log.
+  class IssueTicket
+  {
+  public:
+
+    /// Indicate that the issue has been resolved. The provided message will be
+    /// logged for this robot and the issue will be removed from the robot
+    /// state.
+    void resolve(nlohmann::json msg);
+
+    class Implementation;
+  private:
+    IssueTicket();
+    rmf_utils::unique_impl_ptr<Implementation> _pimpl;
+  };
+
+  /// Create a new issue for the robot.
+  ///
+  /// \param[in] tier
+  ///   The severity of the issue
+  ///
+  /// \param[in] category
+  ///   A brief category to describe the issue
+  ///
+  /// \param[in] detail
+  ///   Full details of the issue that might be relevant to an operator or
+  ///   logging system.
+  ///
+  /// \return A ticket for this issue
+  IssueTicket create_issue(
+    Tier tier, std::string category, nlohmann::json detail);
+
+  // TODO(MXG): Should we offer a "clear_all_issues" function?
+
+  /// Add a log entry with Info severity
+  void log_info(std::string text);
+
+  /// Add a log entry with Warning severity
+  void log_warning(std::string text);
+
+  /// Add a log entry with Error severity
+  void log_error(std::string text);
+
   class Implementation;
 
   /// This API is experimental and will not be supported in the future. Users

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/BroadcastClient.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/BroadcastClient.cpp
@@ -132,7 +132,8 @@ std::shared_ptr<BroadcastClient> BroadcastClient::make(
           {
             RCLCPP_ERROR(
               impl.node->get_logger(),
-              "BroadcastClient unable to publish message");
+              "BroadcastClient unable to publish message: %s",
+              ec.message().c_str());
             // TODO(YV): Check if we should re-connect to server
             break;
           }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/BroadcastClient.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/BroadcastClient.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<BroadcastClient> BroadcastClient::make(
       const auto fleet = c->_fleet_handle.lock();
       if (!fleet)
         return;
-      const auto impl = agv::FleetUpdateHandle::Implementation::get(*fleet);
+      const auto& impl = agv::FleetUpdateHandle::Implementation::get(*fleet);
       for (const auto& [conext, mgr] : impl.task_managers)
       {
         // Publish all task logs to the server
@@ -83,7 +83,7 @@ std::shared_ptr<BroadcastClient> BroadcastClient::make(
         {
           continue;
         }
-        const auto impl = agv::FleetUpdateHandle::Implementation::get(*fleet);
+        const auto& impl = agv::FleetUpdateHandle::Implementation::get(*fleet);
 
         // Try to connect to the server if we are not connected yet
         if (!c->_connected)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Reporting.hpp"
+
+namespace rmf_fleet_adapter {
+
+//==============================================================================
+void Reporting::Ticket::resolve(nlohmann::json msg)
+{
+  const auto upstream = _upstream.lock();
+  if (!upstream)
+    return;
+
+  if (!_issue)
+    return;
+
+  upstream->worker.schedule(
+    [
+      w = upstream->weak_from_this(),
+      msg = std::move(msg),
+      issue = std::move(_issue)
+    ](const auto&)
+    {
+      const auto upstream = w.lock();
+      if (!upstream)
+        return;
+
+      if (upstream->open_issues.erase(issue) > 0)
+        upstream->log.info("Resolved issue [" + issue->category + "]: " + msg.dump());
+    });
+
+  _issue = nullptr;
+}
+
+//==============================================================================
+Reporting::Ticket::~Ticket()
+{
+  const auto upstream = _upstream.lock();
+  if (!upstream)
+    return;
+
+  if (!_issue)
+    return;
+
+  upstream->worker.schedule(
+    [
+      w = upstream->weak_from_this(),
+      issue = std::move(_issue)
+    ](const auto&)
+    {
+      const auto upstream = w.lock();
+      if (!upstream)
+        return;
+
+      if (upstream->open_issues.erase(issue) > 0)
+        upstream->log.warn("Dropped issue [" + issue->category + "]");
+    });
+}
+
+//==============================================================================
+Reporting::Ticket::Ticket(IssuePtr issue, std::shared_ptr<Upstream> upstream)
+: _issue(std::move(issue)),
+  _upstream(std::move(upstream))
+{
+  // Do nothing
+}
+
+//==============================================================================
+Reporting::Reporting()
+: _data(std::make_shared<Upstream>())
+{
+  // Do nothing
+}
+
+//==============================================================================
+Reporting::Ticket Reporting::create_issue(
+  std::string category,
+  nlohmann::json detail)
+{
+  auto issue = std::make_shared<Issue>(
+    Issue{std::move(category), std::move(detail)});
+
+  _data->log.warn("Opened issue [" + issue->category + "]: " + detail.dump());
+
+  _data->open_issues.insert(issue);
+  return Ticket(issue, _data);
+}
+
+//==============================================================================
+auto Reporting::open_issues() const -> const std::unordered_set<IssuePtr>&
+{
+  return _data->open_issues;
+}
+
+//==============================================================================
+rmf_task::Log& Reporting::log()
+{
+  return _data->log;
+}
+
+//==============================================================================
+const rmf_task::Log& Reporting::log() const
+{
+  return _data->log;
+}
+
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.cpp
@@ -117,7 +117,7 @@ std::unique_ptr<Reporting::Ticket> Reporting::create_issue(
 
   std::lock_guard<std::mutex> lock(_data->mutex);
   _data->log.push(
-    tier, "Opened issue [" + issue->category + "]: " + detail.dump());
+    tier, "Opened issue [" + issue->category + "]: " + issue->detail.dump());
 
   _data->open_issues.insert(issue);
   return std::unique_ptr<Ticket>(new Ticket(issue, _data));

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.hpp
@@ -47,6 +47,7 @@ public:
     OpenIssues open_issues;
     rmf_task::Log log;
     rxcpp::schedulers::worker worker;
+    std::mutex mutex;
   };
 
   class Ticket
@@ -70,7 +71,12 @@ public:
 
   Reporting();
 
-  Ticket create_issue(std::string category, nlohmann::json detail);
+  std::mutex& mutex() const;
+
+  Ticket create_issue(
+    rmf_task::Log::Tier tier,
+    std::string category,
+    nlohmann::json detail);
 
   const std::unordered_set<IssuePtr>& open_issues() const;
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.hpp
@@ -44,6 +44,8 @@ public:
 
   struct Upstream : public std::enable_shared_from_this<Upstream>
   {
+    Upstream(rxcpp::schedulers::worker worker_);
+
     OpenIssues open_issues;
     rmf_task::Log log;
     rxcpp::schedulers::worker worker;
@@ -69,11 +71,11 @@ public:
     std::weak_ptr<Upstream> _upstream;
   };
 
-  Reporting();
+  Reporting(rxcpp::schedulers::worker worker);
 
   std::mutex& mutex() const;
 
-  Ticket create_issue(
+  std::unique_ptr<Ticket> create_issue(
     rmf_task::Log::Tier tier,
     std::string category,
     nlohmann::json detail);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/Reporting.hpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__REPORTING_HPP
+#define SRC__RMF_FLEET_ADAPTER__REPORTING_HPP
+
+#include <rmf_task/Log.hpp>
+#include <nlohmann/json.hpp>
+
+#include <rxcpp/rx-includes.hpp>
+
+#include <memory>
+#include <unordered_set>
+
+namespace rmf_fleet_adapter {
+
+//==============================================================================
+class Reporting
+{
+public:
+
+  struct Issue
+  {
+    std::string category;
+    nlohmann::json detail;
+  };
+
+  using IssuePtr = std::shared_ptr<const Issue>;
+  using OpenIssues = std::unordered_set<IssuePtr>;
+
+  struct Upstream : public std::enable_shared_from_this<Upstream>
+  {
+    OpenIssues open_issues;
+    rmf_task::Log log;
+    rxcpp::schedulers::worker worker;
+  };
+
+  class Ticket
+  {
+  public:
+
+    void resolve(nlohmann::json msg);
+
+    // TODO(MXG): Should it be possible to change the category/detail of the
+    // issue from the ticket?
+
+    ~Ticket();
+
+    friend class Reporting;
+  private:
+    Ticket(IssuePtr issue, std::shared_ptr<Upstream> upstream);
+
+    IssuePtr _issue;
+    std::weak_ptr<Upstream> _upstream;
+  };
+
+  Reporting();
+
+  Ticket create_issue(std::string category, nlohmann::json detail);
+
+  const std::unordered_set<IssuePtr>& open_issues() const;
+
+  rmf_task::Log& log();
+
+  const rmf_task::Log& log() const;
+
+private:
+  std::shared_ptr<Upstream> _data;
+};
+
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__REPORTING_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "TaskManager.hpp"
+#include "log_to_json.hpp"
 
 #include <rmf_task/requests/ChargeBattery.hpp>
 #include <rmf_task/requests/Clean.hpp>
@@ -288,11 +289,6 @@ const std::string& TaskManager::ActiveTask::id() const
 }
 
 namespace {
-//==============================================================================
-std::chrono::milliseconds to_millis(rmf_traffic::Duration duration)
-{
-  return std::chrono::duration_cast<std::chrono::milliseconds>(duration);
-}
 
 //==============================================================================
 std::string status_to_string(rmf_task::Event::Status status)
@@ -325,36 +321,6 @@ std::string status_to_string(rmf_task::Event::Status status)
     default:
       return "uninitialized";
   }
-}
-
-//==============================================================================
-std::string tier_to_string(rmf_task::Log::Entry::Tier tier)
-{
-  using Tier = rmf_task::Log::Entry::Tier;
-  switch (tier)
-  {
-    case Tier::Info:
-      return "info";
-    case Tier::Warning:
-      return "warning";
-    case Tier::Error:
-      return "error";
-    default:
-      return "uninitialized";
-  }
-}
-
-//==============================================================================
-nlohmann::json log_to_json(const rmf_task::Log::Entry& entry)
-{
-  nlohmann::json output;
-  output["seq"] = entry.seq();
-  output["tier"] = tier_to_string(entry.tier());
-  output["unix_millis_time"] =
-    to_millis(entry.time().time_since_epoch()).count();
-  output["text"] = entry.text();
-
-  return output;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -25,6 +25,7 @@
 #include "internal_RobotUpdateHandle.hpp"
 #include "RobotContext.hpp"
 
+#include "../log_to_json.hpp"
 #include "../tasks/Delivery.hpp"
 #include "../tasks/Loop.hpp"
 #include "../tasks/Clean.hpp"
@@ -48,6 +49,7 @@
 
 #include <rmf_fleet_adapter/schemas/place.hpp>
 #include <rmf_api_msgs/schemas/task_request.hpp>
+#include <rmf_api_msgs/schemas/fleet_log_update.hpp>
 
 namespace rmf_fleet_adapter {
 namespace agv {
@@ -808,12 +810,21 @@ void FleetUpdateHandle::Implementation::publish_fleet_state_topic() const
 }
 
 //==============================================================================
+void FleetUpdateHandle::Implementation::update_fleet() const
+{
+  update_fleet_state();
+  update_fleet_logs();
+}
+
+//==============================================================================
 void FleetUpdateHandle::Implementation::update_fleet_state() const
 {
   // Publish to API server
   if (broadcast_client)
   {
-    nlohmann::json fleet_state_msg;
+    nlohmann::json fleet_state_update_msg;
+    fleet_state_update_msg["type"] = "fleet_state_update";
+    auto& fleet_state_msg = fleet_state_update_msg["data"];
     fleet_state_msg["name"] = name;
     auto& robots = fleet_state_msg["robots"];
     for (const auto& [context, mgr] : task_managers)
@@ -835,50 +846,109 @@ void FleetUpdateHandle::Implementation::update_fleet_state() const
       location["y"] = location_msg.y;
       location["yaw"] = location_msg.yaw;
 
-      // TODO(YV): json["issues"]
+      const auto& issues = context->reporting().open_issues();
+      auto& issues_msg = json["issues"];
+      issues_msg = std::vector<nlohmann::json>();
+      for (const auto& issue : issues)
+      {
+        nlohmann::json issue_msg;
+        issue_msg["category"] = issue->category;
+        issue_msg["detail"] = issue->detail;
+        issues_msg.push_back(std::move(issue_msg));
+      }
     }
 
-    const auto fleet_schema = rmf_api_msgs::schemas::fleet_state_update;
-    const auto loader =
-      [n = node, s = schema_dictionary](const nlohmann::json_uri& id,
-        nlohmann::json& value)
-      {
-        const auto it = s.find(id.url());
-        if (it == s.end())
-        {
-          RCLCPP_ERROR(
-            n->get_logger(),
-            "url: %s not found in schema dictionary", id.url().c_str());
-          return;
-        }
-
-        value = it->second;
-      };
-
-    nlohmann::json fleet_state_update_msg;
-    fleet_state_update_msg["type"] = "fleet_state_update";
-    fleet_state_update_msg["data"] = fleet_state_msg;
     try
     {
-      static const nlohmann::json_schema::json_validator
-        validator(fleet_schema, loader);
+      static const auto validator =
+        make_validator(rmf_api_msgs::schemas::fleet_state_update);
 
       validator.validate(fleet_state_update_msg);
+      broadcast_client->publish(fleet_state_update_msg);
     }
     catch (const std::exception& e)
     {
       RCLCPP_ERROR(
         node->get_logger(),
-        "Unable to publish fleet state json message: %s",
-        e.what());
-      return;
+        "Malformed outgoing fleet state json message: %s\nMessage:\n%s",
+        e.what(),
+        fleet_state_update_msg.dump(2).c_str());
     }
-
-    broadcast_client->publish(fleet_state_update_msg);
   }
 }
 
+//==============================================================================
+void FleetUpdateHandle::Implementation::update_fleet_logs() const
+{
+  if (broadcast_client)
+  {
+    nlohmann::json fleet_log_update_msg;
+    fleet_log_update_msg["type"] = "fleet_log_update";
+    auto& fleet_log_msg = fleet_log_update_msg["data"];
+    fleet_log_msg["name"] = name;
+    // TODO(MXG): fleet_log_msg["log"]
+    auto& robots_msg = fleet_log_msg["robots"];
+    for (const auto& [context, _] : task_managers)
+    {
+      auto& robot_log_msg_array = robots_msg[context->name()];
+      robot_log_msg_array = std::vector<nlohmann::json>();
+
+      const auto& log = context->reporting().log();
+      for (const auto& entry : log_reader.read(log.view()))
+        robot_log_msg_array.push_back(log_to_json(entry));
+    }
+
+    if (robots_msg.empty())
+    {
+      // No new logs to report
+      return;
+    }
+
+    try
+    {
+      static const auto validator =
+        make_validator(rmf_api_msgs::schemas::fleet_log_update);
+
+      validator.validate(fleet_log_update_msg);
+      broadcast_client->publish(fleet_log_update_msg);
+    }
+    catch (const std::exception& e)
+    {
+      RCLCPP_ERROR(
+        node->get_logger(),
+        "Malformed outgoing fleet log json message: %s\nMessage:\n%s",
+        e.what(),
+        fleet_log_update_msg.dump(2).c_str());
+    }
+  }
+}
+
+//==============================================================================
+nlohmann::json_schema::json_validator
+FleetUpdateHandle::Implementation::make_validator(
+  const nlohmann::json& schema) const
+{
+  const auto loader =
+    [n = node, s = schema_dictionary](const nlohmann::json_uri& id,
+      nlohmann::json& value)
+    {
+      const auto it = s.find(id.url());
+      if (it == s.end())
+      {
+        RCLCPP_ERROR(
+          n->get_logger(),
+          "url: %s not found in schema dictionary", id.url().c_str());
+        return;
+      }
+
+      value = it->second;
+    };
+
+  return nlohmann::json_schema::json_validator(schema, loader);
+}
+
 namespace {
+//==============================================================================
 PlaceDeserializer make_place_deserializer(
   std::shared_ptr<const std::shared_ptr<const rmf_traffic::agv::Planner>>
   planner)
@@ -1702,7 +1772,7 @@ FleetUpdateHandle& FleetUpdateHandle::fleet_state_update_period(
       [me = weak_from_this()]
       {
         if (const auto self = me.lock())
-          self->_pimpl->update_fleet_state();
+          self->_pimpl->update_fleet();
       });
   }
   else

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -846,6 +846,7 @@ void FleetUpdateHandle::Implementation::update_fleet_state() const
       location["y"] = location_msg.y;
       location["yaw"] = location_msg.yaw;
 
+      std::lock_guard<std::mutex> lock(context->reporting().mutex());
       const auto& issues = context->reporting().open_issues();
       auto& issues_msg = json["issues"];
       issues_msg = std::vector<nlohmann::json>();
@@ -892,6 +893,7 @@ void FleetUpdateHandle::Implementation::update_fleet_logs() const
     {
       auto robot_log_msg_array = std::vector<nlohmann::json>();
 
+      std::lock_guard<std::mutex> lock(context->reporting().mutex());
       const auto& log = context->reporting().log();
       for (const auto& entry : log_reader.read(log.view()))
         robot_log_msg_array.push_back(log_to_json(entry));

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -890,12 +890,14 @@ void FleetUpdateHandle::Implementation::update_fleet_logs() const
     auto& robots_msg = fleet_log_msg["robots"];
     for (const auto& [context, _] : task_managers)
     {
-      auto& robot_log_msg_array = robots_msg[context->name()];
-      robot_log_msg_array = std::vector<nlohmann::json>();
+      auto robot_log_msg_array = std::vector<nlohmann::json>();
 
       const auto& log = context->reporting().log();
       for (const auto& entry : log_reader.read(log.view()))
         robot_log_msg_array.push_back(log_to_json(entry));
+
+      if (!robot_log_msg_array.empty())
+        robots_msg[context->name()] = std::move(robot_log_msg_array);
     }
 
     if (robots_msg.empty())

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -49,7 +49,6 @@
 
 #include <rmf_fleet_adapter/schemas/place.hpp>
 #include <rmf_api_msgs/schemas/task_request.hpp>
-#include <rmf_api_msgs/schemas/fleet_log_update.hpp>
 
 namespace rmf_fleet_adapter {
 namespace agv {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -424,6 +424,18 @@ std::shared_ptr<TaskManager> RobotContext::task_manager()
 }
 
 //==============================================================================
+Reporting& RobotContext::reporting()
+{
+  return _reporting;
+}
+
+//==============================================================================
+const Reporting& RobotContext::reporting() const
+{
+  return _reporting;
+}
+
+//==============================================================================
 RobotContext::RobotContext(
   std::shared_ptr<RobotCommandHandle> command_handle,
   std::vector<rmf_traffic::agv::Plan::Start> _initial_location,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -465,7 +465,8 @@ RobotContext::RobotContext(
   _charger_wp(state.dedicated_charging_waypoint().value()),
   _current_task_end_state(state),
   _current_task_id(std::nullopt),
-  _task_planner(std::move(task_planner))
+  _task_planner(std::move(task_planner)),
+  _reporting(_worker)
 {
   _profile = std::make_shared<rmf_traffic::Profile>(
     _itinerary.description().profile());

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -1,5 +1,22 @@
-#ifndef SRC__RMF_FLEET_ADAPTER__ROBOTCONTEXT_HPP
-#define SRC__RMF_FLEET_ADAPTER__ROBOTCONTEXT_HPP
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__AGV__ROBOTCONTEXT_HPP
+#define SRC__RMF_FLEET_ADAPTER__AGV__ROBOTCONTEXT_HPP
 
 #include <rmf_fleet_adapter/agv/RobotCommandHandle.hpp>
 #include <rmf_fleet_adapter/agv/RobotUpdateHandle.hpp>
@@ -22,6 +39,7 @@
 #include <rxcpp/rx-observable.hpp>
 
 #include "Node.hpp"
+#include "../Reporting.hpp"
 
 namespace rmf_fleet_adapter {
 
@@ -202,6 +220,10 @@ public:
   /// Get the task manager for this robot, if it exists.
   std::shared_ptr<TaskManager> task_manager();
 
+  Reporting& reporting();
+
+  const Reporting& reporting() const;
+
 private:
   friend class FleetUpdateHandle;
   friend class RobotUpdateHandle;
@@ -264,6 +286,7 @@ private:
   uint32_t _current_mode;
 
   RobotUpdateHandle::ActionExecutor _action_executor;
+  Reporting _reporting;
 };
 
 using RobotContextPtr = std::shared_ptr<RobotContext>;
@@ -278,4 +301,4 @@ struct GetContext
 } // namespace agv
 } // namespace rmf_fleet_adapter
 
-#endif // SRC__RMF_FLEET_ADAPTER__ROBOTCONTEXT_HPP
+#endif // SRC__RMF_FLEET_ADAPTER__AGV__ROBOTCONTEXT_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -373,9 +373,9 @@ class RobotUpdateHandle::IssueTicket::Implementation
 {
 public:
 
-  Reporting::Ticket ticket;
+  std::unique_ptr<Reporting::Ticket> ticket;
 
-  static IssueTicket make(Reporting::Ticket ticket)
+  static IssueTicket make(std::unique_ptr<Reporting::Ticket> ticket)
   {
     IssueTicket output;
     output._pimpl = rmf_utils::make_unique_impl<Implementation>(
@@ -387,7 +387,7 @@ public:
 //==============================================================================
 void RobotUpdateHandle::IssueTicket::resolve(nlohmann::json msg)
 {
-  _pimpl->ticket.resolve(std::move(msg));
+  _pimpl->ticket->resolve(std::move(msg));
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -209,6 +209,32 @@ void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 }
 
 //==============================================================================
+RobotUpdateHandle& RobotUpdateHandle::maximum_delay(
+  rmf_utils::optional<rmf_traffic::Duration> value)
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->worker().schedule(
+      [context, value](const auto&)
+      {
+        context->maximum_delay(value);
+      });
+  }
+
+  return *this;
+}
+
+//==============================================================================
+rmf_utils::optional<rmf_traffic::Duration>
+RobotUpdateHandle::maximum_delay() const
+{
+  if (const auto context = _pimpl->get_context())
+    return context->maximum_delay();
+
+  return rmf_utils::nullopt;
+}
+
+//==============================================================================
 void RobotUpdateHandle::set_action_executor(
   RobotUpdateHandle::ActionExecutor action_executor)
 {
@@ -343,29 +369,100 @@ auto RobotUpdateHandle::interrupt(
 }
 
 //==============================================================================
-RobotUpdateHandle& RobotUpdateHandle::maximum_delay(
-  rmf_utils::optional<rmf_traffic::Duration> value)
+class RobotUpdateHandle::IssueTicket::Implementation
 {
-  if (const auto context = _pimpl->get_context())
-  {
-    context->worker().schedule(
-      [context, value](const auto&)
-      {
-        context->maximum_delay(value);
-      });
-  }
+public:
 
-  return *this;
+  Reporting::Ticket ticket;
+
+  static IssueTicket make(Reporting::Ticket ticket)
+  {
+    IssueTicket output;
+    output._pimpl = rmf_utils::make_unique_impl<Implementation>(
+      Implementation{std::move(ticket)});
+    return output;
+  }
+};
+
+//==============================================================================
+void RobotUpdateHandle::IssueTicket::resolve(nlohmann::json msg)
+{
+  _pimpl->ticket.resolve(std::move(msg));
 }
 
 //==============================================================================
-rmf_utils::optional<rmf_traffic::Duration>
-RobotUpdateHandle::maximum_delay() const
+RobotUpdateHandle::IssueTicket::IssueTicket()
 {
-  if (const auto context = _pimpl->get_context())
-    return context->maximum_delay();
+  // Do nothing
+}
 
-  return rmf_utils::nullopt;
+//==============================================================================
+auto RobotUpdateHandle::create_issue(
+  Tier tier, std::string category, nlohmann::json detail) -> IssueTicket
+{
+  const auto context = _pimpl->get_context();
+  if (!context)
+  {
+    // *INDENT-OFF*
+    throw std::runtime_error(
+      "[RobotUpdateHandle::create_issue] Robot context is unavailable.");
+    // *INDENT-ON*
+  }
+
+  auto inner_tier = [](Tier tier) -> rmf_task::Log::Tier
+    {
+      switch (tier)
+      {
+        case Tier::Info: return rmf_task::Log::Tier::Info;
+        case Tier::Warning: return rmf_task::Log::Tier::Warning;
+        case Tier::Error: return rmf_task::Log::Tier::Error;
+        default: return rmf_task::Log::Tier::Uninitialized;
+      }
+    }(tier);
+
+  auto ticket = context->reporting()
+    .create_issue(inner_tier, std::move(category), std::move(detail));
+
+  return RobotUpdateHandle::IssueTicket::Implementation
+    ::make(std::move(ticket));
+}
+
+//==============================================================================
+void RobotUpdateHandle::log_info(std::string text)
+{
+  const auto context = _pimpl->get_context();
+
+  // Should we throw an exception when the context is gone?
+  if (!context)
+    return;
+
+  auto& report = context->reporting();
+  std::lock_guard<std::mutex> lock(report.mutex());
+  report.log().info(std::move(text));
+}
+
+//==============================================================================
+void RobotUpdateHandle::log_warning(std::string text)
+{
+  const auto context = _pimpl->get_context();
+  if (!context)
+    return;
+
+  auto& report = context->reporting();
+  std::lock_guard<std::mutex> lock(report.mutex());
+  report.log().warn(std::move(text));
+}
+
+//==============================================================================
+void RobotUpdateHandle::log_error(std::string text)
+{
+  const auto context = _pimpl->get_context();
+  if (!context)
+    return;
+
+  auto& report = context->reporting();
+  std::lock_guard<std::mutex> lock(report.mutex());
+  report.log().error(std::move(text));
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -418,7 +418,7 @@ auto RobotUpdateHandle::create_issue(
         case Tier::Error: return rmf_task::Log::Tier::Error;
         default: return rmf_task::Log::Tier::Uninitialized;
       }
-    }(tier);
+    } (tier);
 
   auto ticket = context->reporting()
     .create_issue(inner_tier, std::move(category), std::move(detail));

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -61,6 +61,9 @@
 #include <rmf_api_msgs/schemas/fleet_state.hpp>
 #include <rmf_api_msgs/schemas/robot_state.hpp>
 #include <rmf_api_msgs/schemas/location_2D.hpp>
+#include <rmf_api_msgs/schemas/fleet_log_update.hpp>
+#include <rmf_api_msgs/schemas/fleet_log.hpp>
+#include <rmf_api_msgs/schemas/log_entry.hpp>
 
 #include <rmf_fleet_adapter/schemas/event_description__perform_action.hpp>
 
@@ -382,18 +385,20 @@ public:
     }
 
     // Initialize schema dictionary
-    auto schema = rmf_api_msgs::schemas::fleet_state_update;
-    nlohmann::json_uri json_uri = nlohmann::json_uri{schema["$id"]};
-    handle->_pimpl->schema_dictionary.insert({json_uri.url(), schema});
-    schema = rmf_api_msgs::schemas::fleet_state;
-    json_uri = nlohmann::json_uri{schema["$id"]};
-    handle->_pimpl->schema_dictionary.insert({json_uri.url(), schema});
-    schema = rmf_api_msgs::schemas::robot_state;
-    json_uri = nlohmann::json_uri{schema["$id"]};
-    handle->_pimpl->schema_dictionary.insert({json_uri.url(), schema});
-    schema = rmf_api_msgs::schemas::location_2D;
-    json_uri = nlohmann::json_uri{schema["$id"]};
-    handle->_pimpl->schema_dictionary.insert({json_uri.url(), schema});
+    const std::vector<nlohmann::json> schemas = {
+      rmf_api_msgs::schemas::fleet_state_update,
+      rmf_api_msgs::schemas::fleet_state,
+      rmf_api_msgs::schemas::robot_state,
+      rmf_api_msgs::schemas::location_2D,
+      rmf_api_msgs::schemas::fleet_log,
+      rmf_api_msgs::schemas::log_entry
+    };
+
+    for (const auto& schema : schemas)
+    {
+      const auto json_uri = nlohmann::json_uri{schema["$id"]};
+      handle->_pimpl->schema_dictionary.insert({json_uri.url(), schema});
+    }
 
     // Start the BroadcastClient
     if (handle->_pimpl->server_uri.has_value())

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -303,6 +303,8 @@ public:
   using DockSummarySub = rclcpp::Subscription<DockSummary>::SharedPtr;
   DockSummarySub dock_summary_sub = nullptr;
 
+  mutable rmf_task::Log::Reader log_reader = {};
+
   template<typename... Args>
   static std::shared_ptr<FleetUpdateHandle> make(Args&& ... args)
   {
@@ -524,7 +526,13 @@ public:
 
   void publish_fleet_state_topic() const;
 
+  void update_fleet() const;
+
   void update_fleet_state() const;
+  void update_fleet_logs() const;
+
+  nlohmann::json_schema::json_validator make_validator(
+    const nlohmann::json& schema) const;
 
   void add_standard_tasks();
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/log_to_json.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/log_to_json.hpp
@@ -32,9 +32,9 @@ inline std::chrono::milliseconds to_millis(std::chrono::nanoseconds duration)
 }
 
 //==============================================================================
-inline std::string tier_to_string(rmf_task::Log::Entry::Tier tier)
+inline std::string tier_to_string(rmf_task::Log::Tier tier)
 {
-  using Tier = rmf_task::Log::Entry::Tier;
+  using Tier = rmf_task::Log::Tier;
   switch (tier)
   {
     case Tier::Info:

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/log_to_json.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/log_to_json.hpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__LOG_TO_JSON_HPP
+#define SRC__RMF_FLEET_ADAPTER__LOG_TO_JSON_HPP
+
+#include <rmf_task/Log.hpp>
+
+#include <nlohmann/json.hpp>
+#include <chrono>
+
+namespace rmf_fleet_adapter {
+
+//==============================================================================
+inline std::chrono::milliseconds to_millis(std::chrono::nanoseconds duration)
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+}
+
+//==============================================================================
+inline std::string tier_to_string(rmf_task::Log::Entry::Tier tier)
+{
+  using Tier = rmf_task::Log::Entry::Tier;
+  switch (tier)
+  {
+    case Tier::Info:
+      return "info";
+    case Tier::Warning:
+      return "warning";
+    case Tier::Error:
+      return "error";
+    default:
+      return "uninitialized";
+  }
+}
+
+//==============================================================================
+inline nlohmann::json log_to_json(const rmf_task::Log::Entry& entry)
+{
+  nlohmann::json output;
+  output["seq"] = entry.seq();
+  output["tier"] = tier_to_string(entry.tier());
+  output["unix_millis_time"] =
+    to_millis(entry.time().time_since_epoch()).count();
+  output["text"] = entry.text();
+
+  return output;
+}
+
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__LOG_TO_JSON_HPP

--- a/rmf_fleet_adapter_python/scripts/rmf_msg_observer.py
+++ b/rmf_fleet_adapter_python/scripts/rmf_msg_observer.py
@@ -130,6 +130,7 @@ class AsyncRmfMsgObserver:
         # return await asyncio.wrap_future(self.future)
 
     async def __internal_spin(self):
+        print('Beginning websocket.serve')
         async with websockets.serve(
                 self.__msg_handler, self.server_url, self.server_port):
             await self.__check_future()
@@ -167,7 +168,7 @@ def main(argv=sys.argv):
     elif args.task_log:
         msg_type = RmfMsgType.TaskLog
     else:
-        print('Error! No msg_type is selected. select one: \n', 
+        print('Error! No msg_type is selected. select one: \n',
               '  task_state, task_log, fleet_state, fleet_log \n')
         parser.print_help(sys.stderr)
         exit(1)

--- a/rmf_fleet_adapter_python/scripts/test_reporting.py
+++ b/rmf_fleet_adapter_python/scripts/test_reporting.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+
+from concurrent.futures import thread
+import rclpy
+import time
+import json
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+
+import rmf_adapter as adpt
+import rmf_adapter.vehicletraits as traits
+import rmf_adapter.geometry as geometry
+import rmf_adapter.graph as graph
+import rmf_adapter.battery as battery
+import rmf_adapter.plan as plan
+import rmf_adapter.type as Type
+
+from rmf_adapter.robot_update_handle import Tier
+
+import datetime
+import asyncio
+import threading
+from itertools import groupby
+
+from test_utils import MockRobotCommand
+from test_utils import fleet_state_observer_fn
+
+from functools import partial
+
+test_task_id = "patrol.direct.001"  # aka task_id
+map_name = "test_map"
+fleet_name = "test_fleet"
+rmf_server_uri = "ws://localhost:7878"  # random port
+
+start_name = "start_wp"  # 7
+finish_name = "finish_wp"  # 10
+loop_count = 2
+
+def main():
+    # INIT RCL ================================================================
+    rclpy.init()
+
+    try:
+        adpt.init_rclcpp()
+    except RuntimeError:
+        # Continue if it is already initialized
+        pass
+
+    # INIT GRAPH ==============================================================
+    # Copied from test_loop.py
+    test_graph = graph.Graph()
+
+    test_graph.add_waypoint(map_name, [0.0, -10.0])  # 0
+    test_graph.add_waypoint(map_name, [0.0, -5.0])  # 1
+    test_graph.add_waypoint(map_name, [5.0, -5.0]) # 2
+    test_graph.add_waypoint(map_name, [-10.0, 0])  # 3
+    test_graph.add_waypoint(map_name, [-5.0, 0.0])  # 4
+    test_graph.add_waypoint(map_name, [0.0, 0.0])  # 5
+    test_graph.add_waypoint(map_name, [5.0, 0.0])  # 6
+    test_graph.add_waypoint(map_name, [10.0, 0.0])  # 7
+    test_graph.add_waypoint(map_name, [0.0, 5.0])  # 8
+    test_graph.add_waypoint(map_name, [5.0, 5.0]) # 9
+    test_graph.add_waypoint(map_name, [0.0, 10.0]).set_holding_point(
+        True).set_charger(True)  # 10
+
+    test_graph.add_bidir_lane(0, 1)  # 0   1
+    test_graph.add_bidir_lane(1, 2)  # 2   3
+    test_graph.add_bidir_lane(1, 5)  # 4   5
+    test_graph.add_bidir_lane(2, 6)  # 6   7
+    test_graph.add_bidir_lane(3, 4)  # 8   9
+    test_graph.add_bidir_lane(4, 5)  # 10 11
+    test_graph.add_bidir_lane(5, 6)  # 12 13
+    test_graph.add_dock_lane(6, 7, "A")  # 14 15
+    test_graph.add_bidir_lane(5, 8)  # 16 17
+    test_graph.add_bidir_lane(6, 9)  # 18 19
+    test_graph.add_bidir_lane(8, 9)  # 20 21
+    test_graph.add_dock_lane(8, 10, "B")  # 22 23
+
+    test_graph.add_key(start_name, 7)
+    test_graph.add_key(finish_name, 10)
+
+    # INIT FLEET ==============================================================
+    profile = traits.Profile(geometry.make_final_convex_circle(1.0))
+    robot_traits = traits.VehicleTraits(
+        linear=traits.Limits(0.7, 0.3),
+        angular=traits.Limits(1.0, 0.45),
+        profile=profile
+    )
+
+    adapter = adpt.MockAdapter("TestReportingAdapter")
+    fleet = adapter.add_fleet(
+        fleet_name, robot_traits, test_graph, rmf_server_uri
+    )
+
+    # Set fleet battery profile
+    battery_sys = battery.BatterySystem.make(24.0, 40.0, 8.8)
+    mech_sys = battery.MechanicalSystem.make(70.0, 40.0, 0.22)
+    motion_sink = battery.SimpleMotionPowerSink(battery_sys, mech_sys)
+    ambient_power_sys = battery.PowerSystem.make(20.0)
+    ambient_sink = battery.SimpleDevicePowerSink(
+        battery_sys, ambient_power_sys)
+    tool_power_sys = battery.PowerSystem.make(10.0)
+    tool_sink = battery.SimpleDevicePowerSink(battery_sys, tool_power_sys)
+
+    b_success = fleet.set_task_planner_params(
+        battery_sys, motion_sink, ambient_sink, tool_sink, 0.2, 1.0, False)
+
+    assert b_success, "set task planner params failed"
+
+    cmd_node = Node("RobotCommandHandle")
+
+    start = plan.Start(adapter.now(), 0, 0.0)
+
+    def updater_inserter(handle_obj, updater):
+        updater.update_battery_soc(1.0)
+        handle_obj.updater = updater
+
+    robot_cmd = MockRobotCommand(cmd_node, test_graph)
+
+    fleet.add_robot(
+        robot_cmd, "R0", profile, [start], partial(updater_inserter, robot_cmd)
+    )
+
+    fleet.fleet_state_update_period(datetime.timedelta(milliseconds=5))
+
+    # FINAL PREP ==============================================================
+    rclpy_executor = SingleThreadedExecutor()
+    rclpy_executor.add_node(cmd_node)
+
+    # GO! =====================================================================
+    adapter.start()
+
+    fleet_state = None
+    cv_fleet_state = threading.Condition()
+    def update_fleet_state(_, data):
+        nonlocal fleet_state
+        with cv_fleet_state:
+            fleet_state = data
+            cv_fleet_state.notify_all()
+
+    # INIT TASK STATE OBSERVER ==============================================
+    print("spawn observer thread")
+    fut = asyncio.Future()
+    observer_th = threading.Thread(
+        target=fleet_state_observer_fn, args=(update_fleet_state, fut))
+    observer_th.start()
+
+    counter = 0
+    while counter < 10:
+        with cv_fleet_state:
+            if not cv_fleet_state.wait(timeout=10.0):
+                raise RuntimeError('Failed to ever receive a fleet state')
+
+            if fleet_state is None:
+                raise RuntimeError('Failed to receive a fleet state')
+
+            for robot, state in fleet_state['robots'].items():
+                assert robot == 'R0', f'Wrong name of robot: {robot}'
+                assert len(state['issues']) == 0
+
+        counter += 1
+
+    # We successfully found that the robot R0 has no issues!
+
+    first_issue_ticket = robot_cmd.updater.create_issue(
+        Tier.Warning,
+        'Something bad is happening',
+        {
+            'This object': 'has details',
+            'about': ['the', 'bad', 'thing']
+        }
+    )
+
+    counter = 0
+    counter_limit = 1000
+    noticed_the_issue = False
+    while counter < counter_limit:
+        with cv_fleet_state:
+            if not cv_fleet_state.wait(timeout=10.0):
+                raise RuntimeError('Failed to receive a fleet state')
+
+            num_issues = len(fleet_state['robots']['R0']['issues'])
+            if num_issues > 0:
+                if not noticed_the_issue:
+                    print(f'Noticed the first issue:\n{fleet_state["robots"]["R0"]["issues"][0]}')
+                    counter_limit = counter + 50
+                noticed_the_issue = True
+                assert num_issues == 1
+            else:
+                assert not noticed_the_issue, \
+                    'The issue disappeared earlier than it should have'
+
+        counter += 1
+
+    assert noticed_the_issue, 'The first issue was never noticed!'
+
+    second_issue_ticket = robot_cmd.updater.create_issue(
+        Tier.Error,
+        'Something even worse is happening',
+        {
+            'This problem': 'is even worse',
+            'so': {
+                'we': 'labeled it',
+                'as': 'an error'
+            }
+        }
+    )
+
+    counter = 0
+    counter_limit = 1000
+    noticed_both_issues = False
+    while counter < counter_limit:
+        with cv_fleet_state:
+            if not cv_fleet_state.wait(timeout=10.0):
+                raise RuntimeError('Failed to receive a fleet state')
+
+            num_issues = len(fleet_state['robots']['R0']['issues'])
+            if num_issues > 1:
+                if not noticed_both_issues:
+                    print('Noticed both issues:')
+                    for issue in fleet_state['robots']['R0']['issues']:
+                        print(f'{issue}')
+                    counter_limit = counter + 50
+                noticed_both_issues = True
+            else:
+                assert num_issues == 1
+                assert not noticed_both_issues, \
+                    'One of the issues disappeared earlier than it should have'
+
+        counter += 1
+
+    first_issue_ticket.resolve(
+        {
+            'This': 'issue',
+            'is': ['now', 'fixed']
+        }
+    )
+
+    first_issue_gone = False
+    counter = 0
+    counter_limit = 1000
+    while counter < counter_limit:
+        with cv_fleet_state:
+            if not cv_fleet_state.wait(timeout=10.0):
+                raise RuntimeError('Failed to receive a fleet state')
+
+            num_issues = len(fleet_state['robots']['R0']['issues'])
+            if num_issues < 2:
+                if not first_issue_gone:
+                    print('Noticed that an issue was resolved')
+                    counter_limit = counter + 50
+                first_issue_gone = True
+                assert num_issues == 1
+            else:
+                assert num_issues == 2, f'Wrong number of issues: {num_issues}'
+                assert not first_issue_gone, 'Somehow an issue came back??'
+
+        counter += 1
+
+    assert first_issue_gone
+
+    # Delete the second ticket, causing its issue to get dropped
+    del second_issue_ticket
+
+    both_issues_gone = False
+    counter = 0
+    counter_limit = 1000
+    while counter < counter_limit:
+        with cv_fleet_state:
+            if not cv_fleet_state.wait(timeout=10.0):
+                raise RuntimeError('Failed to receive a fleet state')
+
+            num_issues = len(fleet_state['robots']['R0']['issues'])
+            if num_issues == 0:
+                if not both_issues_gone:
+                    print('Noticed that both issues are gone')
+                    counter_limit = counter + 50
+                both_issues_gone = True
+            else:
+                assert not both_issues_gone, 'Somehow an issue came back??'
+
+        counter += 1
+
+    assert both_issues_gone
+    fut.set_result(True)
+
+if __name__ == "__main__":
+    main()

--- a/rmf_fleet_adapter_python/scripts/test_utils.py
+++ b/rmf_fleet_adapter_python/scripts/test_utils.py
@@ -401,7 +401,6 @@ Thus it is recommended to run this on a different thread,
 """
 def task_state_observer_fn(fut: asyncio.Future, target_id: str):
     print("Starting task state observer")
-    start_time = time.time()
 
     # sample function for user to provide
     def checkstate_callback(msg_type, data):
@@ -416,7 +415,17 @@ def task_state_observer_fn(fut: asyncio.Future, target_id: str):
     observer = AsyncRmfMsgObserver(
         checkstate_callback,
         msg_filters={
-            RmfMsgType.TaskState: []}
+            RmfMsgType.TaskState: []
+        }
     )
     observer.spin(fut)
     print("Exit observer function")
+
+def fleet_state_observer_fn(callback, fut: asyncio.Future):
+    observer = AsyncRmfMsgObserver(
+        callback,
+        msg_filters={
+            RmfMsgType.FleetState: []
+        }
+    )
+    observer.spin(fut)

--- a/rmf_fleet_adapter_python/scripts/test_utils.py
+++ b/rmf_fleet_adapter_python/scripts/test_utils.py
@@ -421,6 +421,6 @@ def task_state_observer_fn(fut: asyncio.Future, target_id: str):
     observer.spin(fut)
     print("Exit observer function")
 
-def update_observer(callback, fut: asyncio.Future, msg_filter):
-    observer = AsyncRmfMsgObserver(callback, msg_filter)
+def update_observer(callback, fut: asyncio.Future, msg_filters):
+    observer = AsyncRmfMsgObserver(callback, msg_filters=msg_filters)
     observer.spin(fut)

--- a/rmf_fleet_adapter_python/scripts/test_utils.py
+++ b/rmf_fleet_adapter_python/scripts/test_utils.py
@@ -421,11 +421,6 @@ def task_state_observer_fn(fut: asyncio.Future, target_id: str):
     observer.spin(fut)
     print("Exit observer function")
 
-def fleet_state_observer_fn(callback, fut: asyncio.Future):
-    observer = AsyncRmfMsgObserver(
-        callback,
-        msg_filters={
-            RmfMsgType.FleetState: []
-        }
-    )
+def update_observer(callback, fut: asyncio.Future, msg_filter):
+    observer = AsyncRmfMsgObserver(callback, msg_filter)
     observer.spin(fut)

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -39,6 +39,7 @@ using ModifiedConsiderRequest =
 
 using ActionExecution = agv::RobotUpdateHandle::ActionExecution;
 using RobotInterruption = agv::RobotUpdateHandle::Interruption;
+using IssueTicket = agv::RobotUpdateHandle::IssueTicket;
 
 void bind_types(py::module&);
 void bind_graph(py::module&);
@@ -163,7 +164,21 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def("interrupt",
     &agv::RobotUpdateHandle::interrupt,
     py::arg("labels"),
-    py::arg("robot_is_interrupted"));
+    py::arg("robot_is_interrupted"))
+  .def("create_issue",
+    &agv::RobotUpdateHandle::create_issue,
+    py::arg("tier"),
+    py::arg("category"),
+    py::arg("detail"))
+  .def("log_info",
+    &agv::RobotUpdateHandle::log_info,
+    py::arg("text"))
+  .def("log_warning",
+    &agv::RobotUpdateHandle::log_warning,
+    py::arg("text"))
+  .def("log_error",
+    &agv::RobotUpdateHandle::log_error,
+    py::arg("text"));
 
   // ACTION EXECUTOR   =======================================================
   auto m_robot_update_handle = m.def_submodule("robot_update_handle");
@@ -182,6 +197,20 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def("resume",
     &RobotInterruption::resume,
     py::arg("labels"));
+
+  // ISSUE TICKET   ==========================================================
+  py::class_<IssueTicket>(
+    m_robot_update_handle, "IssueTicket")
+  .def("resolve",
+    &IssueTicket::resolve,
+    py::arg("msg"));
+
+  // Tier   ==================================================================
+  py::enum_<agv::RobotUpdateHandle::Tier>(
+    m_robot_update_handle, "Tier")
+    .value("Info", agv::RobotUpdateHandle::Tier::Info)
+    .value("Warning", agv::RobotUpdateHandle::Tier::Warning)
+    .value("Error", agv::RobotUpdateHandle::Tier::Error);
 
   // FLEETUPDATE HANDLE ======================================================
   py::class_<agv::FleetUpdateHandle,


### PR DESCRIPTION
The robot state and robot log schemas are already defined to support reporting issues and log events, but that has gone unused until now because we were not exposing a way for system integrators to provide that information.

This PR introduces that API. System integrators can now log robot-specific events and report issues that the robot is experiencing. Each issue has a lifecycle which the system integrator maintains by holding onto an `IssueTicket`. The issue will remain in the robot state until the ticket is marked as resolved or the ticket gets dropped by the system integrator.

This PR depends on https://github.com/open-rmf/rmf_task/pull/59