### PR TITLE
Decommissioning

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -323,6 +323,19 @@ public:
   class Unstable
   {
   public:
+    /// True if this robot is allowed to accept new tasks. False if the robot
+    /// will not accept any new tasks.
+    bool is_commissioned() const;
+
+    /// Stop this robot from accepting any new tasks. It will continue to
+    /// perform tasks that are already in its queue. To reassign those tasks,
+    /// you will need to use the task request API to cancel the tasks and
+    /// re-request them.
+    void decommission();
+
+    /// Allow this robot to resume accepting new tasks.
+    void recommission();
+
     /// Get the schedule participant of this robot
     rmf_traffic::schedule::Participant* get_participant();
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1132,6 +1132,10 @@ auto FleetUpdateHandle::Implementation::aggregate_expectations() const
   Expectations expect;
   for (const auto& t : task_managers)
   {
+    // Ignore any robots that are not currently commissioned.
+    if (!t.first->is_commissioned())
+      continue;
+
     expect.states.push_back(t.second->expected_finish_state());
     const auto requests = t.second->requests();
     expect.pending_requests.insert(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -436,6 +436,24 @@ std::shared_ptr<TaskManager> RobotContext::task_manager()
 }
 
 //==============================================================================
+bool RobotContext::is_commissioned() const
+{
+  return _commissioned;
+}
+
+//==============================================================================
+void RobotContext::decommission()
+{
+  _commissioned = false;
+}
+
+//==============================================================================
+void RobotContext::recommission()
+{
+  _commissioned = true;
+}
+
+//==============================================================================
 Reporting& RobotContext::reporting()
 {
   return _reporting;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -229,6 +229,14 @@ public:
   /// Get the task manager for this robot, if it exists.
   std::shared_ptr<TaskManager> task_manager();
 
+  /// Return true if this robot is currently commissioned (available to accept
+  /// new tasks).
+  bool is_commissioned() const;
+
+  void decommission();
+
+  void recommission();
+
   Reporting& reporting();
 
   const Reporting& reporting() const;
@@ -290,6 +298,7 @@ private:
 
   RobotUpdateHandle::Unstable::Watchdog _lift_watchdog;
   rmf_traffic::Duration _lift_rewait_duration = std::chrono::seconds(0);
+  bool _commissioned = true;
 
   // Mode value for RobotMode message
   uint32_t _current_mode;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -626,6 +626,43 @@ const RobotUpdateHandle::Unstable& RobotUpdateHandle::unstable() const
 }
 
 //==============================================================================
+bool RobotUpdateHandle::Unstable::is_commissioned() const
+{
+  if (const auto context = _pimpl->get_context())
+    return context->is_commissioned();
+
+  return false;
+}
+
+//==============================================================================
+void RobotUpdateHandle::Unstable::decommission()
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->worker().schedule(
+      [w = context->weak_from_this()](const auto&)
+      {
+        if (const auto context = w.lock())
+          context->decommission();
+      });
+  }
+}
+
+//==============================================================================
+void RobotUpdateHandle::Unstable::recommission()
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->worker().schedule(
+      [w = context->weak_from_this()](const auto&)
+      {
+        if (const auto context = w.lock())
+          context->recommission();
+      });
+  }
+}
+
+//==============================================================================
 rmf_traffic::schedule::Participant*
 RobotUpdateHandle::Unstable::get_participant()
 {

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -138,6 +138,25 @@ PYBIND11_MODULE(rmf_adapter, m) {
       self.maximum_delay(duration);
     },
     py::arg("seconds"))
+  .def("unstable_is_commissioned",
+    [&](const agv::RobotUpdateHandle& self)
+    {
+      return self.unstable().is_commissioned();
+    },
+    "Check if the robot is currently allowed to accept any new tasks")
+  .def("unstable_decommission",
+    [&](agv::RobotUpdateHandle& self)
+    {
+      return self.unstable().decommission();
+    },
+    "Stop this robot from accepting any new tasks. Use recommission to resume")
+  .def("unstable_recommission",
+    [&](agv::RobotUpdateHandle& self)
+    {
+      return self.unstable().recommission();
+    },
+    "Allow this robot to resume accepting new tasks if it was ever "
+    "decommissioned in the past")
   .def("get_unstable_participant",
     [&](agv::RobotUpdateHandle& self)
     {


### PR DESCRIPTION
This PR adds an experimental API for "decommissioning" robots. After a robot is decommissioned it will no longer accept any new tasks. It will continue performing any tasks that have accumulated in its queue. To clear the tasks that are already in its queue, they will need to be explicitly canceled using the [task API](https://github.com/open-rmf/rmf_api_msgs/tree/main/rmf_api_msgs/schemas).

A decommissioned robot can use the `recommission` function at any time to resume accepting new tasks.

To have a robot immediately stop performing ongoing tasks, you must use the [interrupt, cancel, or kill](https://github.com/open-rmf/rmf_ros2/blob/617e83d32f028f2115885dd4f4f6b66799762db6/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp#L214-L260) APIs.