### PR TITLE
Catch and report bad request change inputs

### DIFF
--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -919,13 +919,13 @@ void ScheduleNode::request_changes(
         try
         {
           if (rmf_utils::modular(request->version).less_than(
-            *mirror_update_topic_info.last_sent_version))
+              *mirror_update_topic_info.last_sent_version))
           {
             mirror_update_topic_info
             .remediation_requests.insert(request->version);
           }
         }
-        catch(const std::exception& e)
+        catch (const std::exception& e)
         {
           RCLCPP_ERROR(
             get_logger(),


### PR DESCRIPTION
It is possible for malformed change requests to come in, so we will catch those situations and report them as errors instead of allowing the node to crash.