### PR TITLE
Bump 2.2.0

### DIFF
--- a/rmf_fleet_adapter/CHANGELOG.rst
+++ b/rmf_fleet_adapter/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rmf_fleet_adapter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.2.0 (2023-06-06)
+------------------
 * Fix race condition related to the ``finished`` callback of ``perform_action`` events: (`#273 <https://github.com/open-rmf/rmf_ros2/pull/273>`_)
 * Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
 * Contributors: Grey, Yadunund

--- a/rmf_fleet_adapter/CHANGELOG.rst
+++ b/rmf_fleet_adapter/CHANGELOG.rst
@@ -5,11 +5,12 @@ Changelog for package rmf_fleet_adapter
 Forthcoming
 -----------
 * Fix race condition related to the ``finished`` callback of ``perform_action`` events: (`#273 <https://github.com/open-rmf/rmf_ros2/pull/273>`_)
-* Contributors: Grey
+* Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
+* Contributors: Grey, Yadunund
 
 2.1.5 (2023-05-20)
 ------------------
-* Reformat code to meet expectations of uncrustify-0.72.0: (`#274 <https://github.com/open-rmf/rmf_ros2/pull/27>`_)
+* Reformat code to meet expectations of uncrustify-0.72.0: (`#274 <https://github.com/open-rmf/rmf_ros2/pull/274>`_)
 * Contributors: Yadunund
 
 2.1.4 (2023-04-27)
@@ -17,10 +18,10 @@ Forthcoming
 
 2.1.3 (2023-04-26)
 ------------------
-* Fix emergency response for waiting robots: (`#253 <https://github.com/open-rmf/rmf_ros2/pull/25>`_)
-* Properly cleanup emergency pullover task: (`#258 <https://github.com/open-rmf/rmf_ros2/pull/25>`_)
-* Fix priority assignment when parsing tasks: (`#265 <https://github.com/open-rmf/rmf_ros2/pull/26>`_)
-* Link Threads to fix build errors on certain platforms: (`#204 <https://github.com/open-rmf/rmf_ros2/issues/20>`_)
+* Fix emergency response for waiting robots: (`#253 <https://github.com/open-rmf/rmf_ros2/pull/253>`_)
+* Properly cleanup emergency pullover task: (`#258 <https://github.com/open-rmf/rmf_ros2/pull/258>`_)
+* Fix priority assignment when parsing tasks: (`#265 <https://github.com/open-rmf/rmf_ros2/pull/265>`_)
+* Link Threads to fix build errors on certain platforms: (`#204 <https://github.com/open-rmf/rmf_ros2/pull/204>`_)
 * Contributors: decada-robotics, Luca Della Vedova, Grey, Yadunund
 
 2.1.2 (2022-10-10)
@@ -28,70 +29,70 @@ Forthcoming
 
 2.1.0 (2022-10-03)
 ------------------
-* Add API to update speed limits for lanes: (`#217 <https://github.com/open-rmf/rmf_ros2/pull/21>`_)
-* Make async behaviors more robust: (`#228 <https://github.com/open-rmf/rmf_ros2/pull/22>`_)
-* Allow fleet adapters to change schedule participant profiles: (`#229 <https://github.com/open-rmf/rmf_ros2/pull/22>`_)
-* Allow robots to be decommissioned from the task dispatch system: (`#233 <https://github.com/open-rmf/rmf_ros2/pull/23>`_)
-* Allow manual toggling of stubborn negotiation: (`#196 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Allow users to specify a custom update listener: (`#198 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Introduce `WaitUntil` activity and use it in the `ResponsiveWait`: (`#199 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Better support for patrol behaviors: (`#205 <https://github.com/open-rmf/rmf_ros2/pull/20>`_)
-* Allow `ResponsiveWait` to be enabled and disabled: (`#209 <https://github.com/open-rmf/rmf_ros2/pull/20>`_)
-* Publish the navigation graph of the fleet adapter: (`#207 <https://github.com/open-rmf/rmf_ros2/pull/20>`_)
-* Allow robot status to be overridden by the user: (`#191 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Add API to report status for `perform_action`: (`#190 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Add APIs for cancelling and killing tasks from the `RobotUpdateHandle`: (`#205 <https://github.com/open-rmf/rmf_ros2/pull/20>`_)
-* Add a WaitUntil event and use it for ResponsiveWait: (`#199 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
+* Add API to update speed limits for lanes: (`#217 <https://github.com/open-rmf/rmf_ros2/pull/217>`_)
+* Make async behaviors more robust: (`#228 <https://github.com/open-rmf/rmf_ros2/pull/228>`_)
+* Allow fleet adapters to change schedule participant profiles: (`#229 <https://github.com/open-rmf/rmf_ros2/pull/229>`_)
+* Allow robots to be decommissioned from the task dispatch system: (`#233 <https://github.com/open-rmf/rmf_ros2/pull/233>`_)
+* Allow manual toggling of stubborn negotiation: (`#196 <https://github.com/open-rmf/rmf_ros2/pull/196>`_)
+* Allow users to specify a custom update listener: (`#198 <https://github.com/open-rmf/rmf_ros2/pull/198>`_)
+* Introduce `WaitUntil` activity and use it in the `ResponsiveWait`: (`#199 <https://github.com/open-rmf/rmf_ros2/pull/199>`_)
+* Better support for patrol behaviors: (`#205 <https://github.com/open-rmf/rmf_ros2/pull/205>`_)
+* Allow `ResponsiveWait` to be enabled and disabled: (`#209 <https://github.com/open-rmf/rmf_ros2/pull/209>`_)
+* Publish the navigation graph of the fleet adapter: (`#207 <https://github.com/open-rmf/rmf_ros2/pull/207>`_)
+* Allow robot status to be overridden by the user: (`#191 <https://github.com/open-rmf/rmf_ros2/pull/191>`_)
+* Add API to report status for `perform_action`: (`#190 <https://github.com/open-rmf/rmf_ros2/pull/190>`_)
+* Add APIs for cancelling and killing tasks from the `RobotUpdateHandle`: (`#205 <https://github.com/open-rmf/rmf_ros2/pull/205>`_)
+* Add a WaitUntil event and use it for ResponsiveWait: (`#199 <https://github.com/open-rmf/rmf_ros2/pull/199>`_)
 
 2.0.0 (2022-03-18)
 ------------------
-* Update to traffic dependency system: (`#188 <https://github.com/open-rmf/rmf_ros2/pull/18>`_)
+* Update to traffic dependency system: (`#188 <https://github.com/open-rmf/rmf_ros2/pull/188>`_)
 
 1.5.0 (2022-02-14)
 ------------------
-* Support flexible task definitions (`#168 <https://github.com/open-rmf/rmf_ros2/pull/16>`_)
-* Add lane speed limit to graph parsing function (`#124 <https://github.com/open-rmf/rmf_ros2/pull/12>`_)
-* Support for geojson graphs (`#142 <https://github.com/open-rmf/rmf_ros2/pull/14>`_)
+* Support flexible task definitions (`#168 <https://github.com/open-rmf/rmf_ros2/pull/168>`_)
+* Add lane speed limit to graph parsing function (`#124 <https://github.com/open-rmf/rmf_ros2/pull/124>`_)
+* Support for geojson graphs (`#142 <https://github.com/open-rmf/rmf_ros2/pull/142>`_)
 
 1.4.0 (2021-09-01)
 ------------------
-* Add read_only_blockade adapter: (`#110 <https://github.com/open-rmf/rmf_ros2/pull/11>`_)
-* Accommodate finishing tasks: (`#108 <https://github.com/open-rmf/rmf_ros2/pull/10>`_)
-* Check if lane request's fleet_name is equal to the fleet's fleet_name: (`#95 <https://github.com/open-rmf/rmf_ros2/pull/9>`_)
-* Find nearest waypoint among starts: (`#98 <https://github.com/open-rmf/rmf_ros2/pull/9>`_)
+* Add read_only_blockade adapter: (`#110 <https://github.com/open-rmf/rmf_ros2/pull/110>`_)
+* Accommodate finishing tasks: (`#108 <https://github.com/open-rmf/rmf_ros2/pull/109>`_)
+* Check if lane request's fleet_name is equal to the fleet's fleet_name: (`#95 <https://github.com/open-rmf/rmf_ros2/pull/95>`_)
+* Find nearest waypoint among starts: (`#98 <https://github.com/open-rmf/rmf_ros2/pull/98>`_)
 
 1.3.0 (2021-06-07)
 ------------------
-* Add API for opening and closing lanes: (`#15 <https://github.com/open-rmf/rmf_ros2/pull/1>`_)
+* Add API for opening and closing lanes: (`#15 <https://github.com/open-rmf/rmf_ros2/pull/15>`_)
     * Added `open_lanes` and `close_lanes` CLI tools for issuing requests
-* Allow Traffic Light APIs to update the location of a robot while it is idle: (`#270 <https://github.com/osrf/rmf_core/pull/27>`_)
-* Allow TrafficLight and EasyTrafficLight API to update battery level: (`#263 <https://github.com/osrf/rmf_core/pull/26>`_)
+* Allow Traffic Light APIs to update the location of a robot while it is idle: (`#270 <https://github.com/osrf/rmf_core/pull/270>`_)
+* Allow TrafficLight and EasyTrafficLight API to update battery level: (`#263 <https://github.com/osrf/rmf_core/pull/263>`_)
 * Migrating to a task dispatcher framework: (`#21 <https://github.com/osrf/rmf_core/pull/21>`_)
     * The `rmf_fleet_adapter::agv` component interacts with a dispatcher node over topics with `rmf_task` prefix as specified in `rmf_fleet_adapter/StandardNames.hpp`
     * Support for executing tasks at specified timepoints
     * Support for `Loop`, `Delivery`, `Clean` and `ChargeBattery` tasks
-* Introduce ResponsiveWait: (`#308 <https://github.com/osrf/rmf_core/pull/30>`_)
+* Introduce ResponsiveWait: (`#308 <https://github.com/osrf/rmf_core/pull/308>`_)
     * The new ResponsiveWait task phase can be used to have idle/waiting robots respond to schedule conflicts
     * Idle robots (robots that do not have an assigned task) will automatically enter ResponsiveWait mode
 
 
 1.2.0 (2021-01-05)
 ------------------
-* Automatically publish fleet states from the fleet adapter API: (`#232 <https://github.com/osrf/rmf_core/pull/23>`_)
-* Easy Traffic Light API: (`#226 <https://github.com/osrf/rmf_core/pull/22>`_)
-* Gridlock-proof Traffic Light Implementation: (`#226 <https://github.com/osrf/rmf_core/pull/22>`_)
+* Automatically publish fleet states from the fleet adapter API: (`#232 <https://github.com/osrf/rmf_core/pull/232>`_)
+* Easy Traffic Light API: (`#226 <https://github.com/osrf/rmf_core/pull/226>`_)
+* Gridlock-proof Traffic Light Implementation: (`#226 <https://github.com/osrf/rmf_core/pull/226>`_)
 
 1.1.0 (2020-09-24)
 ------------------
-* Traffic Light API: (`#147 <https://github.com/osrf/rmf_core/pull/147) [#176](https://github.com/osrf/rmf_core/pull/176) [#180](https://github.com/osrf/rmf_core/pull/18>`_)
-* Allow fleet adapters to adjust the maximum delay: (`#148 <https://github.com/osrf/rmf_core/pull/14>`_)
-* Full Control Fleet Adapters respond to emergency alarm topic: (`#162 <https://github.com/osrf/rmf_core/pull/16>`_)
-* Migrating to ROS2 Foxy: (`#133 <https://github.com/osrf/rmf_core/pull/13>`_)
+* Traffic Light API: (`#147 <https://github.com/osrf/rmf_core/pull/147>`_) (`#176 <https://github.com/osrf/rmf_core/pull/176>`_) (`#180 <https://github.com/osrf/rmf_core/pull/180>`_)
+* Allow fleet adapters to adjust the maximum delay: (`#148 <https://github.com/osrf/rmf_core/pull/148>`_)
+* Full Control Fleet Adapters respond to emergency alarm topic: (`#162 <https://github.com/osrf/rmf_core/pull/162>`_)
+* Migrating to ROS2 Foxy: (`#133 <https://github.com/osrf/rmf_core/pull/133>`_)
 * Contributors: Chen Bainian, Grey, Kevin_Skywalker, Marco A. Gutiérrez, Rushyendra Maganty, Yadu
 
 1.0.2 (2020-07-27)
 ------------------
-* Always respond to negotiations: (`#138 <https://github.com/osrf/rmf_core/pull/13>`_)
+* Always respond to negotiations: (`#138 <https://github.com/osrf/rmf_core/pull/138>`_)
 
 1.0.1 (2020-07-20)
 ------------------

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_fleet_adapter</name>
-  <version>2.1.5</version>
+  <version>2.2.0</version>
   <description>Fleet Adapter package for RMF fleets.</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <maintainer email="aaron@openrobotics.org">Aaron</maintainer>

--- a/rmf_fleet_adapter_python/CHANGELOG.rst
+++ b/rmf_fleet_adapter_python/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rmf_fleet_adapter_python
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.2.0 (2023-06-06)
+------------------
 * Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
 * Contributors: Yadunund
 

--- a/rmf_fleet_adapter_python/CHANGELOG.rst
+++ b/rmf_fleet_adapter_python/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rmf_fleet_adapter_python
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
+* Contributors: Yadunund
+
 2.1.5 (2023-05-20)
 ------------------
 
@@ -16,16 +21,16 @@ Changelog for package rmf_fleet_adapter_python
 
 2.1.0 (2022-10-03)
 ------------------
-* Make async behaviors more robust: (`#228 <https://github.com/open-rmf/rmf_ros2/pull/22>`_)
-* Allow fleet adapters to change schedule participant profiles: (`#229 <https://github.com/open-rmf/rmf_ros2/pull/22>`_)
-* Allow robots to be decommissioned from the task dispatch system: (`#233 <https://github.com/open-rmf/rmf_ros2/pull/23>`_)
-* Allow manual toggling of stubborn negotiation: (`#196 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Allow users to specify a custom update listener: (`#198 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Fix various segfaults related to pybind: (`#205 <https://github.com/open-rmf/rmf_ros2/pull/20>`_)
-* Allow `ResponsiveWait` to be enabled and disabled: (`#209 <https://github.com/open-rmf/rmf_ros2/pull/20>`_)
-* Allow robot status to be overridden by the user: (`#191 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Add API to report status for `perform_action`: (`#190 <https://github.com/open-rmf/rmf_ros2/pull/19>`_)
-* Changes for humble compatibility: (`#215 <https://github.com/open-rmf/rmf_ros2/issues/21>`_)
+* Make async behaviors more robust: (`#228 <https://github.com/open-rmf/rmf_ros2/pull/228>`_)
+* Allow fleet adapters to change schedule participant profiles: (`#229 <https://github.com/open-rmf/rmf_ros2/pull/229>`_)
+* Allow robots to be decommissioned from the task dispatch system: (`#233 <https://github.com/open-rmf/rmf_ros2/pull/233>`_)
+* Allow manual toggling of stubborn negotiation: (`#196 <https://github.com/open-rmf/rmf_ros2/pull/196>`_)
+* Allow users to specify a custom update listener: (`#198 <https://github.com/open-rmf/rmf_ros2/pull/198>`_)
+* Fix various segfaults related to pybind: (`#205 <https://github.com/open-rmf/rmf_ros2/pull/205>`_)
+* Allow `ResponsiveWait` to be enabled and disabled: (`#209 <https://github.com/open-rmf/rmf_ros2/pull/209>`_)
+* Allow robot status to be overridden by the user: (`#191 <https://github.com/open-rmf/rmf_ros2/pull/191>`_)
+* Add API to report status for `perform_action`: (`#190 <https://github.com/open-rmf/rmf_ros2/pull/190>`_)
+* Changes for humble compatibility: (`#215 <https://github.com/open-rmf/rmf_ros2/pull/215>`_)
 
 2.0.0 (2022-03-18)
 ------------------
@@ -33,23 +38,23 @@ No changes yet
 
 1.5.0 (2022-02-14)
 ------------------
-* Support flexible task definitions (`#168 <https://github.com/open-rmf/rmf_ros2/pull/16>`_)
-* Add lane speed limit to graph parsing function (`#124 <https://github.com/open-rmf/rmf_ros2/pull/12>`_)
+* Support flexible task definitions (`#168 <https://github.com/open-rmf/rmf_ros2/pull/168>`_)
+* Add lane speed limit to graph parsing function (`#124 <https://github.com/open-rmf/rmf_ros2/pull/124>`_)
 
 1.3.0 (2021-06-07)
 ------------------
-* Modifications to support refactor of rmf_task (`#51 <https://github.com/open-rmf/rmf_ros2/issues/51>`_)
-* Fix symlink-install compilation (`#32 <https://github.com/open-rmf/rmf_ros2/issues/32>`_)
-* Updated package.xml (`#26 <https://github.com/open-rmf/rmf_ros2/issues/26>`_)
-* Fix/rmf task ros2 cleanup (`#21 <https://github.com/open-rmf/rmf_ros2/issues/21>`_)
-* Feature/python binding planner (`#11 <https://github.com/open-rmf/rmf_ros2/issues/11>`_)
-* Adding reference_internal tag to function bindings that return raw pointers (`#6 <https://github.com/open-rmf/rmf_ros2/issues/6>`_)
-* Feature/add unstable participant api (`#11 <https://github.com/open-rmf/rmf_ros2/issues/11>`_)
-* Feature/add simple docs (`#9 <https://github.com/open-rmf/rmf_ros2/issues/9>`_)
-* Support apis for task dispatcher (`#10 <https://github.com/open-rmf/rmf_ros2/issues/10>`_)
-* differentiate functions to prevent overloading (`#8 <https://github.com/open-rmf/rmf_ros2/issues/8>`_)
-* support ez traffic light (`#7 <https://github.com/open-rmf/rmf_ros2/issues/7>`_)
-* Update/release 1.1 (`#6 <https://github.com/open-rmf/rmf_ros2/issues/6>`_)
+* Modifications to support refactor of rmf_task (`#51 <https://github.com/open-rmf/rmf_ros2/pull/51>`_)
+* Fix symlink-install compilation (`#32 <https://github.com/open-rmf/rmf_ros2/pull/32>`_)
+* Updated package.xml (`#26 <https://github.com/open-rmf/rmf_ros2/pull/26>`_)
+* Fix/rmf task ros2 cleanup (`#21 <https://github.com/open-rmf/rmf_ros2/pull/21>`_)
+* Feature/python binding planner (`#11 <https://github.com/open-rmf/rmf_ros2/pull/11>`_)
+* Adding reference_internal tag to function bindings that return raw pointers (`#6 <https://github.com/open-rmf/rmf_ros2/pull/6>`_)
+* Feature/add unstable participant api (`#11 <https://github.com/open-rmf/rmf_ros2/pull/11>`_)
+* Feature/add simple docs (`#9 <https://github.com/open-rmf/rmf_ros2/pull/9>`_)
+* Support apis for task dispatcher (`#10 <https://github.com/open-rmf/rmf_ros2/pull/10>`_)
+* differentiate functions to prevent overloading (`#8 <https://github.com/open-rmf/rmf_ros2/pull/8>`_)
+* support ez traffic light (`#7 <https://github.com/open-rmf/rmf_ros2/pull/7>`_)
+* Update/release 1.1 (`#6 <https://github.com/open-rmf/rmf_ros2/pull/6>`_)
 * Implement binding for Duration optional
 * Make integration test even stricter
 * Add reference capture for posterity
@@ -59,5 +64,5 @@ No changes yet
 * Bind optional constructors and delivery msg interfaces
 * Bind compute_plan_starts
 * Add update_position overload
-* Implement Python Bindings for rmf_fleet_adapter (`#1 <https://github.com/open-rmf/rmf_ros2/issues/1>`_)
+* Implement Python Bindings for rmf_fleet_adapter (`#1 <https://github.com/open-rmf/rmf_ros2/pull/1>`_)
 * Contributors: Aaron Chong, Charayaphan Nakorn Boon Han, Geoffrey Biggs, Grey, Marco A. Gutiérrez, Yadu, methylDragon, youliang

--- a/rmf_fleet_adapter_python/package.xml
+++ b/rmf_fleet_adapter_python/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_fleet_adapter_python</name>
-  <version>2.1.5</version>
+  <version>2.2.0</version>
   <description>Python bindings for the rmf_fleet_adapter</description>
   <maintainer email="methylDragon@gmail.com">methylDragon</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_task_ros2/CHANGELOG.rst
+++ b/rmf_task_ros2/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rmf_task_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.2.0 (2023-06-06)
+------------------
 * Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
 * Contributors: Yadunund
 

--- a/rmf_task_ros2/CHANGELOG.rst
+++ b/rmf_task_ros2/CHANGELOG.rst
@@ -2,9 +2,14 @@
 Changelog for package rmf_task_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
+* Contributors: Yadunund
+
 2.1.5 (2023-05-20)
 ------------------
-* Reformat code to meet expectations of uncrustify-0.72.0: (`#274 <https://github.com/open-rmf/rmf_ros2/issues/27>`_)
+* Reformat code to meet expectations of uncrustify-0.72.0: (`#274 <https://github.com/open-rmf/rmf_ros2/pull/274>`_)
 * Contributors: Yadunund
 
 2.1.4 (2023-04-27)
@@ -12,7 +17,7 @@ Changelog for package rmf_task_ros2
 
 2.1.3 (2023-04-26)
 ------------------
-* Link Threads to fix build errors on certain platforms: (`#204 <https://github.com/open-rmf/rmf_ros2/issues/20>`_)
+* Link Threads to fix build errors on certain platforms: (`#204 <https://github.com/open-rmf/rmf_ros2/pull/204>`_)
 * Contributors: decada-robotics, Grey
 
 2.1.2 (2022-10-10)
@@ -27,10 +32,10 @@ Changelog for package rmf_task_ros2
 
 2.1.0 (2022-10-03)
 ------------------
-* Change default task auction evaluator to `QuickestFinishEvaluator`: (`#211 <https://github.com/open-rmf/rmf_ros2/pull/21>`_)
-* ws broadcast client in dispatcher node (`#212 <https://github.com/open-rmf/rmf_ros2/pull/21>`_)
-* create unique task_id with timestamp (`#223 <https://github.com/open-rmf/rmf_ros2/pull/22>`_)
-* Changes for humble compatibility: (`#215 <https://github.com/open-rmf/rmf_ros2/issues/21>`_)
+* Change default task auction evaluator to `QuickestFinishEvaluator`: (`#211 <https://github.com/open-rmf/rmf_ros2/pull/211>`_)
+* ws broadcast client in dispatcher node (`#212 <https://github.com/open-rmf/rmf_ros2/pull/212>`_)
+* create unique task_id with timestamp (`#223 <https://github.com/open-rmf/rmf_ros2/pull/223>`_)
+* Changes for humble compatibility: (`#215 <https://github.com/open-rmf/rmf_ros2/pull/215>`_)
 
 2.0.0 (2022-03-18)
 ------------------
@@ -38,8 +43,8 @@ No changes yet
 
 1.5.0 (2022-02-14)
 ------------------
-* Support flexible task definitions (`#168 <https://github.com/open-rmf/rmf_ros2/pull/16>`_)
+* Support flexible task definitions (`#168 <https://github.com/open-rmf/rmf_ros2/pull/168>`_)
 
 1.3.0 (2021-01-13)
 ------------------
-* Introduce dispatcher node to facilitate dispatching of tasks: (`#217 <https://github.com/osrf/rmf_core/pull/21>`_)
+* Introduce dispatcher node to facilitate dispatching of tasks: (`#217 <https://github.com/osrf/rmf_core/pull/217>`_)

--- a/rmf_task_ros2/package.xml
+++ b/rmf_task_ros2/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_task_ros2</name>
-  <version>2.1.5</version>
+  <version>2.2.0</version>
   <description>A package managing the dispatching of tasks in RMF system.</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_traffic_ros2/CHANGELOG.rst
+++ b/rmf_traffic_ros2/CHANGELOG.rst
@@ -2,9 +2,14 @@
 Changelog for package rmf_traffic_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
+* Contributors: Yadunund
+
 2.1.5 (2023-05-20)
 ------------------
-* Reformat code to meet expectations of uncrustify-0.72.0: (`#274 <https://github.com/open-rmf/rmf_ros2/issues/27>`_)
+* Reformat code to meet expectations of uncrustify-0.72.0: (`#274 <https://github.com/open-rmf/rmf_ros2/pull/274>`_)
 * Contributors: Yadunund
 
 2.1.4 (2023-04-27)
@@ -18,32 +23,32 @@ Changelog for package rmf_traffic_ros2
 
 2.1.0 (2022-10-03)
 ------------------
-* Make async behaviors more robust: (`#228 <https://github.com/open-rmf/rmf_ros2/pull/22>`_)
-* Make schedule failover more robust: (`#232 <https://github.com/open-rmf/rmf_ros2/pull/23>`_)
-* Ignore conflicts between any plans that have a dependency: (`#205 <https://github.com/open-rmf/rmf_ros2/pull/20>`_)
-* Add support for docking in lanes with entry events: (`#226 <https://github.com/open-rmf/rmf_ros2/pull/22>`_)
-* Add message conversion functions for the navigation graph: (`#207 <https://github.com/open-rmf/rmf_ros2/pull/20>`_)
-* Changes for humble compatibility: (`#215 <https://github.com/open-rmf/rmf_ros2/issues/21>`_)
+* Make async behaviors more robust: (`#228 <https://github.com/open-rmf/rmf_ros2/pull/228>`_)
+* Make schedule failover more robust: (`#232 <https://github.com/open-rmf/rmf_ros2/pull/232>`_)
+* Ignore conflicts between any plans that have a dependency: (`#205 <https://github.com/open-rmf/rmf_ros2/pull/205>`_)
+* Add support for docking in lanes with entry events: (`#226 <https://github.com/open-rmf/rmf_ros2/pull/226>`_)
+* Add message conversion functions for the navigation graph: (`#207 <https://github.com/open-rmf/rmf_ros2/pull/207>`_)
+* Changes for humble compatibility: (`#215 <https://github.com/open-rmf/rmf_ros2/pull/215>`_)
 
 2.0.0 (2022-03-18)
 ------------------
-* Update to the traffic dependency system: (`#188 <https://github.com/open-rmf/rmf_ros2/pull/18>`_)
+* Update to the traffic dependency system: (`#188 <https://github.com/open-rmf/rmf_ros2/pull/188>`_)
 
 1.5.0 (2022-02-14)
 ------------------
-* Allow participants to sync up with remote databases when discrepancies arise (`#145 <https://github.com/open-rmf/rmf_ros2/pull/14>`_)
-* Support for geojson graphs (`#142 <https://github.com/open-rmf/rmf_ros2/pull/14>`_)
+* Allow participants to sync up with remote databases when discrepancies arise (`#145 <https://github.com/open-rmf/rmf_ros2/pull/145>`_)
+* Support for geojson graphs (`#142 <https://github.com/open-rmf/rmf_ros2/pull/142>`_)
 
 1.4.0 (2021-09-01)
 ------------------
-* Make traffic schedule updates more efficient: (`#86 <https://github.com/open-rmf/rmf_ros2/pull/8>`_)
-* Add redundancy to the traffic schedule node: (`#61 <https://github.com/open-rmf/rmf_ros2/pull/6>`_)
+* Make traffic schedule updates more efficient: (`#86 <https://github.com/open-rmf/rmf_ros2/pull/86>`_)
+* Add redundancy to the traffic schedule node: (`#61 <https://github.com/open-rmf/rmf_ros2/pull/61>`_)
 
 1.3.0 (2021-06-07)
 ------------------
-* Use topics to update schedule mirrors: (`#17 <https://github.com/open-rmf/rmf_ros2/pull/1>`_)
-* Allow participant descriptions to update: (`#17 <https://github.com/open-rmf/rmf_ros2/pull/1>`_)
-* Add persistence to Traffic Schedule Participant IDs: (`#242 <https://github.com/osrf/rmf_core/pull/24>`_)
+* Use topics to update schedule mirrors: (`#17 <https://github.com/open-rmf/rmf_ros2/pull/17>`_)
+* Allow participant descriptions to update: (`#17 <https://github.com/open-rmf/rmf_ros2/pull/17>`_)
+* Add persistence to Traffic Schedule Participant IDs: (`#242 <https://github.com/osrf/rmf_core/pull/242>`_)
 
 1.2.0 (2021-01-05)
 ------------------
@@ -51,7 +56,7 @@ Changelog for package rmf_traffic_ros2
 
 1.1.0 (2020-09-24)
 ------------------
-* Add a schedule node factory to the public API: (`#147 <https://github.com/osrf/rmf_core/pull/14>`_)
+* Add a schedule node factory to the public API: (`#147 <https://github.com/osrf/rmf_core/pull/147>`_)
 * Allow the Negotiation class to accept callbacks for Table updates: (`#140 <https://github.com/osrf/rmf_core/pull/140>`_)
 * Allow the Negotiation class to provide views for existing Tables: (`#140 <https://github.com/osrf/rmf_core/pull/140>`_)
 * Allow the Negotiation class to store up to a certain number of completed negotiations: (`#140 <https://github.com/osrf/rmf_core/pull/140>`_)
@@ -60,7 +65,7 @@ Changelog for package rmf_traffic_ros2
 
 1.0.2 (2020-07-27)
 ------------------
-* Always respond to negotiations: (`#138 <https://github.com/osrf/rmf_core/pull/13>`_)
+* Always respond to negotiations: (`#138 <https://github.com/osrf/rmf_core/pull/138>`_)
 
 1.0.0 (2020-06-23)
 ------------------

--- a/rmf_traffic_ros2/CHANGELOG.rst
+++ b/rmf_traffic_ros2/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rmf_traffic_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.2.0 (2023-06-06)
+------------------
 * Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
 * Contributors: Yadunund
 

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_traffic_ros2</name>
-  <version>2.1.5</version>
+  <version>2.2.0</version>
   <description>A package containing messages used by the RMF traffic management system.</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_websocket/CHANGELOG.rst
+++ b/rmf_websocket/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rmf_websocket
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.2.0 (2023-06-06)
+------------------
 * Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
 * Contributors: Yadunund
 

--- a/rmf_websocket/CHANGELOG.rst
+++ b/rmf_websocket/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rmf_websocket
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Switch to rst changelogs (`#276 <https://github.com/open-rmf/rmf_ros2/pull/276>`_)
+* Contributors: Yadunund
+
 2.1.5 (2023-05-20)
 ------------------
 

--- a/rmf_websocket/package.xml
+++ b/rmf_websocket/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_websocket</name>
-  <version>2.1.5</version>
+  <version>2.2.0</version>
   <description>A package managing the websocket api endpoints in RMF system.</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>


### PR DESCRIPTION
Merge commit instead of squash merge.

> Note: The diff has some changes to fix the links in the changelog entries.