### PR TITLE
Change default task auction evaluator to QuickestFinishEvaluator

### DIFF
--- a/rmf_task_ros2/include/rmf_task_ros2/Dispatcher.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/Dispatcher.hpp
@@ -120,7 +120,7 @@ public:
   void on_change(DispatchStateCallback on_change_fn);
 
   /// Change the default evaluator to a custom evaluator, which is used by
-  /// bidding auctioneer. Default evaluator is: `LeastFleetDiffCostEvaluator`
+  /// bidding auctioneer. Default evaluator is: `QuickestFinishEvaluator`
   ///
   /// \param [in] evaluator
   ///   evaluator used to select the best bid from fleets

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -254,7 +254,7 @@ public:
       {
         this->conclude_bid(task_id, std::move(winner), errors);
       },
-      std::make_shared<bidding::LeastFleetDiffCostEvaluator>());
+      std::make_shared<bidding::QuickestFinishEvaluator>());
 
     // Setup up stream srv interfaces
     submit_task_srv = node->create_service<SubmitTaskSrv>(


### PR DESCRIPTION
It seems the default task auction evaluator was reverted to a less preferable class during the refactoring of #168. This PR switches it back to the "Quickest Finish" evaluator, which should help optimize the finish times of all tasks.

Much thanks to @jkeshav-bvignesh for [pointing out this issue](https://github.com/open-rmf/rmf/discussions/147#discussioncomment-2782812).