### PR TITLE
Fix rmf_obstacle_ros2 intersection checker

### DIFF
--- a/rmf_obstacle_ros2/src/lane_blocker/LaneBlocker.cpp
+++ b/rmf_obstacle_ros2/src/lane_blocker/LaneBlocker.cpp
@@ -26,7 +26,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <rclcpp_components/register_node_macro.hpp>
 

--- a/rmf_obstacle_ros2/src/lane_blocker/LaneBlocker.cpp
+++ b/rmf_obstacle_ros2/src/lane_blocker/LaneBlocker.cpp
@@ -26,7 +26,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <rclcpp_components/register_node_macro.hpp>
 

--- a/rmf_obstacle_ros2/src/lane_blocker/test/test_IntersectionChecker.cpp
+++ b/rmf_obstacle_ros2/src/lane_blocker/test/test_IntersectionChecker.cpp
@@ -39,7 +39,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("AABB geometries are not intersecting and 1m apart")
   {
     double how_much;
-    double expected = 1.0;
+    const double expected = 1.0;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(1.0)
@@ -67,7 +67,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("OBB geometries are not intersecting and 1m apart")
   {
     double how_much;
-    double expected = 0.586;
+    const double expected = 0.586;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(1.0)
@@ -215,7 +215,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("Test #1")
   {
     double how_much;
-    double expected = 2.344;
+    const double expected = 2.344;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(8.6824)
@@ -243,7 +243,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("Test #2")
   {
     double how_much;
-    double expected = 6.593;
+    const double expected = 6.593;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(11.6892)
@@ -271,7 +271,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("Test #3")
   {
     double how_much;
-    double expected = 4.292;
+    const double expected = 4.292;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(9.57985)
@@ -299,7 +299,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("Test #4")
   {
     double how_much;
-    double expected = 7.702;
+    const double expected = 7.702;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(-3.7801)
@@ -327,7 +327,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("Test #5")
   {
     double how_much;
-    double expected = 17.126;
+    const double expected = 17.126;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(-9.12337)

--- a/rmf_obstacle_ros2/src/lane_blocker/test/test_IntersectionChecker.cpp
+++ b/rmf_obstacle_ros2/src/lane_blocker/test/test_IntersectionChecker.cpp
@@ -39,6 +39,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("AABB geometries are not intersecting and 1m apart")
   {
     double how_much;
+    double expected = 1.0;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(1.0)
@@ -58,13 +59,15 @@ SCENARIO("Test IntersectionChecker")
     const bool intersect = IntersectionChecker::between(
       ob1, ob2, how_much);
     REQUIRE_FALSE(intersect);
+    std::cout <<"expected: " << expected << std::endl;
     std::cout <<"how_much: " << how_much << std::endl;
-    CHECK(how_much - 1.0 == Approx(0.0).margin(1e-3));
+    CHECK((how_much - expected) == Approx(0.0).margin(1e-3));
   }
 
   WHEN("OBB geometries are not intersecting and 1m apart")
   {
     double how_much;
+    double expected = 0.586;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(1.0)
@@ -84,8 +87,9 @@ SCENARIO("Test IntersectionChecker")
     const bool intersect = IntersectionChecker::between(
       ob1, ob2, how_much);
     REQUIRE_FALSE(intersect);
+    std::cout <<"expected: " << expected << std::endl;
     std::cout <<"how_much: " << how_much << std::endl;
-    CHECK((how_much - 0.586) == Approx(0.0).margin(1e-3));
+    CHECK((how_much - expected) == Approx(0.0).margin(1e-3));
   }
 
   WHEN("AABB geometries are overlapping along X-Axis")
@@ -211,6 +215,7 @@ SCENARIO("Test IntersectionChecker")
   WHEN("Test #1")
   {
     double how_much;
+    double expected = 2.344;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(8.6824)
@@ -230,13 +235,15 @@ SCENARIO("Test IntersectionChecker")
     const bool intersect = IntersectionChecker::between(
       ob1, ob2, how_much);
     REQUIRE_FALSE(intersect);
-    CHECK((how_much - 2.336) == Approx(0.0).margin(1e-1));
+    std::cout <<"expected: " << expected << std::endl;
     std::cout <<"how_much: " << how_much << std::endl;
+    CHECK((how_much - expected) == Approx(0.0).margin(1e-3));
   }
 
   WHEN("Test #2")
   {
     double how_much;
+    double expected = 6.593;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(11.6892)
@@ -256,13 +263,15 @@ SCENARIO("Test IntersectionChecker")
     const bool intersect = IntersectionChecker::between(
       ob1, ob2, how_much);
     REQUIRE_FALSE(intersect);
-    CHECK((how_much - 6.773) == Approx(0.0).margin(1e-1));
+    std::cout <<"expected: " << expected << std::endl;
     std::cout <<"how_much: " << how_much << std::endl;
+    CHECK((how_much - expected) == Approx(0.0).margin(1e-3));
   }
 
   WHEN("Test #3")
   {
     double how_much;
+    double expected = 4.292;
     const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
       .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
         .x(9.57985)
@@ -282,7 +291,64 @@ SCENARIO("Test IntersectionChecker")
     const bool intersect = IntersectionChecker::between(
       ob1, ob2, how_much);
     REQUIRE_FALSE(intersect);
-    CHECK((how_much - 4.314) == Approx(0.0).margin(1e-1));
+    std::cout <<"expected: " << expected << std::endl;
     std::cout <<"how_much: " << how_much << std::endl;
+    CHECK((how_much - expected) == Approx(0.0).margin(1e-3));
+  }
+
+  WHEN("Test #4")
+  {
+    double how_much;
+    double expected = 7.702;
+    const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
+      .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
+        .x(-3.7801)
+        .y(-2.48618)
+        .theta(-2.95867))
+      .size_x(4.76905)
+      .size_y(0.734582);
+
+    const auto ob2 = rmf_obstacle_msgs::build<CollisionGeometry>()
+      .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
+        .x(6.81831)
+        .y(-1.99772)
+        .theta(0.990476))
+      .size_x(0.6)
+      .size_y(0.6);
+
+    const bool intersect = IntersectionChecker::between(
+      ob1, ob2, how_much);
+    REQUIRE_FALSE(intersect);
+    std::cout <<"expected: " << expected << std::endl;
+    std::cout <<"how_much: " << how_much << std::endl;
+    CHECK((how_much - expected) == Approx(0.0).margin(1e-3));
+  }
+
+  WHEN("Test #5")
+  {
+    double how_much;
+    double expected = 17.126;
+    const auto ob1 = rmf_obstacle_msgs::build<CollisionGeometry>()
+      .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
+        .x(-9.12337)
+        .y(2.63674)
+        .theta(7.05773))
+      .size_x(4.92557)
+      .size_y(1.66422);
+
+    const auto ob2 = rmf_obstacle_msgs::build<CollisionGeometry>()
+      .center(geometry_msgs::build<geometry_msgs::msg::Pose2D>()
+        .x(8.87474)
+        .y(-5.78416)
+        .theta(-1.90750))
+      .size_x(0.7)
+      .size_y(1.1);
+
+    const bool intersect = IntersectionChecker::between(
+      ob1, ob2, how_much);
+    REQUIRE_FALSE(intersect);
+    std::cout <<"expected: " << expected << std::endl;
+    std::cout <<"how_much: " << how_much << std::endl;
+    CHECK((how_much - expected) == Approx(0.0).margin(1e-3));
   }
 }

--- a/rmf_obstacle_ros2/src/rmf_obstacle_ros2/obstacles/Convert.cpp
+++ b/rmf_obstacle_ros2/src/rmf_obstacle_ros2/obstacles/Convert.cpp
@@ -80,7 +80,9 @@ PointCloud convert(
   sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
 
   // Note that the non-trivial call to tree->end_leafs() should be done only once for efficiency
-  for(auto leaf_it = tree.begin_leafs(), end = tree.end_leafs(); leaf_it != end; ++leaf_it)
+  for (auto leaf_it = tree.begin_leafs(),
+    end = tree.end_leafs(); leaf_it != end;
+    ++leaf_it)
   {
     const auto& p = leaf_it.getCoordinate();
     *iter_x = p.x();


### PR DESCRIPTION
## Summary
test_IntersectionChecker.cpp failing Test 3.

IntersectionChecker.cpp provides methods to check if 2 bounding boxes are intersecting. If they are not intersecting, it returns the distance between the 2 bounding boxes.

## Changes

1. `make_transformed_box(...)` method was fixed in IntersectionChecker.cpp
2. Expected distance between bounding boxes was updated in test_IntersectionChecker.cpp
3. Test 4 & 5 created to check when both bounding boxes are at random positions and orientations

## Result

1. Test 3 is passing
2. Test 1 & 2 passing with smaller error margin
3. Test 4 & 5 passing

Onshape was used to visualize the test cases and measure the expected distance between non-intersecting bounding boxes.
https://cad.onshape.com/documents/437b8a87624f92ed41e30c3b/w/fd8e8a03d1faf030c1f83614/e/7bbd8a761aa9f5c4f8223de4?renderMode=0&uiState=62e8da33b51e8d734cd12865