### PR TITLE
Fix/append schemas dict for override_status

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -24,6 +24,7 @@
 #include <nlohmann/json.hpp>
 #include <nlohmann/json-schema.hpp>
 #include <rmf_api_msgs/schemas/robot_state.hpp>
+#include <rmf_api_msgs/schemas/location_2D.hpp>
 
 namespace rmf_fleet_adapter {
 namespace agv {
@@ -93,6 +94,7 @@ public:
     // Initialize schema dictionary
     const std::vector<nlohmann::json> schemas = {
       rmf_api_msgs::schemas::robot_state,
+      rmf_api_msgs::schemas::location_2D,
     };
 
     for (const auto& schema : schemas)


### PR DESCRIPTION
Tested scenarios with the new `override_status()` api, https://github.com/open-rmf/rmf_ros2/pull/191. a simple fix related to that.