### PR TITLE
Fix boost link problem

### DIFF
--- a/rmf_websocket/CMakeLists.txt
+++ b/rmf_websocket/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(rclcpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(nlohmann_json_schema_validator_vendor REQUIRED)
 find_package(websocketpp REQUIRED)
+find_package(Boost COMPONENTS system filesystem REQUIRED)
 
 file(GLOB_RECURSE core_lib_srcs "src/rmf_websocket/*.cpp")
 add_library(rmf_websocket SHARED ${core_lib_srcs})
@@ -31,6 +32,8 @@ target_link_libraries(rmf_websocket
     rmf_utils::rmf_utils
     nlohmann_json::nlohmann_json
     nlohmann_json_schema_validator
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
 )
 
 target_include_directories(rmf_websocket
@@ -42,7 +45,7 @@ target_include_directories(rmf_websocket
 )
 
 ament_export_targets(rmf_websocket HAS_LIBRARY_TARGET)
-ament_export_dependencies(rmf_traffic rclcpp nlohmann_json)
+ament_export_dependencies(rmf_traffic rclcpp nlohmann_json websocketpp)
 
 #===============================================================================
 install(

--- a/rmf_websocket/CMakeLists.txt
+++ b/rmf_websocket/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(rmf_websocket
     rmf_utils::rmf_utils
     nlohmann_json::nlohmann_json
     nlohmann_json_schema_validator
+  PRIVATE
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
 )

--- a/rmf_websocket/include/rmf_websocket/BroadcastServer.hpp
+++ b/rmf_websocket/include/rmf_websocket/BroadcastServer.hpp
@@ -18,15 +18,10 @@
 #ifndef RMF_WEBSOCKET__BROADCAST_SERVER_HPP
 #define RMF_WEBSOCKET__BROADCAST_SERVER_HPP
 
-#include <websocketpp/config/asio_no_tls.hpp>
-#include <websocketpp/server.hpp>
-
 #include <nlohmann/json.hpp>
 
 #include <optional>
 #include <rmf_utils/impl_ptr.hpp>
-
-using Server = websocketpp::server<websocketpp::config::asio>;
 
 namespace rmf_websocket {
 

--- a/rmf_websocket/package.xml
+++ b/rmf_websocket/package.xml
@@ -19,6 +19,9 @@
 
   <build_depend>eigen</build_depend>
 
+  <build_depend>boost</build_depend>
+  <exec_depend>boost</exec_depend>
+
   <test_depend>ament_cmake_catch2</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
 

--- a/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
+++ b/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
@@ -28,6 +28,8 @@
 
 namespace rmf_websocket {
 
+using Server = websocketpp::server<websocketpp::config::asio>;
+
 //==============================================================================
 class BroadcastServer::Implementation
 {


### PR DESCRIPTION
Compiling in Redhat I was getting this error until I explicitly included the boost libs dependency:

```
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /opt/rmf/lib/librmf_websocket.so: undefined reference to `boost::system::system_category()'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /opt/rmf/lib/librmf_websocket.so: undefined reference to `boost::system::generic_category()'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/rmf_task_dispatcher.dir/build.make:253: rmf_task_dispatcher] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:143: CMakeFiles/rmf_task_dispatcher.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /opt/rmf/lib/librmf_websocket.so: undefined reference to `boost::system::system_category()'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /opt/rmf/lib/librmf_websocket.so: undefined reference to `boost::system::generic_category()'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/rmf_bidder_node.dir/build.make:253: rmf_bidder_node] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:221: CMakeFiles/rmf_bidder_node.dir/all] Error 2
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /opt/rmf/lib/librmf_websocket.so: undefined reference to `boost::system::system_category()'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /opt/rmf/lib/librmf_websocket.so: undefined reference to `boost::system::generic_category()'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/test_rmf_task_ros2.dir/build.make:301: test_rmf_task_ros2] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:117: CMakeFiles/test_rmf_task_ros2.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< rmf_task_ros2 [32.0s, exited with code 2]
[Processing: rmf_task_ros2]
```

Any other more generic solution suggestion would be welcomed.
For the description in this link it looks like it's also expected to explicitly link with boost libs:
https://github.com/zaphoyd/websocketpp/blob/1b11fd301531e6df35a6107c1e8665b1e77a2d8e/docs/getting_started.dox#L14

https://github.com/zaphoyd/websocketpp/blob/1b11fd301531e6df35a6107c1e8665b1e77a2d8e/tutorials/utility_server/utility_server.md?plain=1#L89