### PR TITLE
Bump version to 2.1.3 and update changelogs

### DIFF
--- a/rmf_fleet_adapter/CHANGELOG.md
+++ b/rmf_fleet_adapter/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## Changelog for package rmf_fleet_adapter
 
-2.1.x (2023-xx-xx)
+2.1.3 (2023-04-26)
 ------------------
 * Fix emergency response for waiting robots: [#253](https://github.com/open-rmf/rmf_ros2/pull/253)
 * Properly cleanup emergency pullover task: [#258](https://github.com/open-rmf/rmf_ros2/pull/258)
+* Fix priority assignment when parsing tasks: [#265](https://github.com/open-rmf/rmf_ros2/issues/265)
+* Link Threads to fix build errors on certain platforms: [#204](https://github.com/open-rmf/rmf_ros2/issues/204)
+* Contributors: decada-robotics, Luca Della Vedova, Grey, Yadunund
 
 2.1.2 (2022-10-10)
 ------------------

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -2,11 +2,12 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_fleet_adapter</name>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
   <description>Fleet Adapter package for RMF fleets.</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <maintainer email="aaron@openrobotics.org">Aaron</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
+  <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rmf_fleet_adapter_python/CHANGELOG.md
+++ b/rmf_fleet_adapter_python/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog for package rmf_fleet_adapter_python
 
+2.1.3 (2023-04-26)
+------------------
+
 2.1.2 (2022-10-10)
 ------------------
 
@@ -14,6 +17,7 @@
 * Allow `ResponsiveWait` to be enabled and disabled: [#209](https://github.com/open-rmf/rmf_ros2/pull/209)
 * Allow robot status to be overridden by the user: [#191](https://github.com/open-rmf/rmf_ros2/pull/191)
 * Add API to report status for `perform_action`: [#190](https://github.com/open-rmf/rmf_ros2/pull/190)
+* Changes for humble compatibility: [#215](https://github.com/open-rmf/rmf_ros2/issues/215)
 
 2.0.0 (2022-03-18)
 ------------------

--- a/rmf_fleet_adapter_python/package.xml
+++ b/rmf_fleet_adapter_python/package.xml
@@ -2,10 +2,11 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_fleet_adapter_python</name>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
   <description>Python bindings for the rmf_fleet_adapter</description>
   <maintainer email="methylDragon@gmail.com">methylDragon</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
+  <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <license>Apache License 2.0</license>
 
   <depend>pybind11_vendor</depend>

--- a/rmf_task_ros2/CHANGELOG.md
+++ b/rmf_task_ros2/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for package rmf_task_ros2
 
+2.1.3 (2023-04-26)
+------------------
+* Link Threads to fix build errors on certain platforms: [#204](https://github.com/open-rmf/rmf_ros2/issues/204)
+* Contributors: decada-robotics, Grey
+
 2.1.2 (2022-10-10)
 ------------------
 * Add find_package for vendored project.
@@ -15,6 +20,7 @@
 * Change default task auction evaluator to `QuickestFinishEvaluator`: [#211](https://github.com/open-rmf/rmf_ros2/pull/211)
 * ws broadcast client in dispatcher node [#212](https://github.com/open-rmf/rmf_ros2/pull/212)
 * create unique task_id with timestamp [#223](https://github.com/open-rmf/rmf_ros2/pull/223)
+* Changes for humble compatibility: [#215](https://github.com/open-rmf/rmf_ros2/issues/215)
 
 2.0.0 (2022-03-18)
 ------------------

--- a/rmf_task_ros2/package.xml
+++ b/rmf_task_ros2/package.xml
@@ -2,9 +2,9 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_task_ros2</name>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
   <description>A package managing the dispatching of tasks in RMF system.</description>
-  <maintainer email="youliang@openrobotics.org">youliang</maintainer>
+  <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache License 2.0</license>
 

--- a/rmf_traffic_ros2/CHANGELOG.md
+++ b/rmf_traffic_ros2/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog for package rmf_traffic_ros2
 
+2.1.3 (2023-04-26)
+------------------
+
 2.1.2 (2022-10-10)
 ------------------
 
@@ -10,6 +13,7 @@
 * Ignore conflicts between any plans that have a dependency: [#205](https://github.com/open-rmf/rmf_ros2/pull/205)
 * Add support for docking in lanes with entry events: [#226](https://github.com/open-rmf/rmf_ros2/pull/226)
 * Add message conversion functions for the navigation graph: [#207](https://github.com/open-rmf/rmf_ros2/pull/207)
+* Changes for humble compatibility: [#215](https://github.com/open-rmf/rmf_ros2/issues/215)
 
 2.0.0 (2022-03-18)
 ------------------

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -2,10 +2,11 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_traffic_ros2</name>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
   <description>A package containing messages used by the RMF traffic management system.</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
+  <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -34,4 +35,3 @@
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/rmf_websocket/CHANGELOG.md
+++ b/rmf_websocket/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog for package rmf_websocket
 
+2.1.3 (2023-04-26)
+------------------
+
 2.1.2 (2022-10-10)
 ------------------
 * Add find_package for vendored project.

--- a/rmf_websocket/package.xml
+++ b/rmf_websocket/package.xml
@@ -2,9 +2,9 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_websocket</name>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
   <description>A package managing the websocket api endpoints in RMF system.</description>
-  <maintainer email="youliang@openrobotics.org">youliang</maintainer>
+  <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache License 2.0</license>
 


### PR DESCRIPTION
Bump pkg versions to `2.1.3`, update changelogs and maintainer info.

Once this is merged, I'll tag main as `2.1.3` and bloom releases into `rolling` and `humble`.