### PR TITLE
Add API for reporting status of perform_action

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -119,13 +119,27 @@ public:
   class ActionExecution
   {
   public:
-    // Update the amount of time remaining for this action
+    /// Update the amount of time remaining for this action
     void update_remaining_time(rmf_traffic::Duration remaining_time_estimate);
 
-    // Trigger this when the action is finished
+    /// Set task status to underway and optionally log a message (info tier)
+    void underway(std::optional<std::string> text);
+
+    /// Set task status to error and optionally log a message (error tier)
+    void error(std::optional<std::string> text);
+
+    /// Set the task status to delayed and optionally log a message
+    /// (warning tier)
+    void delayed(std::optional<std::string> text);
+
+    /// Set the task status to blocked and optionally log a message
+    /// (warning tier)
+    void blocked(std::optional<std::string> text);
+
+    /// Trigger this when the action is successfully finished
     void finished();
 
-    // Returns false if the Action has been killed or cancelled
+    /// Returns false if the Action has been killed or cancelled
     bool okay() const;
 
     class Implementation;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -518,6 +518,42 @@ void RobotUpdateHandle::ActionExecution::update_remaining_time(
 }
 
 //==============================================================================
+void RobotUpdateHandle::ActionExecution::underway(
+  std::optional<std::string> text)
+{
+  _pimpl->data->state->update_status(rmf_task::Event::Status::Underway);
+  if (text.has_value())
+    _pimpl->data->state->update_log().info(*text);
+}
+
+//==============================================================================
+void RobotUpdateHandle::ActionExecution::error(
+  std::optional<std::string> text)
+{
+  _pimpl->data->state->update_status(rmf_task::Event::Status::Error);
+  if (text.has_value())
+    _pimpl->data->state->update_log().error(*text);
+}
+
+//==============================================================================
+void RobotUpdateHandle::ActionExecution::delayed(
+  std::optional<std::string> text)
+{
+  _pimpl->data->state->update_status(rmf_task::Event::Status::Delayed);
+  if (text.has_value())
+    _pimpl->data->state->update_log().warn(*text);
+}
+
+//==============================================================================
+void RobotUpdateHandle::ActionExecution::blocked(
+  std::optional<std::string> text)
+{
+  _pimpl->data->state->update_status(rmf_task::Event::Status::Blocked);
+  if (text.has_value())
+    _pimpl->data->state->update_log().warn(*text);
+}
+
+//==============================================================================
 void RobotUpdateHandle::ActionExecution::finished()
 {
   if (!_pimpl->data->finished)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -20,6 +20,7 @@
 
 #include "RobotContext.hpp"
 #include <rmf_fleet_adapter/agv/RobotUpdateHandle.hpp>
+#include <rmf_task/events/SimpleEventState.hpp>
 
 namespace rmf_fleet_adapter {
 namespace agv {
@@ -31,17 +32,19 @@ public:
 
   struct Data
   {
-
     std::function<void()> finished;
+    std::shared_ptr<rmf_task::events::SimpleEventState> state;
     std::optional<rmf_traffic::Duration> remaining_time;
     bool okay;
     // TODO: Consider adding a mutex to lock read/write
 
     Data(
       std::function<void()> finished_,
+      std::shared_ptr<rmf_task::events::SimpleEventState> state_,
       std::optional<rmf_traffic::Duration> remaining_time_ = std::nullopt)
     {
       finished = std::move(finished_);
+      state = std::move(state_);
       remaining_time = remaining_time_;
       okay = true;
     }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -253,7 +253,14 @@ void PerformAction::Active::_execute_action()
     return;
   }
 
-  auto data = std::make_shared<ExecutionData>(_finished, std::nullopt);
+  auto finished = [state = _state, cb = _finished]()
+    {
+      state->update_status(Status::Completed);
+      cb();
+    };
+
+  auto data = std::make_shared<ExecutionData>(
+    std::move(finished), _state, std::nullopt);
   _execution_data = data;
 
   auto action_execution =

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -185,11 +185,15 @@ PYBIND11_MODULE(rmf_adapter, m) {
 
   py::class_<ActionExecution>(
     m_robot_update_handle, "ActionExecution")
-  .def("finished", &ActionExecution::finished)
-  .def("okay", &ActionExecution::okay)
   .def("update_remaining_time",
     &ActionExecution::update_remaining_time,
-    py::arg("remaining_time_estimate"));
+    py::arg("remaining_time_estimate"))
+  .def("underway", &ActionExecution::underway, py::arg("text"))
+  .def("error", &ActionExecution::error, py::arg("text"))
+  .def("delayed", &ActionExecution::delayed, py::arg("text"))
+  .def("blocked", &ActionExecution::blocked, py::arg("text"))
+  .def("finished", &ActionExecution::finished)
+  .def("okay", &ActionExecution::okay);
 
   // ROBOT INTERRUPTION   ====================================================
   py::class_<RobotInterruption>(


### PR DESCRIPTION
This PR accomplishes three purposes:
1. The task event status can now be updated by the action executor
2. The action executor can now create event log entries
3. The `perform_action` event status will automatically change to `Completed` when the action executor finishes