### PR TITLE
Add Threads dependency

### DIFF
--- a/rmf_websocket/CMakeLists.txt
+++ b/rmf_websocket/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(nlohmann_json REQUIRED)
 find_package(nlohmann_json_schema_validator_vendor REQUIRED)
 find_package(websocketpp REQUIRED)
 find_package(Boost COMPONENTS system filesystem REQUIRED)
+find_package(Threads)
 
 file(GLOB_RECURSE core_lib_srcs "src/rmf_websocket/*.cpp")
 add_library(rmf_websocket SHARED ${core_lib_srcs})
@@ -35,6 +36,7 @@ target_link_libraries(rmf_websocket
   PRIVATE
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
+    Threads::Threads
 )
 
 target_include_directories(rmf_websocket


### PR DESCRIPTION
The implementation of `rmf_websocket` uses `std::thread`, so we should include that in the build script.