### PR TITLE
state as underway during perform action

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -266,6 +266,7 @@ void PerformAction::Active::_execute_action()
   auto action_execution =
     agv::RobotUpdateHandle::ActionExecution::Implementation::make(data);
 
+  _state->update_status(Status::Underway);
   action_executor(
     _action_category,
     _action_description,


### PR DESCRIPTION
During performaction event, the state was shown as "standby". It is more understandable to users if the state is shown as "underway" during an ongoing perform action task. Single line fix
.