### PR TITLE
Explicitly link to the Threads target

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
+find_package(Threads REQUIRED)
 if(DEFINED ENV{RMF_ENABLE_FAILOVER})
   if($ENV{RMF_ENABLE_FAILOVER} EQUAL 1)
     find_package(stubborn_buddies REQUIRED)
@@ -93,6 +94,7 @@ target_link_libraries(rmf_fleet_adapter
     ${rmf_ingestor_msgs_LIBRARIES}
     ${rmf_building_map_msgs_LIBRARIES}
     nlohmann_json_schema_validator
+    Threads::Threads
 )
 
 target_include_directories(rmf_fleet_adapter


### PR DESCRIPTION
It seems the ROS2 build farm [is not happy](https://build.ros2.org/job/Rbin_ujv8_uJv8__rmf_fleet_adapter__ubuntu_jammy_arm64__binary/149/) with `rmf_fleet_adapter`, and it appears to have something to do with pthread in cmake. Usually this kind of issue is resolved by finding cmake's built in `Threads` package and linking to its `Threads::Threads` target. Hopefully this PR resolves the build farm issue.