### PR TITLE
WIP Add api for robot charging tasks

### DIFF
--- a/rmf_fleet_adapter/schemas/event_description__charge.json
+++ b/rmf_fleet_adapter/schemas/event_description__charge.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_ros2/main/rmf_fleet_adapter/schemas/event_description__charge.json",
+  "title": "Charge Event",
+  "description": "Charge a robot",
+  "type": "object",
+  "properties": {
+  }
+}

--- a/rmf_fleet_adapter/schemas/task_description__charge.json
+++ b/rmf_fleet_adapter/schemas/task_description__charge.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_ros2/main/rmf_fleet_adapter/schemas/task_description__charge.json",
+  "title": "Charge Task",
+  "description": "Charge a robot",
+  "$ref": "event_description__charge.json"
+}

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1104,6 +1104,7 @@ void FleetUpdateHandle::Implementation::add_standard_tasks()
     node->clock());
 
   tasks::add_charge_battery(
+    deserialization,
     *activation.task,
     activation.phase,
     *activation.event,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/ChargeBattery.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/ChargeBattery.hpp
@@ -19,6 +19,7 @@
 #define SRC__RMF_FLEET_ADAPTER__TASKS__CHARGEBATTERY_HPP
 
 #include "../LegacyTask.hpp"
+#include "../agv/internal_FleetUpdateHandle.hpp"
 #include "../agv/RobotContext.hpp"
 
 #include <rmf_traffic/agv/Planner.hpp>
@@ -43,6 +44,7 @@ std::shared_ptr<LegacyTask> make_charge_battery(
 
 //==============================================================================
 void add_charge_battery(
+  agv::TaskDeserialization& deserialization,
   rmf_task::Activator& task_activator,
   const rmf_task_sequence::Phase::ConstActivatorPtr& phase_activator,
   rmf_task_sequence::Event::Initializer& event_initializer,


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Closes #261.

### Implementation description

This PR adds support for submitting robot charging requests through a `charge` task.
This task should only be used in direct task requests, since dispatching it to the robot that can charge the fastest doesn't really make a lot of sense.

It can be tested with [this rmf_demos branch](https://github.com/open-rmf/rmf_demos/compare/luca/charge_task) that adds a `dispatch_charge` task, with mandatory `fleet` and `robot` parameters to make sure it is a direct assignment.