### PR TITLE
ws broadcast client in dispatcher node

### DIFF
--- a/rmf_fleet_adapter/schemas/event_description__go_to_place.json
+++ b/rmf_fleet_adapter/schemas/event_description__go_to_place.json
@@ -16,7 +16,8 @@
           "type": "array",
           "items": { "$ref": "place.json" }
         }
-      }
+      },
+      "required": ["place"]
     }
   ]
 }

--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(Eigen3 REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(nlohmann_json_schema_validator_vendor REQUIRED)
+find_package(websocketpp REQUIRED)
 
 file(GLOB_RECURSE core_lib_srcs "src/rmf_task_ros2/*.cpp")
 add_library(rmf_task_ros2 SHARED ${core_lib_srcs})
@@ -33,6 +34,7 @@ target_link_libraries(rmf_task_ros2
     rmf_traffic_ros2::rmf_traffic_ros2
     ${rmf_task_msgs_LIBRARIES}
     ${rclcpp_LIBRARIES}
+    ${websocketpp_LIBRARIES}
     nlohmann_json::nlohmann_json
     nlohmann_json_schema_validator
 )
@@ -44,6 +46,7 @@ target_include_directories(rmf_task_ros2
     ${rmf_traffic_ros2_INCLUDE_DIRS}
     ${rmf_task_msgs_INCLUDE_DIRS}
     ${rclcpp_INCLUDE_DIRS}
+    ${WEBSOCKETPP_INCLUDE_DIR}
 )
 
 ament_export_targets(rmf_task_ros2 HAS_LIBRARY_TARGET)

--- a/rmf_task_ros2/include/rmf_task_ros2/DispatchState.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/DispatchState.hpp
@@ -77,10 +77,16 @@ struct DispatchState
   /// Any errors that have occurred for this dispatching
   std::vector<nlohmann::json> errors;
 
+  /// task request form
+  nlohmann::json request;
+
   DispatchState(std::string task_id, rmf_traffic::Time submission_time);
 };
 
 using DispatchStatePtr = std::shared_ptr<DispatchState>;
+
+//==============================================================================
+std::string status_to_string(DispatchState::Status status);
 
 //==============================================================================
 rmf_task_msgs::msg::Assignment convert(

--- a/rmf_task_ros2/src/rmf_task_ros2/BroadcastClient.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/BroadcastClient.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "BroadcastClient.hpp"
+
+namespace rmf_task_ros2 {
+//==============================================================================
+std::shared_ptr<BroadcastClient> BroadcastClient::make(
+  const std::string& uri,
+  const std::shared_ptr<rclcpp::Node>& node)
+{
+  std::shared_ptr<BroadcastClient> client(new BroadcastClient());
+  client->_uri = std::move(uri);
+  client->_node = std::move(node);
+  client->_shutdown = false;
+  client->_connected = false;
+
+  // Initialize the Asio transport policy
+  client->_client.clear_access_channels(websocketpp::log::alevel::all);
+  client->_client.clear_error_channels(websocketpp::log::elevel::all);
+  client->_client.init_asio();
+  client->_client.start_perpetual();
+  client->_client_thread = std::thread(
+    [c = client]()
+    {
+      c->_client.run();
+    });
+
+  client->_client.set_open_handler(
+    [c = client](websocketpp::connection_hdl)
+    {
+      c->_connected = true;
+      RCLCPP_INFO(
+        c->_node->get_logger(),
+        "BroadcastClient successfully connected to uri: [%s]",
+        c->_uri.c_str());
+    });
+
+  client->_client.set_close_handler(
+    [c = client](websocketpp::connection_hdl)
+    {
+      c->_connected = false;
+    });
+
+  client->_client.set_fail_handler(
+    [c = client](websocketpp::connection_hdl)
+    {
+      c->_connected = false;
+    });
+
+  client->_processing_thread = std::thread(
+    [c = client]()
+    {
+      while (!c->_shutdown)
+      {
+        // Try to connect to the server if we are not connected yet
+        if (!c->_connected)
+        {
+          websocketpp::lib::error_code ec;
+          WebsocketClient::connection_ptr con = c->_client.get_connection(
+            c->_uri, ec);
+
+          if (con)
+          {
+            c->_hdl = con->get_handle();
+            c->_client.connect(con);
+            // TOD(YV): Without sending a test payload, ec seems to be 0 even
+            // when the client has not connected. Avoid sending this message.
+            c->_client.send(c->_hdl, "Hello", websocketpp::frame::opcode::text,
+            ec);
+          }
+
+          if (!con || ec)
+          {
+            RCLCPP_WARN(
+              c->_node->get_logger(),
+              "BroadcastClient unable to connect to [%s]. Please make sure "
+              "server is running. Error msg: %s",
+              c->_uri.c_str(),
+              ec.message().c_str());
+            c->_connected = false;
+            std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+            continue;
+          }
+
+          RCLCPP_INFO(
+            c->_node->get_logger(),
+            "BroadcastClient successfully connected to [%s]",
+            c->_uri.c_str());
+          c->_connected = true;
+        }
+
+        std::unique_lock<std::mutex> lock(c->_wait_mutex);
+        c->_cv.wait(lock,
+        [c]()
+        {
+          return !c->_queue.empty();
+        });
+
+        while (!c->_queue.empty())
+        {
+          std::lock_guard<std::mutex> lock(c->_queue_mutex);
+          websocketpp::lib::error_code ec;
+          const std::string& msg = c->_queue.front().dump();
+          c->_client.send(c->_hdl, msg, websocketpp::frame::opcode::text, ec);
+          if (ec)
+          {
+            RCLCPP_ERROR(
+              c->_node->get_logger(),
+              "BroadcastClient unable to publish message: %s",
+              ec.message().c_str());
+            // TODO(YV): Check if we should re-connect to server
+            break;
+          }
+          c->_queue.pop();
+        }
+      }
+    });
+
+  return client;
+
+}
+
+//==============================================================================
+void BroadcastClient::publish(const nlohmann::json& msg)
+{
+  std::lock_guard<std::mutex> lock(_queue_mutex);
+  _queue.push(msg);
+  _cv.notify_all();
+}
+
+//==============================================================================
+void BroadcastClient::publish(const std::vector<nlohmann::json>& msgs)
+{
+  std::lock_guard<std::mutex> lock(_queue_mutex);
+  for (const auto& msg : msgs)
+    _queue.push(msg);
+  _cv.notify_all();
+}
+
+//==============================================================================
+BroadcastClient::BroadcastClient()
+{
+  // Do nothing
+}
+
+//==============================================================================
+BroadcastClient::~BroadcastClient()
+{
+  _shutdown = true;
+  if (_processing_thread.joinable())
+  {
+    _processing_thread.join();
+  }
+  if (_client_thread.joinable())
+  {
+    _client_thread.join();
+  }
+  _client.stop_perpetual();
+}
+
+} // namespace rmf_task_ros2

--- a/rmf_task_ros2/src/rmf_task_ros2/BroadcastClient.hpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/BroadcastClient.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_TASK_ROS2__BROADCASTCLIENT_HPP
+#define SRC__RMF_TASK_ROS2__BROADCASTCLIENT_HPP
+
+#include <websocketpp/config/asio_no_tls_client.hpp>
+#include <websocketpp/client.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <rclcpp/node.hpp>
+
+#include <memory>
+#include <set>
+#include <queue>
+#include <mutex>
+#include <thread>
+#include <atomic>
+
+namespace rmf_task_ros2 {
+//==============================================================================
+// A wrapper around a websocket client for broadcasting states and logs for
+// fleets, robots and tasks. A queue of json msgs is maintained and published
+// in an internal thread whenever connection to a server is established.
+//
+// \Note: this class is a "copy" of rmf_fleet_adapter::BroadcastClient
+// TODO(YL) create a common broadcastclient lib
+class BroadcastClient : public std::enable_shared_from_this<BroadcastClient>
+{
+public:
+  using WebsocketClient =
+    websocketpp::client<websocketpp::config::asio_client>;
+  using WebsocketMessagePtr = WebsocketClient::message_ptr;
+  using ConnectionHDL = websocketpp::connection_hdl;
+  using Connections = std::set<ConnectionHDL, std::owner_less<ConnectionHDL>>;
+
+  /// \param[in] uri
+  ///   "ws://localhost:9000"
+  ///
+  /// \param[in] node
+  static std::shared_ptr<BroadcastClient> make(
+    const std::string& uri,
+    const std::shared_ptr<rclcpp::Node>& node);
+
+  // Publish a single message
+  void publish(const nlohmann::json& msg);
+
+  // Publish a vector of messages
+  void publish(const std::vector<nlohmann::json>& msgs);
+
+  ~BroadcastClient();
+
+private:
+  BroadcastClient();
+  std::string _uri;
+  std::shared_ptr<rclcpp::Node> _node;
+  WebsocketClient _client;
+  websocketpp::connection_hdl _hdl;
+  std::mutex _wait_mutex;
+  std::mutex _queue_mutex;
+  std::condition_variable _cv;
+  std::queue<nlohmann::json> _queue;
+  std::thread _processing_thread;
+  std::thread _client_thread;
+  std::atomic_bool _connected;
+  std::atomic_bool _shutdown;
+};
+
+} // namespace rmf_task_ros2
+
+#endif // SRC__RMF_TASK_ROS2__BROADCASTCLIENT_HPP

--- a/rmf_task_ros2/src/rmf_task_ros2/DispatchState.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/DispatchState.cpp
@@ -32,6 +32,27 @@ DispatchState::DispatchState(
   // Do nothing
 }
 
+//==============================================================================
+std::string status_to_string(DispatchState::Status status)
+{
+  using Status = DispatchState::Status;
+  switch (status)
+  {
+    case Status::Queued:
+      return "queued";
+    case Status::Selected:
+      return "selected";
+    case Status::Dispatched:
+      return "dispatched";
+    case Status::FailedToAssign:
+      return "failed_to_assign";
+    case Status::CanceledInFlight:
+      return "canceled_in_flight";
+    default:
+      return "failed_to_assign";
+  }
+}
+
 //=============================================================================
 rmf_task_msgs::msg::Assignment convert(
   const std::optional<DispatchState::Assignment>& assignment)

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -18,6 +18,8 @@
 #include <rmf_task_ros2/Dispatcher.hpp>
 #include <rmf_task_ros2/StandardNames.hpp>
 
+#include "BroadcastClient.hpp"
+
 #include <rclcpp/node.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>
 
@@ -97,6 +99,10 @@ public:
 
   std::shared_ptr<rclcpp::Node> node;
   std::shared_ptr<bidding::Auctioneer> auctioneer;
+  std::shared_ptr<rmf_task_ros2::BroadcastClient> broadcast_client;
+
+  const nlohmann::json _task_state_update_json =
+  {{"type", "task_state_update"}, {"data", {}}};
 
   using SubmitTaskSrv = rmf_task_msgs::srv::SubmitTask;
   using CancelTaskSrv = rmf_task_msgs::srv::CancelTask;
@@ -204,6 +210,18 @@ public:
       " Declared publish_active_tasks_period as: %d secs",
       publish_active_tasks_period);
 
+
+    std::optional<std::string> server_uri = std::nullopt;
+    const std::string uri =
+      node->declare_parameter("server_uri", std::string());
+    if (!uri.empty())
+    {
+      RCLCPP_INFO(
+        node->get_logger(),
+        "API server URI: [%s]", uri.c_str());
+      server_uri = uri;
+    }
+
     const auto qos = rclcpp::ServicesQoS().reliable();
     dispatch_states_pub = node->create_publisher<DispatchStatesMsg>(
       rmf_task_ros2::DispatchStatesTopicName, qos);
@@ -244,6 +262,10 @@ public:
       {
         this->handle_dispatch_ack(*msg);
       });
+
+    if(server_uri)
+      broadcast_client = rmf_task_ros2::BroadcastClient::make(
+        *server_uri, node);
 
     auctioneer = bidding::Auctioneer::make(
       node,
@@ -530,35 +552,14 @@ public:
 
   nlohmann::json push_bid_notice(bidding::BidNoticeMsg bid_notice)
   {
-    nlohmann::json state;
-    auto& booking = state["booking"];
-    booking["id"] = bid_notice.task_id;
-
     const auto request = nlohmann::json::parse(bid_notice.request);
-    static const std::vector<std::string> copy_fields = {
-      "unix_millis_earliest_start_time",
-      "priority",
-      "labels"
-    };
-
-    for (const auto& field : copy_fields)
-    {
-      const auto f_it = request.find(field);
-      if (f_it != request.end())
-        booking[field] = f_it.value();
-    }
-
-    state["category"] = request["category"];
-    state["detail"] = request["description"];
-
-    auto& dispatch = state["dispatch"];
-    dispatch["status"] = "queued";
-
-    // TODO(MXG): Publish this initial task state message to the websocket!
-
     auto new_dispatch_state =
       std::make_shared<DispatchState>(
       bid_notice.task_id, std::chrono::steady_clock::now());
+    new_dispatch_state->request = request;
+
+    // Publish this initial task state message to the websocket
+    auto state = publish_task_state_ws(new_dispatch_state, "queued");
 
     active_dispatch_states[bid_notice.task_id] = new_dispatch_state;
 
@@ -740,6 +741,9 @@ public:
         ++error_count;
       }
 
+      /// Publish failed bid
+      publish_task_state_ws(dispatch_state, "failed");
+
       auctioneer->ready_for_next_bid();
       return;
     }
@@ -768,6 +772,55 @@ public:
 
     lingering_commands[award_command.dispatch_id] = award_command;
     dispatch_command_pub->publish(award_command);
+  }
+
+  //==============================================================================
+  nlohmann::json publish_task_state_ws(
+    const std::shared_ptr<DispatchState> state,
+    const std::string& status)
+  {
+    nlohmann::json task_state;
+    auto& booking = task_state["booking"];
+    booking["id"] = state->task_id;
+
+    static const std::vector<std::string> copy_fields = {
+      "unix_millis_earliest_start_time",
+      "priority",
+      "labels"
+    };
+
+    for (const auto& field : copy_fields)
+    {
+      const auto f_it = state->request.find(field);
+      if (f_it != state->request.end())
+        booking[field] = f_it.value();
+    }
+
+    task_state["category"] = state->request["category"];
+    task_state["detail"] = state->request["description"];
+    task_state["status"] = status;
+
+    /// NOTE: This should be null, but the reason of populating this for
+    /// now is to provide an estimated start_time to the dashboard, so
+    /// sort by start time will still work
+    task_state["unix_millis_start_time"] =
+      booking["unix_millis_earliest_start_time"];
+
+    /// TODO: populate assignment from state
+
+    nlohmann::json dispatch_json;
+    dispatch_json["status"] = status_to_string(state->status);
+    dispatch_json["errors"] = state->errors;
+    task_state["dispatch"] = dispatch_json;
+
+    auto task_state_update = _task_state_update_json;
+    task_state_update["data"] = task_state;
+
+    /// TODO: (YL) json validator for taskstateupdate
+
+    if(broadcast_client)
+      broadcast_client->publish(task_state_update);
+    return task_state;
   }
 
   void move_to_finished(const std::string& task_id)


### PR DESCRIPTION
Currently, if a task bidding failed, no task state update will get broadcasted to the ws server. From the rmf-web dashboard, this failed task will get shown as "unknown".

 This solution simply implements the same`BroadcastClient` in the dispatcher_node. Similarly, the user can specify the broadcast uri via rosparam `server_uri`.

Since the impl is similar to the one in `rmf_fleet_adapter` pkg, wonder if it is preferred to create a common lib for task json handling and ws `BroadcastClient`.