### PR TITLE
Add override_status API

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -101,6 +101,12 @@ public:
   /// charge as a fraction of its total charge capacity
   void update_battery_soc(const double battery_soc);
 
+  /// Use this function to override the robot status. The string provided must
+  /// be a valid enum as specified the in robot_state.json schema.
+  /// Pass std::nullopt to cancel the override and allow RMF to automatically
+  /// update the status. Default is std::nullopt.
+  void override_status(std::optional<std::string> status);
+
   /// Specify how high the delay of the current itinerary can become before it
   /// gets interrupted and replanned. A nullopt value will allow for an
   /// arbitrarily long delay to build up without being interrupted.

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -102,9 +102,9 @@ public:
   void update_battery_soc(const double battery_soc);
 
   /// Use this function to override the robot status. The string provided must
-  /// be a valid enum as specified the in robot_state.json schema.
+  /// be a valid enum as specified in the robot_state.json schema.
   /// Pass std::nullopt to cancel the override and allow RMF to automatically
-  /// update the status. Default is std::nullopt.
+  /// update the status. The default value is std::nullopt.
   void override_status(std::optional<std::string> status);
 
   /// Specify how high the delay of the current itinerary can become before it

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -819,6 +819,9 @@ bool TaskManager::cancel_task_if_present(const std::string& task_id)
 //==============================================================================
 std::string TaskManager::robot_status() const
 {
+  if (_context->override_status().has_value())
+    return _context->override_status().value();
+
   if (!_active_task)
     return "idle";
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -396,6 +396,18 @@ uint32_t RobotContext::current_mode() const
 }
 
 //==============================================================================
+void RobotContext::override_status(std::optional<std::string> status)
+{
+  _override_status = status;
+}
+
+//==============================================================================
+std::optional<std::string> RobotContext::override_status() const
+{
+  return _override_status;
+}
+
+//==============================================================================
 void RobotContext::action_executor(
   RobotUpdateHandle::ActionExecutor action_executor)
 {
@@ -476,6 +488,7 @@ RobotContext::RobotContext(
   _battery_soc_obs = _battery_soc_publisher.get_observable();
 
   _current_mode = rmf_fleet_msgs::msg::RobotMode::MODE_IDLE;
+  _override_status = std::nullopt;
 
   _action_executor = nullptr;
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -204,10 +204,19 @@ public:
 
   /// Set the current mode of the robot. This mode should correspond to a
   /// constant in the RobotMode message
+  [[deprecated]]
   void current_mode(uint32_t mode);
 
   /// Return the current mode of the robot
+  [[deprecated]]
   uint32_t current_mode() const;
+
+  /// Set the current mode of the robot.
+  /// Specify a valid string as specified in the robot_state.json schema
+  void override_status(std::optional<std::string> status);
+
+  /// Return the current mode of the robot
+  std::optional<std::string> override_status() const;
 
   /// Set the action executor for requesting this robot to execute a
   /// PerformAction activity
@@ -284,6 +293,7 @@ private:
 
   // Mode value for RobotMode message
   uint32_t _current_mode;
+  std::optional<std::string> _override_status;
 
   RobotUpdateHandle::ActionExecutor _action_executor;
   Reporting _reporting;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -219,8 +219,8 @@ void RobotUpdateHandle::override_status(std::optional<std::string> status)
     {
       const auto loader =
         [n = context->node(), s = _pimpl->schema_dictionary](
-          const nlohmann::json_uri& id,
-          nlohmann::json& value)
+        const nlohmann::json_uri& id,
+        nlohmann::json& value)
         {
           const auto it = s.find(id.url());
           if (it == s.end())

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -34,7 +34,7 @@ using TimePoint = std::chrono::time_point<std::chrono::system_clock,
 ///       in FleetUpdateHandle. This is to replace the ref `confirm` arg with
 ///       a return value
 using Confirmation = agv::FleetUpdateHandle::Confirmation;
-using ModifiedConsiderRequest = 
+using ModifiedConsiderRequest =
   std::function<Confirmation(const nlohmann::json &description)>;
 
 using ActionExecution = agv::RobotUpdateHandle::ActionExecution;
@@ -126,6 +126,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("battery_soc"),
     py::call_guard<py::scoped_ostream_redirect,
     py::scoped_estream_redirect>())
+  .def("override_status", &agv::RobotUpdateHandle::override_status,
+    py::arg("battery_soc"))
   .def_property("maximum_delay",
     py::overload_cast<>(
       &agv::RobotUpdateHandle::maximum_delay, py::const_),
@@ -573,7 +575,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::overload_cast<>(
       &agv::test::MockAdapter::node))
    /// Note: Exposed dispatch_task() for testing
-  .def("dispatch_task", 
+  .def("dispatch_task",
     &agv::test::MockAdapter::dispatch_task,
     py::arg("task_id"),
     py::arg("request"))


### PR DESCRIPTION
This PR introducing `RobotUpdateHandle::override_status(std::optional<std::string > status)` API.

Users can use this API to override the string status for a given robot. By default the `TaskManger` assigns either `idle` or `working` depending on whether the robot is performing a task or not. But in some cases, users may want to explicitly set the status of the robot. In these scenarios, this API may be used. The API internally checks against the `robot_state.json` schema before accepting the new status. When users want RMF to take back control of the status, they may call this API with `std::nullopt`.
 
Signed-off-by: Yadunund <yadunund@openrobotics.org>

