### PR TITLE
Fix ActionExecutor lifecycle

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -128,12 +128,6 @@ public:
     // Returns false if the Action has been killed or cancelled
     bool okay() const;
 
-    // TODO: Consider giving access to the participant schedule and
-    // traffic negotiation
-
-    // The desctructor will trigger finished() if it has not already been called
-    ~ActionExecution();
-
     class Implementation;
   private:
     ActionExecution();

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -539,14 +539,6 @@ RobotUpdateHandle::ActionExecution::ActionExecution()
   // Do nothing
 }
 
-//==============================================================================
-RobotUpdateHandle::ActionExecution::~ActionExecution()
-{
-  // Automatically trigger finished when this object dies
-  if (_pimpl->data->finished)
-    _pimpl->data->finished();
-}
-
 
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -45,6 +45,12 @@ public:
       remaining_time = remaining_time_;
       okay = true;
     }
+
+    ~Data()
+    {
+      if (finished)
+        finished();
+    }
   };
 
   static ActionExecution make(std::shared_ptr<Data> data)


### PR DESCRIPTION
It occurred to me that move semantics can be quite tricky. We want the action to automatically trigger as finished only when the inner shared `Data` class deconstructs, not when the `ActionExecutor` deconstructs. Otherwise copying and moving the object could cause unintended results.