### PR TITLE
Fix emergency response for waiting robots

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1224,12 +1224,19 @@ void TaskManager::_begin_next_task()
   if (_active_task)
     return;
 
+  if (_emergency_active)
+    return;
+
   std::lock_guard<std::mutex> guard(_mutex);
 
   if (_queue.empty() && _direct_queue.empty())
   {
+    std::cout << "QUEUES ARE EMPTY -- BEGIN WAITING" << std::endl;
     if (!_waiting)
+    {
+      std::cout << "WE ARE NOT YET WAITING -- REALLY BEGIN WAITING" << std::endl;
       _begin_waiting();
+    }
 
     return;
   }
@@ -1469,8 +1476,12 @@ void TaskManager::_resume_from_emergency()
       if (!self)
         return;
 
-      if (self->_emergency_active)
+      if (self->_emergency_active) {
+        std::cout << "EMERGENCY IS STILL ACTIVE: WILL CONTINUE WAITING" << std::endl;
         return;
+      }
+
+      std::cout << "EMERGENCY IS NO LONGER ACTIVE" << std::endl;
 
       if (!self->_emergency_pullover_interrupt_token.has_value())
         return;
@@ -1486,6 +1497,7 @@ void TaskManager::_resume_from_emergency()
       }
       else
       {
+        std::cout << "BEGINNING NEXT TASK" << std::endl;
         self->_begin_next_task();
       }
     });

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -128,6 +128,12 @@ TaskManagerPtr TaskManager::make(
         mgr->_emergency_active = msg->data;
         if (msg->data)
         {
+          if (mgr->_waiting)
+          {
+            // Cancel any waiting behavior that might be active.
+            mgr->_waiting.cancel({"emergency pullover"}, mgr->_context->now());
+          }
+
           if (mgr->_active_task)
           {
             mgr->_emergency_pullover_interrupt_token =

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1237,12 +1237,8 @@ void TaskManager::_begin_next_task()
 
   if (_queue.empty() && _direct_queue.empty())
   {
-    std::cout << "QUEUES ARE EMPTY -- BEGIN WAITING" << std::endl;
     if (!_waiting)
-    {
-      std::cout << "WE ARE NOT YET WAITING -- REALLY BEGIN WAITING" << std::endl;
       _begin_waiting();
-    }
 
     return;
   }
@@ -1482,12 +1478,8 @@ void TaskManager::_resume_from_emergency()
       if (!self)
         return;
 
-      if (self->_emergency_active) {
-        std::cout << "EMERGENCY IS STILL ACTIVE: WILL CONTINUE WAITING" << std::endl;
+      if (self->_emergency_active)
         return;
-      }
-
-      std::cout << "EMERGENCY IS NO LONGER ACTIVE" << std::endl;
 
       if (!self->_emergency_pullover_interrupt_token.has_value())
         return;
@@ -1503,7 +1495,6 @@ void TaskManager::_resume_from_emergency()
       }
       else
       {
-        std::cout << "BEGINNING NEXT TASK" << std::endl;
         self->_begin_next_task();
       }
     });


### PR DESCRIPTION
Previously when a robot is in responsive wait mode, it would not behave correctly when an emergency alarm is triggered.

This PR fixes the problem by cancelling the responsive wait behavior when an emergency alarm is activated.