### PR TITLE
create unique task_id with timestamp

### DIFF
--- a/rmf_task_ros2/CHANGELOG.md
+++ b/rmf_task_ros2/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for package rmf_task_ros2
 
+2.1.0 (2022-XX-YY)
+------------------
+* ws broadcast client in dispatcher node [#212](https://github.com/open-rmf/rmf_ros2/pull/212)
+* create unique task_id with timestamp [#223](https://github.com/open-rmf/rmf_ros2/pull/223)
+
 2.0.0 (2022-03-18)
 ------------------
 No changes yet

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -486,7 +486,7 @@ public:
       if (use_timestamp_for_task_id)
       {
         task_id += std::to_string(
-          static_cast<int>(node->get_clock()->now().nanoseconds()/1e9));
+          static_cast<int>(node->get_clock()->now().nanoseconds()/1e6));
       }
       else
       {

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -175,6 +175,7 @@ public:
   builtin_interfaces::msg::Duration bidding_time_window;
   std::size_t terminated_tasks_max_size;
   int publish_active_tasks_period;
+  bool use_timestamp_for_task_id;
 
   std::unordered_map<std::size_t, std::string> legacy_task_type_names =
   {
@@ -209,7 +210,11 @@ public:
     RCLCPP_INFO(node->get_logger(),
       " Declared publish_active_tasks_period as: %d secs",
       publish_active_tasks_period);
-
+    use_timestamp_for_task_id =
+      node->declare_parameter<bool>("use_timestamp_for_task_id", false);
+    RCLCPP_INFO(node->get_logger(),
+      " Use timestamp with task_id: %s",
+      (use_timestamp_for_task_id ? "true" : "false"));
 
     std::optional<std::string> server_uri = std::nullopt;
     const std::string uri =
@@ -474,9 +479,20 @@ public:
       }
 
       const auto& task_request_json = msg_json["request"];
-      const std::string task_id =
+      std::string task_id =
         task_request_json["category"].get<std::string>()
-        + ".dispatch-" + std::to_string(task_counter++);
+        + ".dispatch-";
+
+      if (use_timestamp_for_task_id)
+      {
+        task_id += std::to_string(
+          std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+      }
+      else
+      {
+        task_id += std::to_string(task_counter++);
+      }
 
       const auto task_state = push_bid_notice(
         rmf_task_msgs::build<bidding::BidNoticeMsg>()

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -486,8 +486,7 @@ public:
       if (use_timestamp_for_task_id)
       {
         task_id += std::to_string(
-          std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count());
+          static_cast<int>(node->get_clock()->now().nanoseconds()/1e9));
       }
       else
       {


### PR DESCRIPTION
The current way of generating a task id uses a `task_counter`, which generates the task_id by appending an integer `task counter` value (eg. `patrol.dispatch-1`). However, this poses a problem when we require the task_id to be unique even after restarting the `task dispatcher` node (during deployment setup especially). Therefore, this solution generates a unique id with a timestamp. This can be enabled via ros2 param, by setting  `use_timestamp_for_task_id` as `true`. 

p/s: `use_timestamp_for_task_id` is false by default (using task counter)


## To test

Run dispatcher with use_timestamp_for_task_id as true
```bash
ros2 run rmf_task_ros2 rmf_task_dispatcher  --ros-args -p use_timestamp_for_task_id:=true
```

Try dispatch a dummy task
```bash
ros2 run rmf_demos_tasks dispatch_patrol -p coe
```