### PR TITLE
Publish canceled status after cancel queued task

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1684,7 +1684,7 @@ void TaskManager::_publish_task_queue()
   rmf_task::State expected_state = _context->current_task_end_state();
   for (const auto& pending : _queue)
   {
-    _publish_assignment(pending, expected_state,  "queued");
+    _publish_assignment(pending, expected_state, "queued");
     expected_state = pending.finish_state();
   }
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -401,6 +401,14 @@ private:
   /// Publish the current pending task list
   void _publish_task_queue();
 
+  /// Publish the pending assignment status
+  void _publish_assignment(
+    const Assignment& assignement,
+    const rmf_task::State& expected_state,
+    const std::string& status);
+
+  bool _remove_task_from_queue(const std::string& task_id);
+
   /// Schema loader for validating jsons
   void _schema_loader(
     const nlohmann::json_uri& id, nlohmann::json& value) const;


### PR DESCRIPTION
This fix addresses the issue where `rmf-web` dashboard will not update the status of a "queued" task as "canceled" after a successful cancellation. Publish a "canceled" status after removing the task from the queue.