### PR TITLE
Allow fleet adapters to manually activate stubborn negotiation

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -285,6 +285,37 @@ public:
     /// Get the schedule participant of this robot
     rmf_traffic::schedule::Participant* get_participant();
 
+    /// Override the schedule to say that the robot will be holding at a certain
+    /// position. This should not be used while tasks with automatic schedule
+    /// updating are running, or else the traffic schedule will have jumbled up
+    /// information, which can be disruptive to the overall traffic management.
+    void declare_holding(
+      std::string on_map,
+      Eigen::Vector3d at_position,
+      rmf_traffic::Duration for_duration = std::chrono::seconds(30));
+
+    /// Hold onto this class to tell the robot to behave as a "stubborn
+    /// negotiator", meaning it will always refuse to accommodate the schedule
+    /// of any other agent. This could be used when teleoperating a robot, to
+    /// tell other robots that the agent is unable to negotiate.
+    ///
+    /// When the object is destroyed, the stubbornness will automatically be
+    /// released.
+    class Stubbornness
+    {
+    public:
+      /// Stop being stubborn
+      void release();
+
+      class Implementation;
+    private:
+      Stubbornness();
+      rmf_utils::impl_ptr<Implementation> _pimpl;
+    };
+
+    /// Tell this robot to be a stubborn negotiator.
+    Stubbornness be_stubborn();
+
     enum class Decision
     {
       Undefined = 0,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -369,11 +369,11 @@ void RobotContext::respond(
   const TableViewerPtr& table_viewer,
   const ResponderPtr& responder)
 {
-  if (_negotiator)
+  if (_negotiator && !is_stubborn())
     return _negotiator->respond(table_viewer, responder);
 
-  // If there is no negotiator assigned for this robot, then use a
-  // StubbornNegotiator.
+  // If there is no negotiator assigned for this robot or the stubborn mode has
+  // been requested, then use a StubbornNegotiator.
   //
   // TODO(MXG): Consider if this should be scheduled on a separate thread
   // instead of executed immediately. The StubbornNegotiator doesn't do any

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -569,14 +569,27 @@ void RobotUpdateHandle::Unstable::declare_holding(
 {
   if (const auto context = _pimpl->get_context())
   {
-    const auto now = context->now();
-    rmf_traffic::Trajectory holding;
-    holding.insert(now, at_position, Eigen::Vector3d::Zero());
-    holding.insert(now + for_duration, at_position, Eigen::Vector3d::Zero());
+    context->worker().schedule(
+      [
+        w = context->weak_from_this(),
+        on_map = std::move(on_map),
+        at_position,
+        for_duration
+      ](const auto&)
+    {
+      if (const auto context = w.lock())
+      {
+        const auto now = context->now();
+        const auto zero = Eigen::Vector3d::Zero();
+        rmf_traffic::Trajectory holding;
+        holding.insert(now, at_position, zero);
+        holding.insert(now + for_duration, at_position, zero);
 
-    context->itinerary().set(
-      context->itinerary().assign_plan_id(),
-      {{std::move(on_map), std::move(holding)}});
+        context->itinerary().set(
+          context->itinerary().assign_plan_id(),
+          {{std::move(on_map), std::move(holding)}});
+      }
+    });
   }
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -576,20 +576,20 @@ void RobotUpdateHandle::Unstable::declare_holding(
         at_position,
         for_duration
       ](const auto&)
-    {
-      if (const auto context = w.lock())
       {
-        const auto now = context->now();
-        const auto zero = Eigen::Vector3d::Zero();
-        rmf_traffic::Trajectory holding;
-        holding.insert(now, at_position, zero);
-        holding.insert(now + for_duration, at_position, zero);
+        if (const auto context = w.lock())
+        {
+          const auto now = context->now();
+          const auto zero = Eigen::Vector3d::Zero();
+          rmf_traffic::Trajectory holding;
+          holding.insert(now, at_position, zero);
+          holding.insert(now + for_duration, at_position, zero);
 
-        context->itinerary().set(
-          context->itinerary().assign_plan_id(),
-          {{std::move(on_map), std::move(holding)}});
-      }
-    });
+          context->itinerary().set(
+            context->itinerary().assign_plan_id(),
+            {{std::move(on_map), std::move(holding)}});
+        }
+      });
   }
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/EmergencyPullover.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/EmergencyPullover.cpp
@@ -339,13 +339,6 @@ Negotiator::NegotiatePtr EmergencyPullover::Active::_respond(
   const Negotiator::TableViewerPtr& table_view,
   const Negotiator::ResponderPtr& responder)
 {
-  if (_context->is_stubborn())
-  {
-    rmf_traffic::schedule::StubbornNegotiator(_context->itinerary())
-    .respond(table_view, responder);
-    return nullptr;
-  }
-
   auto approval_cb = [w = weak_from_this()](
     const rmf_traffic::PlanId plan_id,
     const rmf_traffic::agv::Plan& plan)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
@@ -435,13 +435,6 @@ Negotiator::NegotiatePtr GoToPlace::Active::_respond(
   const Negotiator::TableViewerPtr& table_view,
   const Negotiator::ResponderPtr& responder)
 {
-  if (_context->is_stubborn())
-  {
-    rmf_traffic::schedule::StubbornNegotiator(_context->itinerary())
-    .respond(table_view, responder);
-    return nullptr;
-  }
-
   auto approval_cb = [w = weak_from_this()](
     const rmf_traffic::PlanId plan_id,
     const rmf_traffic::agv::Plan& plan)

--- a/rmf_fleet_adapter_python/scripts/test_unstable.py
+++ b/rmf_fleet_adapter_python/scripts/test_unstable.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+
+import rclpy
+import time
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+
+import rmf_adapter as adpt
+import rmf_adapter.vehicletraits as traits
+import rmf_adapter.geometry as geometry
+import rmf_adapter.graph as graph
+import rmf_adapter.battery as battery
+import rmf_adapter.plan as plan
+
+from test_utils import MockRobotCommand
+
+from functools import partial
+
+
+test_task_id = 'patrol.direct_dispatch.001'  # aka task_id
+map_name = "test_map"
+fleet_name = "test_fleet"
+
+start_name = "start_wp"  # 7
+finish_name = "finish_wp"  # 10
+loop_count = 2
+rmf_server_uri = "ws://localhost:7878"  # random port
+
+
+def main():
+    # INIT RCL ================================================================
+    rclpy.init()
+
+    try:
+        adpt.init_rclcpp()
+    except RuntimeError:
+        # Continue if it is already initialized
+        pass
+
+    # INIT GRAPH ==============================================================
+    test_graph = graph.Graph()
+
+    test_graph.add_waypoint(map_name, [0.0, -10.0])  # 0
+    test_graph.add_waypoint(map_name, [0.0, -5.0])  # 1
+    test_graph.add_waypoint(map_name, [5.0, -5.0]).set_holding_point(True)  # 2
+    test_graph.add_waypoint(map_name, [-10.0, 0])  # 3
+    test_graph.add_waypoint(map_name, [-5.0, 0.0])  # 4
+    test_graph.add_waypoint(map_name, [0.0, 0.0])  # 5
+    test_graph.add_waypoint(map_name, [5.0, 0.0])  # 6
+    test_graph.add_waypoint(map_name, [10.0, 0.0])  # 7
+    test_graph.add_waypoint(map_name, [0.0, 5.0])  # 8
+    test_graph.add_waypoint(map_name, [5.0, 5.0]).set_holding_point(True)  # 9
+    test_graph.add_waypoint(map_name, [0.0, 10.0]).set_holding_point(
+        True).set_charger(True)  # 10
+
+    assert test_graph.get_waypoint(2).holding_point
+    assert test_graph.get_waypoint(9).holding_point
+
+    test_graph_legend = \
+        """
+        D : Dispenser
+        I : Ingestor
+        H : Holding Point
+        K : Dock
+        Numerals : Waypoints
+        ---- : Lanes
+        """
+
+    test_graph_vis = \
+        test_graph_legend + \
+        """
+                         10(I,K)
+                          |
+                          |
+                          8------9(H)
+                          |      |
+                          |      |
+            3------4------5------6------7(D,K)
+                          |      |
+                          |      |
+                          1------2(H)
+                          |
+                          |
+                          0
+       """
+
+    test_graph.add_bidir_lane(0, 1)  # 0   1
+    test_graph.add_bidir_lane(1, 2)  # 2   3
+    test_graph.add_bidir_lane(1, 5)  # 4   5
+    test_graph.add_bidir_lane(2, 6)  # 6   7
+    test_graph.add_bidir_lane(3, 4)  # 8   9
+    test_graph.add_bidir_lane(4, 5)  # 10 11
+    test_graph.add_bidir_lane(5, 6)  # 12 13
+    test_graph.add_dock_lane(6, 7, "A")  # 14 15
+    test_graph.add_bidir_lane(5, 8)  # 16 17
+    test_graph.add_bidir_lane(6, 9)  # 18 19
+    test_graph.add_bidir_lane(8, 9)  # 20 21
+    test_graph.add_dock_lane(8, 10, "B")  # 22 23
+
+    assert test_graph.num_lanes == 24
+
+    test_graph.add_key(start_name, 7)
+    test_graph.add_key(finish_name, 10)
+
+    assert len(test_graph.keys) == 2 and start_name in test_graph.keys \
+        and finish_name in test_graph.keys
+
+    # INIT FLEET ==============================================================
+    profile = traits.Profile(geometry.make_final_convex_circle(1.0))
+    robot_traits = traits.VehicleTraits(linear=traits.Limits(0.7, 0.3),
+                                        angular=traits.Limits(1.0, 0.45),
+                                        profile=profile)
+
+    # Manages loop requests
+    adapter = adpt.MockAdapter("TestLoopAdapter")
+    fleet = adapter.add_fleet(
+        fleet_name, robot_traits, test_graph, rmf_server_uri)
+
+    def patrol_req_cb(json_desc):
+        confirmation = adpt.fleet_update_handle.Confirmation()
+        confirmation.accept()
+        print(f" accepted patrol req: {json_desc}")
+        return confirmation
+
+    # Callback when a patrol request is received
+    fleet.consider_patrol_requests(
+        patrol_req_cb)
+
+    # Set fleet battery profile
+    battery_sys = battery.BatterySystem.make(24.0, 40.0, 8.8)
+    mech_sys = battery.MechanicalSystem.make(70.0, 40.0, 0.22)
+    motion_sink = battery.SimpleMotionPowerSink(battery_sys, mech_sys)
+    ambient_power_sys = battery.PowerSystem.make(20.0)
+    ambient_sink = battery.SimpleDevicePowerSink(
+        battery_sys, ambient_power_sys)
+    tool_power_sys = battery.PowerSystem.make(10.0)
+    tool_sink = battery.SimpleDevicePowerSink(battery_sys, tool_power_sys)
+
+    b_success = fleet.set_task_planner_params(
+        battery_sys, motion_sink, ambient_sink, tool_sink, 0.2, 1.0, False)
+
+    assert b_success, "set task planner params failed"
+
+    cmd_node = Node("RobotCommandHandle")
+
+    # Test compute_plan_starts, which tries to place the robot on the navgraph
+    # Your robot MUST be near a waypoint or lane for this to work though!
+    starts = plan.compute_plan_starts(test_graph,
+                                      map_name,
+                                      [[-10.0], [0.0], [0.0]],
+                                      adapter.now())
+    assert [x.waypoint for x in starts] == [3], [x.waypoint for x in starts]
+
+    # Alternatively, if you DO know where your robot is, place it directly!
+    starts = [plan.Start(adapter.now(),
+                         0,
+                         0.0)]
+
+    # Lambda to insert an adapter
+    def updater_inserter(handle_obj, updater):
+        updater.update_battery_soc(1.0)
+        handle_obj.updater = updater
+
+    # Manages and executes robot commands
+    robot_cmd = MockRobotCommand(cmd_node, test_graph)
+
+    fleet.add_robot(robot_cmd,
+                    "T0",
+                    profile,
+                    starts,
+                    partial(updater_inserter, robot_cmd))
+
+    # FINAL PREP ==============================================================
+    rclpy_executor = SingleThreadedExecutor()
+    rclpy_executor.add_node(cmd_node)
+
+    # GO! =====================================================================
+    adapter.start()
+
+    # Wait a moment for the updater to be created
+    time.sleep(0.5)
+    robot_cmd.updater.unstable_declare_holding(
+        map_name,
+        [1.0, 2.0, 3.0],
+        4.0
+    )
+
+    # Wait a moment for the holding declaration to be processed
+    time.sleep(0.5)
+    participant = robot_cmd.updater.unstable_get_participant()
+    itinerary = participant.get_itinerary()
+    assert len(itinerary) > 0
+    for route in itinerary:
+        assert route.map == map_name
+        assert route.trajectory.size() == 2
+        for i in range(route.trajectory.size()):
+            assert route.trajectory.position(i)[0] == 1.0
+            assert route.trajectory.position(i)[1] == 2.0
+            assert route.trajectory.position(i)[2] == 3.0
+
+    # Note that this is not a very reliable test because the
+    # unstable_declare_holding will be competing with the responsive waiting
+    # behavior of the fleet adapter. Race conditions in that contention could
+    # cause this test to fail.
+
+if __name__ == "__main__":
+    main()

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -40,6 +40,7 @@ using ModifiedConsiderRequest =
 using ActionExecution = agv::RobotUpdateHandle::ActionExecution;
 using RobotInterruption = agv::RobotUpdateHandle::Interruption;
 using IssueTicket = agv::RobotUpdateHandle::IssueTicket;
+using Stubbornness = agv::RobotUpdateHandle::Unstable::Stubbornness;
 
 void bind_types(py::module&);
 void bind_graph(py::module&);
@@ -155,6 +156,23 @@ PYBIND11_MODULE(rmf_adapter, m) {
     },
     py::return_value_policy::reference_internal,
     "Experimental API to access the schedule participant")
+  .def("unstable_declare_holding",
+    [&](agv::RobotUpdateHandle& self,
+    std::string on_map,
+    Eigen::Vector3d at_position,
+    rmf_traffic::Duration for_duration)
+    {
+      self.unstable().declare_holding(
+        std::move(on_map), at_position, for_duration);
+    },
+    py::arg("on_map"),
+    py::arg("at_position"),
+    py::arg("for_duration"))
+  .def("unstable_be_stubborn",
+    [&](agv::RobotUpdateHandle& self)
+    {
+      return self.unstable().be_stubborn();
+    })
   .def("set_action_executor",
     &agv::RobotUpdateHandle::set_action_executor,
     py::arg("action_executor"))
@@ -217,6 +235,12 @@ PYBIND11_MODULE(rmf_adapter, m) {
     .value("Info", agv::RobotUpdateHandle::Tier::Info)
     .value("Warning", agv::RobotUpdateHandle::Tier::Warning)
     .value("Error", agv::RobotUpdateHandle::Tier::Error);
+
+  // Stubbornness ============================================================
+  py::class_<Stubbornness>(
+    m_robot_update_handle, "Stubbornness")
+  .def("release",
+    &Stubbornness::release);
 
   // FLEETUPDATE HANDLE ======================================================
   py::class_<agv::FleetUpdateHandle,

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -156,14 +156,29 @@ PYBIND11_MODULE(rmf_adapter, m) {
     },
     py::return_value_policy::reference_internal,
     "Experimental API to access the schedule participant")
+  .def("unstable_get_participant",
+    [&](agv::RobotUpdateHandle& self)
+    {
+      // This is the same as get_unstable_participant, which was the original
+      // function signature for this binding. Since "unstable" describes the
+      // API and does not describe the participant, it should be at the front
+      // of the function name, not attached to "participant". But too many
+      // downstream packages are using get_unstable_participant, so we cannot
+      // simply remove support for it.
+      return self.unstable().get_participant();
+    },
+    py::return_value_policy::reference_internal,
+    "Experimental API to access the schedule participant")
   .def("unstable_declare_holding",
     [&](agv::RobotUpdateHandle& self,
     std::string on_map,
     Eigen::Vector3d at_position,
-    rmf_traffic::Duration for_duration)
+    double for_duration)
     {
       self.unstable().declare_holding(
-        std::move(on_map), at_position, for_duration);
+        std::move(on_map),
+        at_position,
+        rmf_traffic::time::from_seconds(for_duration));
     },
     py::arg("on_map"),
     py::arg("at_position"),

--- a/rmf_fleet_adapter_python/src/schedule/schedule.cpp
+++ b/rmf_fleet_adapter_python/src/schedule/schedule.cpp
@@ -85,5 +85,37 @@ void bind_schedule(py::module& m)
 
   // TRAJECTORY ================================================================
   py::class_<rmf_traffic::Trajectory,
-    std::shared_ptr<rmf_traffic::Trajectory>>(m_schedule, "Trajectory");
+    std::shared_ptr<rmf_traffic::Trajectory>>(m_schedule, "Trajectory")
+  .def(py::init<>())
+  .def("size", &rmf_traffic::Trajectory::size)
+  .def("insert",
+    [&](rmf_traffic::Trajectory& self,
+    double seconds,
+    Eigen::Vector3d position,
+    Eigen::Vector3d velocity)
+    {
+      self.insert(
+        rmf_traffic::Time(rmf_traffic::time::from_seconds(seconds)),
+        position,
+        velocity);
+    },
+    py::arg("time"),
+    py::arg("position"),
+    py::arg("velocity"))
+  .def("position", [](const rmf_traffic::Trajectory& self, std::size_t index)
+    {
+      return self.at(index).position();
+    },
+    py::arg("index"))
+  .def("velocity", [](const rmf_traffic::Trajectory& self, std::size_t index)
+    {
+      return self.at(index).velocity();
+    },
+    py::arg("index"))
+  .def("time", [](const rmf_traffic::Trajectory& self, std::size_t index)
+    {
+      return rmf_traffic::time::to_seconds(
+        self.at(index).time().time_since_epoch());
+    },
+    py::arg("index"));
 }


### PR DESCRIPTION
This PR adds an unstable feature to allow system integrators to manually activate stubborn negotiation. It also provides a simple API for overriding a robot's schedule to say that it is holding at a position.

These are experimental features so they are all in the `Unstable` API for now.