### PR TITLE
Properly cleanup emergency pullover task

### DIFF
--- a/rmf_fleet_adapter/CHANGELOG.md
+++ b/rmf_fleet_adapter/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for package rmf_fleet_adapter
 
+2.1.x (2023-xx-xx)
+------------------
+* Fix emergency response for waiting robots: [#253](https://github.com/open-rmf/rmf_ros2/pull/253)
+* Properly cleanup emergency pullover task: [#258](https://github.com/open-rmf/rmf_ros2/pull/258)
+
 2.1.2 (2022-10-10)
 ------------------
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -153,9 +153,6 @@ TaskManagerPtr TaskManager::make(
           {
             if (mgr->_emergency_pullover.is_finished())
             {
-              // TODO this seems to help but seems a bit dirty?
-              mgr->_emergency_pullover.kill(
-                {"emergency notice topic"}, mgr->_context->now());
               mgr->_resume_from_emergency();
             }
             else
@@ -1484,10 +1481,11 @@ void TaskManager::_resume_from_emergency()
       if (self->_emergency_active)
         return;
 
+      self->_emergency_pullover = ActiveTask();
+
       if (!self->_emergency_pullover_interrupt_token.has_value())
         return;
 
-      self->_emergency_pullover = ActiveTask();
       if (self->_active_task)
       {
         self->_active_task.remove_interruption(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -153,6 +153,9 @@ TaskManagerPtr TaskManager::make(
           {
             if (mgr->_emergency_pullover.is_finished())
             {
+              // TODO this seems to help but seems a bit dirty?
+              mgr->_emergency_pullover.kill(
+                {"emergency notice topic"}, mgr->_context->now());
               mgr->_resume_from_emergency();
             }
             else


### PR DESCRIPTION
## Bug fix

### Fixed bug

Early return in the `_resume_from_emergency` function caused the `_emergency_pullover` task not to be cleared. This would happen when the `_emergency_pullover_interrupt_token` was not set, which would happen when the fire alarm was triggered and a robot was not executing any task.
The emergency pullover still being active created spurious requests for replanning in the fleet adapter, which are quite harmless in simulation but can be troublesome in real deployments since they would stop the robot on the spot, then send a new path.

### Fix applied

Just move the clearing of the emergency pullover task to before the early return.

To test in office world:
* Set the fleet adapter to [do nothing on task finish](https://github.com/open-rmf/rmf_demos/blob/main/rmf_demos/config/office/tinyRobot_config.yaml#L38).
* Assign a task, i.e. `ros2 run rmf_demos_tasks dispatch_patrol -p patrol_A1 -n 1 --use_sim_time`
* Wait for the task to be finished.
* Set the fire alarm: `ros2 topic pub /fire_alarm_trigger std_msgs/msg/Bool "data: true"`
* Wait for emergency pullover to be finished
* Clear the fire alarm `ros2 topic pub /fire_alarm_trigger std_msgs/msg/Bool "data: false"`
* Submit a new task: `ros2 run rmf_demos_tasks dispatch_patrol -p coe lounge -n 3 --use_sim_time`

Without this PR, replanning will be triggered regularly for the robot, with this PR this won't happen.