### PR TITLE
Update easy full control

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -140,6 +140,31 @@ public:
       rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(0.5)
     );
 
+    /// Create a Configuration object using a set of configuration parameters
+    /// imported from YAML files that follow the defined schema. This is an
+    /// alternative to constructing the Configuration using the RMF objects if
+    /// users do not require specific tool systems for their fleets.
+    ///
+    /// \param[in] config_file
+    ///   The path to a configuration YAML file containing data about the fleet's
+    ///   vehicle traits and task capabilities. This file needs to follow the pre-defined
+    ///   config.yaml structure to successfully load the parameters into the Configuration
+    ///   object.
+    ///
+    /// \param[in] nav_graph_path
+    ///   The path to a navigation path file that includes map information necessary
+    ///   to create a rmf_traffic::agv::Graph object
+    ///
+    /// \param[in] server_uri
+    ///   The URI for the websocket server that receives updates on tasks and
+    ///   states. If nullopt, data will not be published.
+    ///
+    /// \return A Configuration object with the essential config parameters loaded.
+    static Configuration make(
+      const std::string& config_file,
+      const std::string& nav_graph_path,
+      std::optional<std::string> server_uri = std::nullopt);
+
     /// Get the fleet name.
     const std::string& fleet_name() const;
 

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -137,7 +137,8 @@ public:
       rmf_task::ConstRequestFactoryPtr finishing_request = nullptr,
       std::optional<std::string> server_uri = std::nullopt,
       rmf_traffic::Duration max_delay = rmf_traffic::time::from_seconds(10.0),
-      rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(0.5)
+      rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(
+        0.5)
     );
 
     /// Create a Configuration object using a set of configuration parameters
@@ -448,8 +449,8 @@ struct Transformation
     double scale_,
     double translation_x_,
     double translation_y_)
-    : rotation(rotation_),
-      scale(scale_)
+  : rotation(rotation_),
+    scale(scale_)
   {
     translation = Eigen::Vector2d{translation_x_, translation_y_};
   }

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -270,21 +270,49 @@ public:
   /// \return RobotState
   using GetStateCallback = std::function<RobotState(void)>;
 
-  /// Signature for a function that is used to track the status of a goal.
+  ///   The GoalStatus class contains information about the robot's progress
+  ///   in completing a goal.
+  class GoalStatus
+  {
+  public:
+
+    /// Constructor
+    ///
+    /// \param[in] success
+    ///   A bool indicating whether the robot has completed the goal
+    ///
+    /// \param[in] remaining_time
+    ///   A duration object containing the time remaining for this goal. If not
+    ///   updated, the adapter will derive the time estimate by interpolating
+    ///   the robot's motion to the destination location.
+    ///
+    /// \param[in] request_replan
+    ///   A bool to request the fleet adapter to generate a new plan for this
+    ///   robot due to issues with completing the goal.
+    GoalStatus(
+      bool success = false,
+      std::optional<rmf_traffic::Duration> remaining_time = std::nullopt,
+      bool request_replan = false);
+
+    /// Get the success status
+    bool success() const;
+
+    /// Get the remaining time
+    std::optional<rmf_traffic::Duration> remaining_time() const;
+
+    /// Get the replan request
+    bool request_replan() const;
+
+    class Implementation;
+
+  private:
+    rmf_utils::impl_ptr<Implementation> _pimpl;
+  };
+
+  /// Signature for a callback that returns the latest GoalStatus of the robot.
   ///
-  /// \param[in] remaining_time
-  ///   A mutable reference to set the time remaining for this goal. If not
-  ///   updated, the adapter will derive the time estimate by interpolating
-  ///   the robot's motion to the destination location.
-  ///
-  /// \param[in]  request_replan
-  ///   A mutable reference to request the fleet adapter to generate a new plan
-  ///   for this robot due to issues with completing the goal.
-  ///
-  /// \return True if the robot has completed the goal.
-  using GoalCompletedCallback = std::function<bool(
-        rmf_traffic::Duration& remaining_time,
-        bool& request_replan)>;
+  /// \return GoalStatus
+  using GoalCompletedCallback = std::function<GoalStatus(void)>;
 
   /// Signature for a function to request the robot to navigate to a location.
   ///

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -430,6 +430,38 @@ private:
 
 using EasyFullControlPtr = std::shared_ptr<EasyFullControl>;
 
+/// A Transformation object that stores the transformation data needed to
+/// perform transformation between robot and RMF cartesian frames.
+struct Transformation
+{
+  /// The 2D translation from one coordinate to another
+  Eigen::Vector2d translation;
+
+  /// The rotation angle (radians) between the two cartesian frames.
+  double rotation;
+
+  /// The scaling factor between the cartesian frames.
+  double scale;
+
+  Transformation(
+    double rotation_,
+    double scale_,
+    double translation_x_,
+    double translation_y_)
+    : rotation(rotation_),
+      scale(scale_)
+  {
+    translation = Eigen::Vector2d{translation_x_, translation_y_};
+  }
+};
+
+/// Helper function to transform between RMF and robot coordinate systems.
+/// Depending on the Transformation defined, this function can be used to
+/// transform robot coordinate system to RMF's coordinate system or vice versa.
+const Eigen::Vector3d transform(
+  const Transformation& transformation,
+  const Eigen::Vector3d& pose);
+
 } // namespace agv
 } // namespace rmf_fleet_adapter
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -668,7 +668,8 @@ void EasyCommandHandle::start_follow()
         _state = InternalRobotState::IDLE;
 
         std::lock_guard<std::mutex> lock(mutex);
-        if (target_waypoint.has_value() && target_waypoint->graph_index.has_value())
+        if (target_waypoint.has_value() &&
+          target_waypoint->graph_index.has_value())
         {
           on_waypoint = target_waypoint->graph_index;
           last_known_waypoint = on_waypoint;
@@ -726,13 +727,14 @@ void EasyCommandHandle::start_follow()
           const auto now = std::chrono::steady_clock::now();
           const rmf_traffic::Trajectory t =
             rmf_traffic::agv::Interpolate::positions(
-              *traits,
-              now,
-              {state.location(), target_waypoint->position}
-          );
+            *traits,
+            now,
+            {state.location(), target_waypoint->position}
+            );
           auto trajectory_time = t.finish_time();
-          rmf_traffic::Duration remaining_time  =
-            trajectory_time ? *trajectory_time - now : rmf_traffic::time::from_seconds(5.0);
+          rmf_traffic::Duration remaining_time =
+            trajectory_time ? *trajectory_time - now :
+            rmf_traffic::time::from_seconds(5.0);
 
           const auto finish_time =
             goal_status.remaining_time().has_value() ?
@@ -997,7 +999,8 @@ EasyFullControl::Configuration EasyFullControl::Configuration::make(
 {
   // Load fleet config file
   const auto fleet_config = YAML::LoadFile(config_file);
-  const std::string fleet_name = fleet_config["rmf_fleet"]["name"].as<std::string>();
+  const std::string fleet_name =
+    fleet_config["rmf_fleet"]["name"].as<std::string>();
   const YAML::Node rmf_fleet = fleet_config["rmf_fleet"];
 
   // Profile and traits
@@ -1093,7 +1096,8 @@ EasyFullControl::Configuration EasyFullControl::Configuration::make(
     *battery_system, *tool_power_system);
 
   // Drain battery
-  const auto account_for_battery_drain = rmf_fleet["account_for_battery_drain"].as<bool>();
+  const auto account_for_battery_drain =
+    rmf_fleet["account_for_battery_drain"].as<bool>();
   // Recharge threshold
   const auto recharge_threshold =
     rmf_fleet["recharge_threshold"].as<double>();
@@ -1336,7 +1340,8 @@ bool EasyFullControl::GoalStatus::success() const
 }
 
 //==============================================================================
-std::optional<rmf_traffic::Duration> EasyFullControl::GoalStatus::remaining_time() const
+std::optional<rmf_traffic::Duration> EasyFullControl::GoalStatus::remaining_time()
+const
 {
   return _pimpl->remaining_time;
 }
@@ -1587,9 +1592,9 @@ std::shared_ptr<EasyFullControl> EasyFullControl::make(
     if (!config_from_params)
     {
       RCLCPP_ERROR(
-      node->get_logger(),
-      "Unable to configure fleet using provided configuration or ROS 2 "
-      "parameters"
+        node->get_logger(),
+        "Unable to configure fleet using provided configuration or ROS 2 "
+        "parameters"
       );
       return nullptr;
     }
@@ -1656,7 +1661,8 @@ std::shared_ptr<EasyFullControl> EasyFullControl::make(
   }
 
   easy_adapter->_pimpl->fleet_handle->default_maximum_delay(config.max_delay());
-  easy_adapter->_pimpl->fleet_handle->fleet_state_topic_publish_period(config.update_interval());
+  easy_adapter->_pimpl->fleet_handle->fleet_state_topic_publish_period(
+    config.update_interval());
 
   RCLCPP_INFO(
     node->get_logger(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -1794,6 +1794,20 @@ auto EasyFullControl::add_robot(
 }
 
 //==============================================================================
+const Eigen::Vector3d transform(
+  const Transformation& transformation,
+  const Eigen::Vector3d& pose)
+{
+  const auto& rotated =
+    Eigen::Rotation2D<double>(transformation.rotation) *
+    (transformation.scale * pose.block<2, 1>(0, 0));
+  const auto& translated = rotated + transformation.translation;
+
+  return Eigen::Vector3d{
+    translated[0], translated[1], pose[2] + transformation.rotation};
+}
+
+//==============================================================================
 
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -832,4 +832,20 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property_readonly("success", &agv::EasyFullControl::GoalStatus::success)
   .def_property_readonly("remaining_time", &agv::EasyFullControl::GoalStatus::remaining_time)
   .def_property_readonly("request_replan", &agv::EasyFullControl::GoalStatus::request_replan);
+
+  // Transformation =============================================================
+  py::class_<agv::Transformation>(m_easy_full_control, "Transformation")
+  .def(py::init<double,
+      double,
+      double,
+      double>(),
+    py::arg("rotation"),
+    py::arg("scale"),
+    py::arg("translation_x"),
+    py::arg("translation_y"));
+
+  m_easy_full_control.def("transform",
+    &agv::transform,
+    py::arg("transformation"),
+    py::arg("pose"));
 }

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -702,22 +702,6 @@ PYBIND11_MODULE(rmf_adapter, m) {
   // EASY FULL CONTROL CONFIGURATION ===============================================
   auto m_easy_full_control = m.def_submodule("easy_full_control");
 
-  // Custom bindings since Python doesn't allow changing ref to primitive types
-  m_easy_full_control.def("goal_completed_callback",[](
-      std::function<std::tuple<
-        bool,
-        rmf_traffic::Duration,
-        bool>(rmf_traffic::Duration&, bool&)> &f) -> agv::EasyFullControl::GoalCompletedCallback
-      {
-        return [f](rmf_traffic::Duration& remaining_time, bool& request_replan) -> bool
-        {
-          auto [completed, _remaining_time, _request_replan] = f(remaining_time, request_replan);
-          remaining_time = _remaining_time;
-          request_replan = _request_replan;
-          return completed;
-        };
-      });
-
   py::class_<agv::EasyFullControl::Configuration>(m_easy_full_control, "Configuration")
   .def(py::init([]( // Lambda function to convert reference to shared ptr
         std::string& fleet_name,
@@ -835,4 +819,17 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property_readonly("map_name", &agv::EasyFullControl::RobotState::map_name)
   .def_property_readonly("location", &agv::EasyFullControl::RobotState::location)
   .def_property_readonly("battery_soc", &agv::EasyFullControl::RobotState::battery_soc);
+
+  // EASY FULL CONTROL GoalStatus ===============================================
+  py::class_<agv::EasyFullControl::GoalStatus>(m_easy_full_control, "GoalStatus")
+  .def(py::init<bool,
+      std::optional<rmf_traffic::Duration>,
+      bool>(),
+    py::arg("success"),
+    py::arg("remaining_time") = std::optional<rmf_traffic::Duration>(
+      std::nullopt),
+    py::arg("request_replan"))
+  .def_property_readonly("success", &agv::EasyFullControl::GoalStatus::success)
+  .def_property_readonly("remaining_time", &agv::EasyFullControl::GoalStatus::remaining_time)
+  .def_property_readonly("request_replan", &agv::EasyFullControl::GoalStatus::request_replan);
 }

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -783,7 +783,12 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("finishing_request") = "nothing",
     py::arg("server_uri") = std::nullopt,
     py::arg("max_delay") = rmf_traffic::time::from_seconds(10.0),
-    py::arg("update_interval") = rmf_traffic::time::from_seconds(0.5));
+    py::arg("update_interval") = rmf_traffic::time::from_seconds(0.5))
+  .def_static("make",
+    &agv::EasyFullControl::Configuration::make,
+    py::arg("config_file"),
+    py::arg("nav_graph_path"),
+    py::arg("server_uri"));
       /*
   .def_property("fleet_name",
     py::overload_cast<>(&agv::Configuration::fleet_name, py::const_),


### PR DESCRIPTION
This PR updates the `feature/easy_full_control` branch with the following:
- `Configuration::make` to easily create a Configuration object by parsing config and navigation graph file paths
- Modify `GoalCompletedCallback` to return the goal remaining time and replan request instead of updating the references
- Add `Transformation` struct and `transform` helper function