### PR TITLE
Fix build failures on build farm

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,9 +14,9 @@ jobs:
     uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
-      # TODO(MXG): rmf_fleet_adapter_python tests are failing in the CI, and it seems to be related to https://github.com/ros2/launch/pull/592. Figure out how to fix this.
       packages: |
             rmf_fleet_adapter
+            rmf_fleet_adapter_python
             rmf_task_ros2
             rmf_traffic_ros2
             rmf_websocket

--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -57,6 +57,7 @@ if(BUILD_TESTING)
   ament_uncrustify(
     include src test rmf_rxcpp/include rmf_rxcpp/src rmf_rxcpp/test
     CONFIG_FILE ${uncrustify_config_file}
+    LANGUAGE C++
     MAX_LINE_LENGTH 80
   )
 endif()

--- a/rmf_fleet_adapter/rmf_rxcpp/include/rmf_rxcpp/RxJobs.hpp
+++ b/rmf_fleet_adapter/rmf_rxcpp/include/rmf_rxcpp/RxJobs.hpp
@@ -32,7 +32,7 @@ inline auto make_job(const std::shared_ptr<Action>& action)
 }
 
 template<typename Job0, typename... Jobs>
-inline auto merge_jobs(const Job0& o0, Jobs&& ... os)
+inline auto merge_jobs(const Job0& o0, Jobs&&... os)
 {
   return o0.merge(rxcpp::serialize_event_loop(), os...);
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -326,7 +326,7 @@ public:
   std::unordered_set<std::size_t> closed_lanes = {};
 
   template<typename... Args>
-  static std::shared_ptr<FleetUpdateHandle> make(Args&& ... args)
+  static std::shared_ptr<FleetUpdateHandle> make(Args&&... args)
   {
     auto handle = std::shared_ptr<FleetUpdateHandle>(new FleetUpdateHandle);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/services/ProgressEvaluator.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/services/ProgressEvaluator.cpp
@@ -38,11 +38,15 @@ ProgressEvaluator::ProgressEvaluator(
 bool ProgressEvaluator::initialize(const Result& setup)
 {
   if (!setup.cost_estimate())
+  {
     return false;
+  }
 
   const double cost = *setup.cost_estimate();
   if (cost < best_estimate.cost)
+  {
     best_estimate = Info{cost, &setup};
+  }
 
   return true;
 }
@@ -62,11 +66,15 @@ bool ProgressEvaluator::evaluate(Result& progress)
   if (progress.success())
   {
     if (cost < best_result.cost)
+    {
       best_result = Info{cost, &progress};
+    }
   }
 
   if (cost < second_best_estimate.cost)
+  {
     second_best_estimate = Info{cost, &progress};
+  }
 
   if (best_estimate.progress == &progress)
   {
@@ -126,7 +134,9 @@ void ProgressEvaluator::discard(Result& progress)
   const double cost = progress.cost_estimate() ?
     *progress.cost_estimate() : std::numeric_limits<double>::infinity();
   if (best_discarded.progress || cost < best_discarded.cost)
+  {
     best_discarded = Info{cost, &progress};
+  }
 
   ++finished_count;
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Clean.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Clean.cpp
@@ -290,7 +290,9 @@ void add_clean(
       agv::FleetUpdateHandle::Confirmation confirm;
       (*consider)(msg, confirm);
       if (!confirm.is_accepted())
+      {
         return {nullptr, confirm.errors()};
+      }
 
       // TODO(MXG): Validate the type of cleaning (vacuum, mopping, etc)
       /* *INDENT-OFF* */
@@ -310,7 +312,9 @@ void add_clean(
     {
       auto clean_task = deserialize_clean(msg);
       if (!clean_task.description)
+      {
         return {nullptr, std::move(clean_task.errors)};
+      }
 
       /* *INDENT-OFF* */
       return {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Compose.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Compose.cpp
@@ -58,7 +58,9 @@ void add_compose(
         // deserialize and use that.
         auto phase = p_it->second.deserializer(description_json);
         if (!phase.description)
+        {
           return {nullptr, std::move(phase.errors)};
+        }
 
         return phase;
       }
@@ -75,7 +77,9 @@ void add_compose(
 
       auto event = e_it->second.deserializer(description_json);
       if (!event.description)
+      {
         return {nullptr, std::move(event.errors)};
+      }
 
       using rmf_task_sequence::phases::SimplePhase;
       /* *INDENT-OFF* */
@@ -103,7 +107,9 @@ void add_compose(
     -> agv::DeserializedTask
     {
       if (!(*consider))
+      {
         return {nullptr, {"Not accepting composed requests"}};
+      }
 
       rmf_task_sequence::Task::Builder builder;
       std::string category = "Composed Task";
@@ -122,7 +128,9 @@ void add_compose(
       {
         auto phase_activity = deser_activity(phase_json.at("activity"));
         if (!phase_activity.description)
+        {
           return {nullptr, std::move(phase_activity.errors)};
+        }
 
         errors.insert(
           errors.end(),
@@ -142,7 +150,9 @@ void add_compose(
                 deser_activity(cancellation_activity_json);
 
               if (!cancellation_activity.description)
+              {
                 return {nullptr, std::move(cancellation_activity.errors)};
+              }
 
               cancel.push_back(cancellation_activity.description);
               errors.insert(
@@ -164,7 +174,9 @@ void add_compose(
       agv::FleetUpdateHandle::Confirmation confirm;
       (*consider)(msg, confirm);
       if (!confirm.is_accepted())
+      {
         return {nullptr, confirm.errors()};
+      }
 
       /* *INDENT-OFF* */
       return {
@@ -210,7 +222,9 @@ void add_compose(
         auto event = e_it->second.deserializer(description_json);
         errors.insert(errors.end(), event.errors.begin(), event.errors.end());
         if (!event.description)
+        {
           return {std::nullopt, std::move(errors)};
+        }
 
         deps.push_back(event.description);
       }
@@ -243,7 +257,9 @@ void add_compose(
       }
 
       if (!dependencies.description.has_value())
+      {
         return {nullptr, std::move(dependencies.errors)};
+      }
 
       /* *INDENT-OFF* */
       return {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.cpp
@@ -229,7 +229,9 @@ make_deserializer(
     ](const nlohmann::json& msg) -> agv::DeserializedEvent
     {
       if (!consider || !(*consider))
+      {
         return {nullptr, {"Not accepting delivery requests"}};
+      }
 
       auto place = place_deser(msg.at("place"));
       if (!place.description.has_value())
@@ -272,7 +274,9 @@ make_deserializer(
       agv::FleetUpdateHandle::Confirmation confirm;
       (*consider)(msg, confirm);
       if (!confirm.is_accepted())
+      {
         return {nullptr, confirm.errors()};
+      }
 
       // TODO(MXG): Add a way for system integrators to specify a duration
       // estimate for the payload transfer

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Patrol.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Patrol.cpp
@@ -58,7 +58,9 @@ void add_patrol(
 
       auto place = place_deser(place_msg);
       if (!place.description.has_value())
+      {
         return {nullptr, std::move(place.errors)};
+      }
 
       const auto desc =
         GoToPlace::Description::make(std::move(*place.description));
@@ -74,16 +76,16 @@ void add_patrol(
             place.errors.end(), f.errors.begin(), f.errors.end());
 
           if (!f.description.has_value())
+          {
             return {nullptr, place.errors};
+          }
 
           followed_by.push_back(*f.description);
         }
         desc->expected_next_destinations(std::move(followed_by));
       }
 
-      /* *INDENT-OFF* */
       return {desc, std::move(place.errors)};
-      /* *INDENT-ON* */
     };
 
   deserialization.event->add(
@@ -108,7 +110,9 @@ void add_patrol(
     ](const nlohmann::json& msg) -> agv::DeserializedTask
     {
       if (!(*consider))
+      {
         return {nullptr, {"Not accepting patrol requests"}};
+      }
 
       const auto& places_json = msg.at("places");
       std::vector<rmf_traffic::agv::Plan::Goal> places;
@@ -126,7 +130,9 @@ void add_patrol(
       }
 
       if (any_failure)
+      {
         return {nullptr, std::move(errors)};
+      }
 
       agv::FleetUpdateHandle::Confirmation confirm;
       (*consider)(msg, confirm);
@@ -134,7 +140,9 @@ void add_patrol(
         errors.end(), confirm.errors().begin(), confirm.errors().end());
 
       if (!confirm.is_accepted())
+      {
         return {nullptr, errors};
+      }
 
       std::size_t rounds = 1;
       const auto& rounds_json_it = msg.find("rounds");

--- a/rmf_fleet_adapter/test/services/test_Negotiate.cpp
+++ b/rmf_fleet_adapter/test/services/test_Negotiate.cpp
@@ -578,7 +578,7 @@ public:
     }
 
     template<typename... Args>
-    static std::shared_ptr<Responder> make(Args&& ... args)
+    static std::shared_ptr<Responder> make(Args&&... args)
     {
       return std::make_shared<Responder>(std::forward<Args>(args)...);
     }

--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -65,6 +65,7 @@ if(BUILD_TESTING)
   ament_uncrustify(
     ARGN include src test
     CONFIG_FILE ${uncrustify_config_file}
+    LANGUAGE C++
     MAX_LINE_LENGTH 80
   )
 

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -50,6 +50,7 @@ if(BUILD_TESTING)
   ament_uncrustify(
     ARGN include src examples
     CONFIG_FILE ${uncrustify_config_file}
+    LANGUAGE C++
     MAX_LINE_LENGTH 80
   )
 

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
@@ -650,7 +650,7 @@ public:
   }
 
   template<typename... Args>
-  static MirrorManager make(Args&& ... args)
+  static MirrorManager make(Args&&... args)
   {
     MirrorManager mgr;
     mgr._pimpl = rmf_utils::make_unique_impl<Implementation>(
@@ -875,7 +875,7 @@ public:
   }
 
   template<typename... Args>
-  static MirrorManagerFuture make(Args&& ... args)
+  static MirrorManagerFuture make(Args&&... args)
   {
     MirrorManagerFuture mmf;
     mmf._pimpl = rmf_utils::make_unique_impl<Implementation>(

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Negotiation.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Negotiation.cpp
@@ -81,7 +81,7 @@ public:
 
     template<typename... Args>
     static std::shared_ptr<Responder> make(
-      Args&& ... args)
+      Args&&... args)
     {
       auto responder = std::make_shared<Responder>(std::forward<Args>(args)...);
       rclcpp::Node& node = responder->impl->node;

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/ParticipantRegistry.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/ParticipantRegistry.cpp
@@ -42,7 +42,7 @@ struct UniqueIdHasher
 {
   std::size_t operator()(UniqueId id) const
   {
-    return std::hash<std::string>{} (id.name + id.owner);
+    return std::hash<std::string>{}(id.name + id.owner);
   }
 };
 


### PR DESCRIPTION
Binary job is failing https://build.ros2.org/job/Rbin_uJ64__rmf_fleet_adapter__ubuntu_jammy_amd64__binary/196/console

Our github action conceals these failures give that the runner is configured to use a patched version of uncrustify which the buildfarm does not use. We should also merge this to avoid such problems in the future https://github.com/open-rmf/rmf_ci_templates/pull/5