### PR TITLE
Changes for humble compatibility

### DIFF
--- a/rmf_fleet_adapter_python/CMakeLists.txt
+++ b/rmf_fleet_adapter_python/CMakeLists.txt
@@ -19,6 +19,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+find_package (Python3 COMPONENTS Interpreter Development)
 find_package(rmf_fleet_adapter REQUIRED)
 find_package(rmf_task REQUIRED)
 find_package(rmf_battery REQUIRED)

--- a/rmf_fleet_adapter_python/CMakeLists.txt
+++ b/rmf_fleet_adapter_python/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package (Python3 COMPONENTS Interpreter Development)
+find_package(Python3 COMPONENTS Interpreter Development)
 find_package(rmf_fleet_adapter REQUIRED)
 find_package(rmf_task REQUIRED)
 find_package(rmf_battery REQUIRED)

--- a/rmf_task_ros2/include/rmf_task_ros2/DispatchState.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/DispatchState.hpp
@@ -20,6 +20,7 @@
 
 #include <unordered_map>
 #include <memory>
+#include <optional>
 
 #include <rmf_traffic_ros2/Time.hpp>
 #include <rmf_task_msgs/msg/dispatch_state.hpp>

--- a/rmf_task_ros2/include/rmf_task_ros2/bidding/Response.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/bidding/Response.hpp
@@ -18,6 +18,8 @@
 #ifndef RMF_TASK_ROS2__BIDDING__RESPONSE_HPP
 #define RMF_TASK_ROS2__BIDDING__RESPONSE_HPP
 
+#include <optional>
+
 #include <rmf_traffic/Time.hpp>
 #include <rmf_task_msgs/msg/bid_notice.hpp>
 #include <rmf_task_msgs/msg/bid_proposal.hpp>

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlSerialization.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/YamlSerialization.cpp
@@ -85,7 +85,7 @@ rmf_traffic_msgs::msg::ConvexShape convex_shape(YAML::Node node)
 
   rmf_traffic_msgs::msg::ConvexShape shape;
   shape.type = shape_type(node[TypeKey]);
-  shape.index = node[IndexKey].as<uint8_t>();
+  shape.index = node[IndexKey].as<uint16_t>();
   return shape;
 }
 
@@ -249,7 +249,7 @@ YAML::Node serialize(rmf_traffic_msgs::msg::ConvexShape shape)
 {
   YAML::Node node;
   node[TypeKey] = serialize_shape_type(shape.type);
-  node[IndexKey] = shape.index;
+  node[IndexKey] = static_cast<uint16_t>(shape.index);
   return node;
 }
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

This PR fixes compile errors for rmf_ros2 under humble.

### Fix applied

Specifically, issues with `optional` not being found in bidding Reponse [here](https://github.com/open-rmf/rmf_ros2/blob/main/rmf_task_ros2/include/rmf_task_ros2/bidding/Response.hpp#L41), as well as an error with the Python bindings:

```
CMake Error at /usr/lib/cmake/pybind11/pybind11NewTools.cmake:207 (python3_add_library):
  Unknown CMake command "python3_add_library".
Call Stack (most recent call first):
  CMakeLists.txt:38 (pybind11_add_module)
```

According to the [CMake documentation](https://cmake.org/cmake/help/latest/module/FindPython3.html), we need to add a find_package(Python3) to add the CMake command.