### PR TITLE
Fix the rosdep key used for uuid

### DIFF
--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -22,8 +22,8 @@
   <depend>proj</depend>
   <depend>zlib</depend>
 
-  <build_depend>uuid-dev</build_depend>
-  <exec_depend>uuid-dev</exec_depend>
+  <build_depend>uuid</build_depend>
+  <exec_depend>uuid</exec_depend>
 
   <build_depend>eigen</build_depend>
 


### PR DESCRIPTION
I guess the wrong rosdep key for `uuid-dev`. This PR updates it to match [the correct key](https://github.com/ros/rosdistro/blob/1f11b8f6cf081f80a1d0be8e81643eb6be29ef08/rosdep/base.yaml#L7948).