### PR TITLE
Reactive easy full control

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
@@ -85,7 +85,7 @@ public:
   ///
   /// \return The handle for adding new robots to the fleet.
   std::shared_ptr<EasyFullControl> add_easy_fleet(
-    EasyFullControl::Configuration config);
+    const EasyFullControl::Configuration& config);
 
   /// Add a fleet to be adapted.
   ///

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
@@ -85,7 +85,7 @@ public:
   ///
   /// \return The handle for adding new robots to the fleet.
   std::shared_ptr<EasyFullControl> add_easy_fleet(
-    const EasyFullControl::Configuration& config);
+    const EasyFullControl::FleetConfiguration& config);
 
   /// Add a fleet to be adapted.
   ///

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
@@ -19,6 +19,7 @@
 
 #include <rmf_fleet_adapter/agv/FleetUpdateHandle.hpp>
 #include <rmf_fleet_adapter/agv/EasyTrafficLight.hpp>
+#include <rmf_fleet_adapter/agv/EasyFullControl.hpp>
 
 #include <rmf_traffic/agv/VehicleTraits.hpp>
 #include <rmf_traffic/agv/Graph.hpp>
@@ -76,6 +77,15 @@ public:
     const std::string& node_name,
     const rclcpp::NodeOptions& node_options = rclcpp::NodeOptions(),
     std::optional<rmf_traffic::Duration> discovery_timeout = std::nullopt);
+
+  /// Add an Easy Full Control fleet to be adapted.
+  ///
+  /// \param[in] config
+  ///   Configuration for the new Easy Full Control fleet.
+  ///
+  /// \return The handle for adding new robots to the fleet.
+  std::shared_ptr<EasyFullControl> add_easy_fleet(
+    EasyFullControl::Configuration config);
 
   /// Add a fleet to be adapted.
   ///

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -59,7 +59,8 @@ public:
   using ActionExecutor = RobotUpdateHandle::ActionExecutor;
   using ActivityIdentifier = RobotUpdateHandle::ActivityIdentifier;
   using ActivityIdentifierPtr = RobotUpdateHandle::ActivityIdentifierPtr;
-  using ConstActivityIdentifierPtr = RobotUpdateHandle::ConstActivityIdentifierPtr;
+  using ConstActivityIdentifierPtr =
+    RobotUpdateHandle::ConstActivityIdentifierPtr;
   using Stubbornness = RobotUpdateHandle::Unstable::Stubbornness;
   using ConsiderRequest = FleetUpdateHandle::ConsiderRequest;
 
@@ -140,6 +141,33 @@ public:
     RobotState state,
     ConstActivityIdentifierPtr current_activity);
 
+  /// Get the maximum allowed merge waypoint distance for this robot.
+  double max_merge_waypoint_distance() const;
+
+  /// Modify the maximum allowed merge distance between the robot and a waypoint.
+  ///
+  /// \param[in] max_merge_waypoint_distance
+  ///   The maximum merge waypoint distance for this robot.
+  void set_max_merge_waypoint_distance(double distance);
+
+  /// Get the maximum allowed merge lane distance for this robot.
+  double max_merge_lane_distance() const;
+
+  /// Modify the maximum allowed merge distance between the robot and a lane.
+  ///
+  /// \param[in] max_merge_lane_distance
+  ///   The maximum merge lane distance for this robot.
+  void set_max_merge_lane_distance(double distance);
+
+  /// Get the minimum lane length for this robot.
+  double min_lane_length() const;
+
+  /// Modify the minimum lane length for this robot.
+  ///
+  /// \param[in] min_lane_length
+  ///   The minimum length of a lane.
+  void set_min_lane_length(double length);
+
   /// Get more options for updating the robot's state
   std::shared_ptr<RobotUpdateHandle> more();
 
@@ -216,7 +244,10 @@ public:
   /// conflicts.
   RobotConfiguration(
     std::vector<std::string> compatible_chargers,
-    std::optional<bool> responsive_wait = std::nullopt);
+    std::optional<bool> responsive_wait = std::nullopt,
+    std::optional<double> max_merge_waypoint_distance = 1e-3,
+    std::optional<double> max_merge_lane_distance = 0.3,
+    std::optional<double> min_lane_length = 1e-8);
 
   /// List of chargers that this robot is compatible with
   const std::vector<std::string>& compatible_chargers() const;
@@ -236,6 +267,37 @@ public:
   /// Toggle responsive wait on (true), off (false), or use fleet default
   /// (std::nullopt).
   void set_responsive_wait(std::optional<bool> enable);
+
+  /// Get the maximum merge distance between a robot and a waypoint. This refers
+  /// to the maximum distance allowed to consider a robot to be on a particular
+  /// waypoint.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default merge waypoint
+  /// distance will be used.
+  std::optional<double> max_merge_waypoint_distance() const;
+
+  /// Set the maximum merge distance between a robot and a waypoint.
+  void set_max_merge_waypoint_distance(std::optional<double> distance);
+
+  /// Get the maximum merge distance between a robot and a lane. This refers
+  /// to the maximum distance allowed to consider a robot to be on a particular
+  /// lane.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default merge lane
+  /// distance will be used.
+  std::optional<double> max_merge_lane_distance() const;
+
+  /// Set the maximum merge distance between a robot and a lane.
+  void set_max_merge_lane_distance(std::optional<double> distance);
+
+  /// Get the minimum lane length.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default minimum lane length
+  /// will be used.
+  std::optional<double> min_lane_length() const;
+
+  /// Set the minimum lane length.
+  void set_min_lane_length(std::optional<double> distance);
 
   class Implementation;
 private:
@@ -450,10 +512,21 @@ public:
   /// \param[in] default_responsive_wait
   ///   Should the robots in this fleet have responsive wait enabled (true) or
   ///   disabled (false) by default?
+  ///
+  /// \param[in] default_max_merge_waypoint_distance
+  ///   The maximum merge distance between a robot position and a waypoint.
+  ///
+  /// \param[in] default_max_merge_lane_distance
+  ///   The maximum merge distance between a robot position and a lane.
+  ///
+  /// \param[in] default_min_lane_length
+  ///   The minimum length that a lane should have.
   FleetConfiguration(
     const std::string& fleet_name,
-    std::optional<std::unordered_map<std::string, Transformation>> transformations_to_robot_coordinates,
-    std::unordered_map<std::string, RobotConfiguration> known_robot_configurations,
+    std::optional<std::unordered_map<std::string, Transformation>>
+    transformations_to_robot_coordinates,
+    std::unordered_map<std::string, RobotConfiguration>
+    known_robot_configurations,
     std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
     std::shared_ptr<const rmf_traffic::agv::Graph> graph,
     rmf_battery::agv::ConstBatterySystemPtr battery_system,
@@ -471,7 +544,10 @@ public:
     rmf_traffic::Duration max_delay = rmf_traffic::time::from_seconds(10.0),
     rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(
       0.5),
-    bool default_responsive_wait = false
+    bool default_responsive_wait = false,
+    double default_max_merge_waypoint_distance = 1e-3,
+    double default_max_merge_lane_distance = 0.3,
+    double min_lane_length = 1e-8
   );
 
   /// Create a FleetConfiguration object using a set of configuration parameters
@@ -648,6 +724,24 @@ public:
   /// Set whether robots in this fleet should have responsive wait enabled by
   /// default.
   void set_default_responsive_wait(bool enable);
+
+  /// Get the maximum merge distance between a robot position and a waypoint.
+  double default_max_merge_waypoint_distance() const;
+
+  /// Set the maximum merge distance between a robot position and a waypoint.
+  void set_default_max_merge_waypoint_distance(double distance);
+
+  /// Get the maximum merge distance between a robot position and a lane.
+  double default_max_merge_lane_distance() const;
+
+  /// Set the maximum merge distance between a robot position and a lane.
+  void set_default_max_merge_lane_distance(double distance);
+
+  /// Get the minimum lane length allowed.
+  double default_min_lane_length() const;
+
+  /// Set the minimum lane length.
+  void set_default_min_lane_length(double distance);
 
   class Implementation;
 private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -100,11 +100,6 @@ public:
 
   /// Add a robot to the fleet once it is available.
   ///
-  /// \note This will internally call Planner::compute_plan_starts() using the
-  ///    provieded start_state determine the StartSet of the robot. If you
-  ///    have a custom method to determine the StartSet of the robot, consider
-  ///    calling fleet_handle()->add_robot() instead.
-  ///
   /// \param[in] start_state
   ///   The initial state of the robot when it is added to the fleet.
   ///
@@ -380,7 +375,7 @@ public:
   ///   states. If nullopt, data will not be published.
   ///
   /// \return A Configuration object with the essential config parameters loaded.
-  static std::shared_ptr<Configuration> from_config_files(
+  static Configuration from_config_files(
     const std::string& config_file,
     const std::string& nav_graph_path,
     std::optional<std::string> server_uri = std::nullopt);

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -270,6 +270,13 @@ public:
   /// \param[in] fleet_name
   ///   The name of the fleet that is being added.
   ///
+  /// \param[in] transformations_to_robot_coordinates
+  ///   A dictionary of transformations from RMF canonical coordinates to the
+  ///   the coordinate system used by the robot. Each map should be assigned its
+  ///   own transformation. If this is not nullptr, then a warning will be
+  ///   logged whenever the dictionary is missing a transform for a map, and the
+  ///   canonical RMF coordinates will be used.
+  ///
   /// \param[in] traits
   ///   Specify the approximate traits of the vehicles in this fleet.
   ///
@@ -334,6 +341,7 @@ public:
   ///   the fleet adapter.
   Configuration(
     const std::string& fleet_name,
+    std::optional<std::unordered_map<std::string, Transformation>> transformations_to_robot_coordinates,
     std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
     std::shared_ptr<const rmf_traffic::agv::Graph> graph,
     rmf_battery::agv::ConstBatterySystemPtr battery_system,
@@ -375,7 +383,7 @@ public:
   ///   states. If nullopt, data will not be published.
   ///
   /// \return A Configuration object with the essential config parameters loaded.
-  static Configuration from_config_files(
+  static std::optional<Configuration> from_config_files(
     const std::string& config_file,
     const std::string& nav_graph_path,
     std::optional<std::string> server_uri = std::nullopt);
@@ -385,6 +393,18 @@ public:
 
   /// Set the fleet name.
   void set_fleet_name(std::string value);
+
+  /// Get the transformations into robot coordinates for this fleet.
+  const std::optional<std::unordered_map<std::string, Transformation>>&
+  transformations_to_robot_coordinates() const;
+
+  /// Set the transformation into robot coordinates for a map. This will replace
+  /// any transformation previously set for the map. If the transformation
+  /// dictionary was previously nullopt, this will initialize it with an empty 
+  /// value before inserting this transformation.
+  void add_robot_coordinate_transformation(
+    std::string map,
+    Transformation transformation);
 
   /// Get the fleet vehicle traits.
   const std::shared_ptr<const VehicleTraits>& vehicle_traits() const;

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -57,263 +57,37 @@ public:
   using Graph = rmf_traffic::agv::Graph;
   using VehicleTraits = rmf_traffic::agv::VehicleTraits;
   using ActionExecutor = RobotUpdateHandle::ActionExecutor;
+  using ActivityIdentifierPtr = RobotUpdateHandle::ActivityIdentifierPtr;
+  using ConstActivityIdentifierPtr = RobotUpdateHandle::ConstActivityIdentifierPtr;
+  using Stubbornness = RobotUpdateHandle::Unstable::Stubbornness;
   using ConsiderRequest = FleetUpdateHandle::ConsiderRequest;
 
-  /// The Configuration class contains parameters necessary to initialize an
-  /// EasyFullControl instance and add fleets to the adapter.
-  class Configuration
-  {
-  public:
+  // Nested class declarations
+  class EasyRobotUpdateHandle;
+  class Configuration;
+  class InitializeRobot;
+  class CommandExecution;
 
-    /// Constructor
-    ///
-    /// \param[in] fleet_name
-    ///   The name of the fleet that is being added.
-    ///
-    /// \param[in] traits
-    ///   Specify the approximate traits of the vehicles in this fleet.
-    ///
-    /// \param[in] navigation_graph
-    ///   Specify the navigation graph used by the vehicles in this fleet.
-    ///
-    /// \param[in] battery_system
-    ///   Specify the battery system used by the vehicles in this fleet.
-    ///
-    /// \param[in] motion_sink
-    ///   Specify the motion sink that describes the vehicles in this fleet.
-    ///
-    /// \param[in] ambient_sink
-    ///   Specify the device sink for ambient sensors used by the vehicles in this fleet.
-    ///
-    /// \param[in] tool_sink
-    ///   Specify the device sink for special tools used by the vehicles in this fleet.
-    ///
-    /// \param[in] recharge_threshold
-    ///   The threshold for state of charge below which robots in this fleet
-    ///   will cease to operate and require recharging. A value between 0.0 and
-    ///   1.0 should be specified.
-    ///
-    /// \param[in] recharge_soc
-    ///   The state of charge to which robots in this fleet should be charged up
-    ///   to by automatic recharging tasks. A value between 0.0 and 1.0 should be
-    ///   specified.
-    ///
-    /// \param[in] account_for_battery_drain
-    ///   Specify whether battery drain is to be considered while allocating tasks.
-    ///   If false, battery drain will not be considered when planning for tasks.
-    ///   As a consequence, charging tasks will not be automatically assigned to
-    ///   vehicles in this fleet when battery levels fall below the
-    ///   recharge_threshold.
-    ///
-    /// \param[in] task_categories
-    ///   Provide callbacks for considering tasks belonging to each category.
-    ///
-    /// \param[in] action_categories
-    ///   List of actions that this fleet can perform. Each item represents a
-    ///   category in the PerformAction description.
-    ///
-    /// \param[in] finishing_request
-    ///   A factory for a request that should be performed by each robot in this
-    ///   fleet at the end of its assignments.
-    ///
-    /// \param[in] server_uri
-    ///   The URI for the websocket server that receives updates on tasks and
-    ///   states. If nullopt, data will not be published.
-    ///
-    /// \param[in] max_delay
-    ///   Specify the default value for how high the delay of the current itinerary
-    ///   can become before it gets interrupted and replanned.
-    ///
-    /// \param[in] update_interval
-    ///   The duration between positional state updates that are sent to
-    ///   the fleet adapter.
-    Configuration(
-      const std::string& fleet_name,
-      rmf_traffic::agv::VehicleTraits traits,
-      rmf_traffic::agv::Graph graph,
-      std::shared_ptr<rmf_battery::agv::BatterySystem> battery_system,
-      std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-      std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-      std::shared_ptr<rmf_battery::DevicePowerSink> tool_sink,
-      double recharge_threshold,
-      double recharge_soc,
-      bool account_for_battery_drain,
-      std::unordered_map<std::string, ConsiderRequest> task_consideration,
-      std::unordered_map<std::string, ConsiderRequest> action_consideration,
-      rmf_task::ConstRequestFactoryPtr finishing_request = nullptr,
-      std::optional<std::string> server_uri = std::nullopt,
-      rmf_traffic::Duration max_delay = rmf_traffic::time::from_seconds(10.0),
-      rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(
-        0.5)
-    );
-
-    /// Create a Configuration object using a set of configuration parameters
-    /// imported from YAML files that follow the defined schema. This is an
-    /// alternative to constructing the Configuration using the RMF objects if
-    /// users do not require specific tool systems for their fleets. The
-    /// Configuration object will be instantiated with instances of
-    /// SimpleMotionPowerSink and SimpleDevicePowerSink.
-    ///
-    /// \param[in] config_file
-    ///   The path to a configuration YAML file containing data about the fleet's
-    ///   vehicle traits and task capabilities. This file needs to follow the pre-defined
-    ///   config.yaml structure to successfully load the parameters into the Configuration
-    ///   object.
-    ///
-    /// \param[in] nav_graph_path
-    ///   The path to a navigation path file that includes map information necessary
-    ///   to create a rmf_traffic::agv::Graph object
-    ///
-    /// \param[in] server_uri
-    ///   The URI for the websocket server that receives updates on tasks and
-    ///   states. If nullopt, data will not be published.
-    ///
-    /// \return A Configuration object with the essential config parameters loaded.
-    static std::shared_ptr<Configuration> make_simple(
-      const std::string& config_file,
-      const std::string& nav_graph_path,
-      std::optional<std::string> server_uri = std::nullopt);
-
-    /// Get the fleet name.
-    const std::string& fleet_name() const;
-
-    /// Get the fleet vehicle traits.
-    const VehicleTraits& vehicle_traits() const;
-
-    /// Get the fleet navigation graph.
-    const Graph& graph() const;
-
-    /// Get the battery system.
-    std::shared_ptr<rmf_battery::agv::BatterySystem> battery_system() const;
-
-    /// Get the motion sink.
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink() const;
-
-    /// Get the ambient sink.
-    std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink() const;
-
-    /// Get the tool sink.
-    std::shared_ptr<rmf_battery::DevicePowerSink> tool_sink() const;
-
-    /// Get the recharge threshold.
-    double recharge_threshold() const;
-
-    /// Get the recharge soc.
-    double recharge_soc() const;
-
-    /// Get whether or not to account for battery drain during task planning.
-    bool account_for_battery_drain() const;
-
-    /// Get the task categories
-    const std::unordered_map<std::string,
-      ConsiderRequest>& task_consideration() const;
-
-    /// Get the action categories
-    const std::unordered_map<std::string,
-      ConsiderRequest>& action_consideration() const;
-
-    /// Get the finishing request.
-    rmf_task::ConstRequestFactoryPtr finishing_request() const;
-
-    /// Get the server uri.
-    std::optional<std::string> server_uri() const;
-
-    /// Get the max delay.
-    rmf_traffic::Duration max_delay() const;
-
-    /// Get the update interval.
-    rmf_traffic::Duration update_interval() const;
-
-    class Implementation;
-  private:
-    rmf_utils::impl_ptr<Implementation> _pimpl;
-  };
-
-  /// The RobotState class encapsulates information about a robot in this fleet.
-  class RobotState
-  {
-  public:
-
-    /// Constructor
-    ///
-    /// \param[in] name
-    ///   The name of this robot.
-    ///
-    /// \param[in] charger_name
-    ///   The name of the charger waypoint of this robot.
-    ///
-    /// \param[in] map_name
-    ///   The name of the map this robot is currenly on.
-    ///
-    /// \param[in] location
-    ///   The XY position and orientation of this robot on current map.
-    ///
-    /// \param[in] battery_soc
-    ///   The state of charge of the battery of this robot.
-    ///   This should be a value between 0.0 and 1.0.
-    ///
-    /// \param[in] action
-    ///   The state of action of this robot. True if robot is
-    ///   performing an action.
-    RobotState(
-      const std::string& name,
-      const std::string& charger_name,
-      const std::string& map_name,
-      Eigen::Vector3d location,
-      double battery_soc,
-      bool action);
-
-    /// Get the name.
-    const std::string& name() const;
-
-    /// Get the charger name.
-    const std::string& charger_name() const;
-
-    /// Get the map name.
-    const std::string& map_name() const;
-
-    /// Get the location.
-    const Eigen::Vector3d& location() const;
-
-    /// Get the battery_soc.
-    double battery_soc() const;
-
-    /// Get the action status.
-    bool action() const;
-
-    class Implementation;
-
-  private:
-    rmf_utils::impl_ptr<Implementation> _pimpl;
-  };
-
-  /// Signature for a callback that returns the current RobotState of the robot.
-  ///
-  /// \return RobotState
-  using GetStateCallback = std::function<RobotState(void)>;
-
-  /// Signature for a function to request the robot to navigate to a location.
+  /// Signature for a function that handles navigation requests. The request
+  /// will specify an (x, y) location and yaw on a map.
   ///
   /// \param[in] map_name
   ///   The name of the map where the location exists.
   ///
   /// \param[in] location
-  ///   The XY position and orientation of the location.
+  ///   The (x, y) position and orientation of the location.
   ///
   /// \param[in] execution
-  ///   The action execution may be used to update navigation request items
-  ///   as well as to obtain the robot handle for the robot to submit any
-  ///   issue tickets regarding challenges with reaching the location.
+  ///   The command execution progress updater. Use this to keep the fleet
+  ///   adapter updated on the progress of the command.
   using NavigationRequest =
     std::function<void(
         const std::string& map_name,
         const Eigen::Vector3d location,
-        RobotUpdateHandle::ActionExecution execution)>;
+        CommandExecution execution)>;
 
-  /// Signature for a function to request the robot to stop.
-  ///
-  /// \return true if the robot has come to a stop.
-  using StopRequest = std::function<bool(void)>;
+  /// Signature for a function to handle stop requests.
+  using StopRequest = std::function<void(ConstActivityIdentifierPtr)>;
 
   /// Signature for a function to request the robot to dock at a location.
   ///
@@ -327,44 +101,14 @@ public:
   using DockRequest =
     std::function<void(
         const std::string& dock_name,
-        RobotUpdateHandle::ActionExecution execution)>;
-
-  /// Make an EasyFullControl adapter instance.
-  /// \param[in] config
-  ///   The Configuration for the adapter that contains parameters used by the
-  ///   fleet robots.
-  ///   If nullopt, the adapter will attempt to read all required parameters
-  ///   via its ROS 2 parameter server.
-  ///
-  /// \param[in] node_options
-  ///   The options that the rclcpp::Node will be constructed with.
-  ///
-  /// \param[in] discovery_timeout
-  ///   How long we will wait to discover the Schedule Node before giving up. If
-  ///   rmf_utils::nullopt is given, then this will try to use the
-  ///   discovery_timeout node parameter, or it will wait 1 minute if the
-  ///   discovery_timeout node parameter was not defined.
-  static std::shared_ptr<EasyFullControl> make(
-    std::optional<Configuration> config = std::nullopt,
-    const rclcpp::NodeOptions& options = rclcpp::NodeOptions(),
-    std::optional<rmf_traffic::Duration> discovery_timeout = std::nullopt);
-
-  /// Get the rclcpp::Node that this adapter will be using for communication.
-  std::shared_ptr<rclcpp::Node> node();
-
-  /// Get the FleetUpdateHandle that this adapter will be using.
-  /// This may be used to perform more specialized customizations using the
-  /// standard FleetUpdateHandle API.
-  std::shared_ptr<FleetUpdateHandle> fleet_handle();
-
-  /// Wait till the adapter is finished spinning.
-  EasyFullControl& wait();
-
-  /// Update the newly closed lanes for the robots to replan as necessary.
-  void newly_closed_lanes(
-    const std::unordered_set<std::size_t>& closed_lanes);
+        CommandExecution execution)>;
 
   /// Add a robot to the fleet once it is available.
+  ///
+  /// \note This will internally call Planner::compute_plan_starts() using the
+  ///    provieded start_state determine the StartSet of the robot. If you
+  ///    have a custom method to determine the StartSet of the robot, consider
+  ///    calling fleet_handle()->add_robot() instead.
   ///
   /// \param[in] start_state
   ///   The initial state of the robot when it is added to the fleet.
@@ -386,21 +130,23 @@ public:
   /// \param[in] action_executor
   ///   The ActionExecutor callback to request the robot to perform an action.
   ///
-  /// \return false if the robot was not added to the fleet.
-  /// \note This will internally call Planner::compute_plan_starts() using the
-  ///    provieded start_state determine the StartSet of the robot. If you
-  ///    have a custom method to determine the StartSet of the robot, consider
-  ///    calling fleet_handle()->add_robot() instead.
-  bool add_robot(
-    RobotState start_state,
-    GetStateCallback get_state,
+  /// \return an easy robot update handle on success. A nullptr if an error
+  /// occurred.
+  std::shared_ptr<EasyRobotUpdateHandle> add_robot(
+    InitializeRobot initial_state,
     NavigationRequest navigate,
     StopRequest stop,
     DockRequest dock,
     ActionExecutor action_executor);
 
-  // TODO(YV): Add an overloaded API for add_robot() where users can pass in a
-  // RobotCommandHandle instead of all the callbacks.
+  /// Get the FleetUpdateHandle that this adapter will be using.
+  /// This may be used to perform more specialized customizations using the
+  /// standard FleetUpdateHandle API.
+  std::shared_ptr<FleetUpdateHandle> fleet_handle();
+
+  /// Update the newly closed lanes for the robots to replan as necessary.
+  void newly_closed_lanes(
+    const std::unordered_set<std::size_t>& closed_lanes);
 
   class Implementation;
 private:
@@ -409,6 +155,355 @@ private:
 };
 
 using EasyFullControlPtr = std::shared_ptr<EasyFullControl>;
+
+class EasyFullControl::EasyRobotUpdateHandle
+{
+public:
+  /// Recommended function for updating the position of a robot in an
+  /// EasyFullControl fleet.
+  ///
+  /// \param[in] map_name
+  ///   The name of the map the robot is currently on
+  ///
+  /// \param[in] position
+  ///   The current position of the robot
+  ///
+  /// \param[in] current_action
+  ///   The action that the robot is currently executing
+  void update_position(
+    const std::string& map_name,
+    const Eigen::Vector3d& position,
+    ConstActivityIdentifierPtr current_activity);
+
+  /// Get more options for updating the robot's state
+  RobotUpdateHandle& more();
+
+  class Implementation;
+private:
+  EasyRobotUpdateHandle();
+  rmf_utils::unique_impl_ptr<Implementation> _pimpl;
+};
+
+///
+class EasyFullControl::CommandExecution
+{
+public:
+
+  /// Trigger this when the command is successfully finished. No other function
+  /// in this CommandExecution instance will be usable after this.
+  void finished();
+
+  /// Returns false if the command has been stopped.
+  bool okay() const;
+
+  /// Use this to override the traffic schedule for the agent while it performs
+  /// this command.
+  ///
+  /// If the given trajectory results in a traffic conflict then a negotiation
+  /// will be triggered. Hold onto the `Stubbornness` returned by this function
+  /// to ask other agents to plan around your trajectory, otherwise the
+  /// negotiation may result in a replan for this agent and a new command will
+  /// be issued.
+  ///
+  /// \note Using this will function always trigger a replan once the agent
+  /// finishes the command.
+  ///
+  /// \warning Too many overridden/stubborn agents can cause a deadlock. It's
+  ///   recommended to use this API sparingly and only over short distances or
+  ///   small deviations.
+  ///
+  /// \param[in] map
+  ///   Name of the map where the trajectory will take place
+  ///
+  /// \param[in] trajectory
+  ///   The motion of the agent
+  ///
+  /// \return a Stubbornness handle that tells the fleet adapter to
+  Stubbornness override_schedule(
+    std::string map,
+    rmf_traffic::Trajectory trajectory);
+
+  /// Activity handle for this command. Pass this into
+  /// EasyRobotUpdateHandle::update_position while executing this command.
+  ConstActivityIdentifierPtr handle() const;
+
+  class Implementation;
+private:
+  CommandExecution();
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+/// The Configuration class contains parameters necessary to initialize an
+/// EasyFullControl fleet instance and add fleets to the adapter.
+class EasyFullControl::Configuration
+{
+public:
+
+  /// Constructor
+  ///
+  /// \param[in] fleet_name
+  ///   The name of the fleet that is being added.
+  ///
+  /// \param[in] traits
+  ///   Specify the approximate traits of the vehicles in this fleet.
+  ///
+  /// \param[in] navigation_graph
+  ///   Specify the navigation graph used by the vehicles in this fleet.
+  ///
+  /// \param[in] battery_system
+  ///   Specify the battery system used by the vehicles in this fleet.
+  ///
+  /// \param[in] motion_sink
+  ///   Specify the motion sink that describes the vehicles in this fleet.
+  ///
+  /// \param[in] ambient_sink
+  ///   Specify the device sink for ambient sensors used by the vehicles in this fleet.
+  ///
+  /// \param[in] tool_sink
+  ///   Specify the device sink for special tools used by the vehicles in this fleet.
+  ///
+  /// \param[in] recharge_threshold
+  ///   The threshold for state of charge below which robots in this fleet
+  ///   will cease to operate and require recharging. A value between 0.0 and
+  ///   1.0 should be specified.
+  ///
+  /// \param[in] recharge_soc
+  ///   The state of charge to which robots in this fleet should be charged up
+  ///   to by automatic recharging tasks. A value between 0.0 and 1.0 should be
+  ///   specified.
+  ///
+  /// \param[in] account_for_battery_drain
+  ///   Specify whether battery drain is to be considered while allocating tasks.
+  ///   If false, battery drain will not be considered when planning for tasks.
+  ///   As a consequence, charging tasks will not be automatically assigned to
+  ///   vehicles in this fleet when battery levels fall below the
+  ///   recharge_threshold.
+  ///
+  /// \param[in] task_categories
+  ///   Provide callbacks for considering tasks belonging to each category.
+  ///
+  /// \param[in] action_categories
+  ///   List of actions that this fleet can perform. Each item represents a
+  ///   category in the PerformAction description.
+  ///
+  /// \param[in] finishing_request
+  ///   A factory for a request that should be performed by each robot in this
+  ///   fleet at the end of its assignments.
+  ///
+  /// \param[in] server_uri
+  ///   The URI for the websocket server that receives updates on tasks and
+  ///   states. If nullopt, data will not be published.
+  ///
+  /// \param[in] max_delay
+  ///   Specify the default value for how high the delay of the current itinerary
+  ///   can become before it gets interrupted and replanned.
+  ///
+  /// \param[in] update_interval
+  ///   The duration between positional state updates that are sent to
+  ///   the fleet adapter.
+  Configuration(
+    const std::string& fleet_name,
+    rmf_traffic::agv::VehicleTraits traits,
+    rmf_traffic::agv::Graph graph,
+    rmf_battery::agv::ConstBatterySystemPtr battery_system,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+    rmf_battery::ConstDevicePowerSinkPtr tool_sink,
+    double recharge_threshold,
+    double recharge_soc,
+    bool account_for_battery_drain,
+    std::unordered_map<std::string, ConsiderRequest> task_consideration,
+    std::unordered_map<std::string, ConsiderRequest> action_consideration,
+    rmf_task::ConstRequestFactoryPtr finishing_request = nullptr,
+    std::optional<std::string> server_uri = std::nullopt,
+    rmf_traffic::Duration max_delay = rmf_traffic::time::from_seconds(10.0),
+    rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(
+      0.5)
+  );
+
+  /// Create a Configuration object using a set of configuration parameters
+  /// imported from YAML files that follow the defined schema. This is an
+  /// alternative to constructing the Configuration using the RMF objects if
+  /// users do not require specific tool systems for their fleets. The
+  /// Configuration object will be instantiated with instances of
+  /// SimpleMotionPowerSink and SimpleDevicePowerSink.
+  ///
+  /// \param[in] config_file
+  ///   The path to a configuration YAML file containing data about the fleet's
+  ///   vehicle traits and task capabilities. This file needs to follow the pre-defined
+  ///   config.yaml structure to successfully load the parameters into the Configuration
+  ///   object.
+  ///
+  /// \param[in] nav_graph_path
+  ///   The path to a navigation path file that includes map information necessary
+  ///   to create a rmf_traffic::agv::Graph object
+  ///
+  /// \param[in] server_uri
+  ///   The URI for the websocket server that receives updates on tasks and
+  ///   states. If nullopt, data will not be published.
+  ///
+  /// \return A Configuration object with the essential config parameters loaded.
+  static std::shared_ptr<Configuration> from_config_files(
+    const std::string& config_file,
+    const std::string& nav_graph_path,
+    std::optional<std::string> server_uri = std::nullopt);
+
+  /// Get the fleet name.
+  const std::string& fleet_name() const;
+
+  /// Set the fleet name.
+  void set_fleet_name(std::string value);
+
+  /// Get the fleet vehicle traits.
+  const std::shared_ptr<const VehicleTraits>& vehicle_traits() const;
+
+  /// Set the vehicle traits.
+  void set_vehicle_traits(std::shared_ptr<const VehicleTraits> value);
+
+  /// Get the fleet navigation graph.
+  const std::shared_ptr<const Graph>& graph() const;
+
+  /// Set the fleet navigation graph.
+  void set_graph(std::shared_ptr<const Graph> value);
+
+  /// Get the battery system.
+  rmf_battery::agv::ConstBatterySystemPtr battery_system() const;
+
+  /// Set the battery system.
+  void set_battery_system(rmf_battery::agv::ConstBatterySystemPtr value);
+
+  /// Get the motion sink.
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink() const;
+
+  /// Set the motion sink.
+  void set_motion_sink(rmf_battery::ConstMotionPowerSinkPtr value);
+
+  /// Get the ambient sink.
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink() const;
+
+  /// Set the ambient sink.
+  void set_ambient_sink(rmf_battery::ConstDevicePowerSinkPtr value);
+
+  /// Get the tool sink.
+  rmf_battery::ConstDevicePowerSinkPtr tool_sink() const;
+
+  /// Set the tool sink.
+  void set_tool_sink(rmf_battery::ConstDevicePowerSinkPtr value);
+
+  /// Get the recharge threshold.
+  double recharge_threshold() const;
+
+  /// Set the recharge threshold.
+  void set_recharge_threshold(double value);
+
+  /// Get the recharge state of charge. If the robot's state of charge dips
+  /// below this value then its next task will be to recharge.
+  double recharge_soc() const;
+
+  /// Set the recharge state of charge.
+  void set_recharge_soc(double value);
+
+  /// Get whether or not to account for battery drain during task planning.
+  bool account_for_battery_drain() const;
+
+  /// Set whether or not to account for battery drain during task planning.
+  void set_account_for_battery_drain(bool value);
+
+  /// Get the task categories
+  const std::unordered_map<std::string, ConsiderRequest>&
+  task_consideration() const;
+
+  /// Mutable access to the task consideration map.
+  std::unordered_map<std::string, ConsiderRequest>& task_consideration();
+
+  /// Get the action categories
+  const std::unordered_map<std::string, ConsiderRequest>&
+  action_consideration() const;
+
+  /// Mutable access to the action consideration map.
+  std::unordered_map<std::string, ConsiderRequest>& action_consideration();
+
+  /// Get the finishing request.
+  rmf_task::ConstRequestFactoryPtr finishing_request() const;
+
+  /// Set the finishing request.
+  void set_finishing_request(rmf_task::ConstRequestFactoryPtr value);
+
+  /// Get the server uri.
+  std::optional<std::string> server_uri() const;
+
+  /// Set the server uri.
+  void set_server_uri(std::optional<std::string> value);
+
+  /// Get the max delay.
+  rmf_traffic::Duration max_delay() const;
+
+  /// Set the max delay.
+  void set_max_delay(rmf_traffic::Duration value);
+
+  /// Get the update interval.
+  rmf_traffic::Duration update_interval() const;
+
+  /// Set the update interval.
+  void set_update_interval(rmf_traffic::Duration value);
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+/// The InitializeRobot class encapsulates information about a robot in this fleet.
+class EasyFullControl::InitializeRobot
+{
+public:
+  /// Constructor
+  ///
+  /// \param[in] name
+  ///   The name of this robot.
+  ///
+  /// \param[in] charger_name
+  ///   The name of the charger waypoint of this robot.
+  ///
+  /// \param[in] map_name
+  ///   The name of the map this robot is currenly on.
+  ///
+  /// \param[in] location
+  ///   The XY position and orientation of this robot on current map.
+  ///
+  /// \param[in] battery_soc
+  ///   The state of charge of the battery of this robot.
+  ///   This should be a value between 0.0 and 1.0.
+  ///
+  /// \param[in] action
+  ///   The state of action of this robot. True if robot is
+  ///   performing an action.
+  InitializeRobot(
+    const std::string& name,
+    const std::string& charger_name,
+    const std::string& map_name,
+    Eigen::Vector3d location,
+    double battery_soc);
+
+  /// Get the name.
+  const std::string& name() const;
+
+  /// Get the charger name.
+  const std::string& charger_name() const;
+
+  /// Get the map name.
+  const std::string& map_name() const;
+
+  /// Get the location.
+  const Eigen::Vector3d& location() const;
+
+  /// Get the battery_soc.
+  double battery_soc() const;
+
+  class Implementation;
+
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
 
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -331,6 +331,10 @@ public:
   /// from this field.
   std::optional<std::size_t> graph_index() const;
 
+  /// If there is a speed limit that should be respected while approaching the
+  /// destination, this will indicate it.
+  std::optional<double> speed_limit() const;
+
   /// If the destination should be reached by performing a dock maneuver, this
   /// will contain the name of the dock.
   std::optional<std::string> dock() const;
@@ -494,6 +498,9 @@ public:
   /// from a fleet configuration file.
   const std::unordered_map<std::string, RobotConfiguration>&
   known_robot_configurations() const;
+
+  /// Get the names of all robots with known robot configurations.
+  std::vector<std::string> known_robots() const;
 
   /// Provide a known configuration for a named robot.
   ///

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -207,18 +207,35 @@ public:
   /// \param[in] compatible_chargers
   ///   List of chargers that this robot is compatible with
   ///
+  /// \param[in] responsive_wait
+  ///   Should this robot use the responsive wait behavior? true / false / fleet default.
+  ///
   /// \warning This must contain a single string value until a later release of
   /// RMF. We are using a vector for forward API compatibility. For now, make
   /// sure each robot has only one unique compatible charger to avoid charging
   /// conflicts.
   RobotConfiguration(
-    std::vector<std::string> compatible_chargers);
+    std::vector<std::string> compatible_chargers,
+    std::optional<bool> responsive_wait = std::nullopt);
 
   /// List of chargers that this robot is compatible with
   const std::vector<std::string>& compatible_chargers() const;
 
   /// Set the list of chargers compatible with this robot.
   void set_compatible_chargers(std::vector<std::string> chargers);
+
+  /// Should this robot use the responsive wait behavior? Responsive wait means
+  /// that when the robot is idle on a point, it will report to the traffic
+  /// schedule that it is waiting on that point, and it will negotiate with
+  /// other robots to let them pass while ultimately remaining on the point.
+  ///
+  /// If std::nullopt is used, then the fleet-wide responsive wait behavior will
+  /// be used.
+  std::optional<bool> responsive_wait() const;
+
+  /// Toggle responsive wait on (true), off (false), or use fleet default
+  /// (std::nullopt).
+  void set_responsive_wait(std::optional<bool> enable);
 
   class Implementation;
 private:
@@ -429,6 +446,10 @@ public:
   /// \param[in] update_interval
   ///   The duration between positional state updates that are sent to
   ///   the fleet adapter.
+  ///
+  /// \param[in] default_responsive_wait
+  ///   Should the robots in this fleet have responsive wait enabled (true) or
+  ///   disabled (false) by default?
   FleetConfiguration(
     const std::string& fleet_name,
     std::optional<std::unordered_map<std::string, Transformation>> transformations_to_robot_coordinates,
@@ -449,7 +470,8 @@ public:
     std::optional<std::string> server_uri = std::nullopt,
     rmf_traffic::Duration max_delay = rmf_traffic::time::from_seconds(10.0),
     rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(
-      0.5)
+      0.5),
+    bool default_responsive_wait = false
   );
 
   /// Create a FleetConfiguration object using a set of configuration parameters
@@ -619,6 +641,13 @@ public:
 
   /// Set the update interval.
   void set_update_interval(rmf_traffic::Duration value);
+
+  /// Should robots in this fleet have responsive wait enabled by default?
+  bool default_responsive_wait() const;
+
+  /// Set whether robots in this fleet should have responsive wait enabled by
+  /// default.
+  void set_default_responsive_wait(bool enable);
 
   class Implementation;
 private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -424,6 +424,7 @@ public:
   FleetConfiguration(
     const std::string& fleet_name,
     std::optional<std::unordered_map<std::string, Transformation>> transformations_to_robot_coordinates,
+    std::unordered_map<std::string, RobotConfiguration> known_robot_configurations,
     std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
     std::shared_ptr<const rmf_traffic::agv::Graph> graph,
     rmf_battery::agv::ConstBatterySystemPtr battery_system,
@@ -487,6 +488,27 @@ public:
   void add_robot_coordinate_transformation(
     std::string map,
     Transformation transformation);
+
+  /// Get a dictionary of known robot configurations. The key is the name of the
+  /// robot belonging to this fleet. These configurations are usually parsed
+  /// from a fleet configuration file.
+  const std::unordered_map<std::string, RobotConfiguration>&
+  known_robot_configurations() const;
+
+  /// Provide a known configuration for a named robot.
+  ///
+  /// \param[in] robot_name
+  ///   The unique name of the robot.
+  ///
+  /// \param[in] configuration
+  ///   The configuration for the robot.
+  void add_known_robot_configuration(
+    std::string robot_name,
+    RobotConfiguration configuration);
+
+  /// Get a known configuration for a robot based on its name.
+  std::optional<RobotConfiguration> get_known_robot_configuration(
+    const std::string& robot_name) const;
 
   /// Get the fleet vehicle traits.
   const std::shared_ptr<const VehicleTraits>& vehicle_traits() const;

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -291,15 +291,19 @@ public:
   /// \param[in] map
   ///   Name of the map where the trajectory will take place
   ///
-  /// \param[in] trajectory
+  /// \param[in] path
   ///   The path of the agent
+  ///
+  /// \param[in] hold
+  ///   How long the agent will wait at the end of the path
   ///
   /// \return a Stubbornness handle that tells the fleet adapter to not let the
   /// overridden path be negotiated. The returned handle will stop having an
   /// effect after this command execution is finished.
   Stubbornness override_schedule(
     std::string map,
-    std::vector<Eigen::Vector3d> path);
+    std::vector<Eigen::Vector3d> path,
+    rmf_traffic::Duration hold = rmf_traffic::Duration(0));
 
   /// Activity handle for this command. Pass this into
   /// EasyRobotUpdateHandle::update_position while executing this command.

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -42,6 +42,8 @@ namespace agv {
 class FleetUpdateHandle : public std::enable_shared_from_this<FleetUpdateHandle>
 {
 public:
+  /// Get the name of the fleet that his handle is managing.
+  const std::string& fleet_name() const;
 
   /// Add a robot to this fleet adapter.
   ///
@@ -277,10 +279,10 @@ public:
   ///
   /// \return true if task planner parameters were successfully updated.
   bool set_task_planner_params(
-    std::shared_ptr<rmf_battery::agv::BatterySystem> battery_system,
-    std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-    std::shared_ptr<rmf_battery::DevicePowerSink> tool_sink,
+    rmf_battery::agv::ConstBatterySystemPtr battery_system,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+    rmf_battery::ConstDevicePowerSinkPtr tool_sink,
     double recharge_threshold,
     double recharge_soc,
     bool account_for_battery_drain,

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -286,7 +286,7 @@ public:
     double recharge_threshold,
     double recharge_soc,
     bool account_for_battery_drain,
-    rmf_task::ConstRequestFactoryPtr finishing_requst = nullptr);
+    rmf_task::ConstRequestFactoryPtr finishing_request = nullptr);
 
   /// A callback function that evaluates whether a fleet will accept a task
   /// request

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -103,7 +103,8 @@ public:
   RobotUpdateHandle& set_charger_waypoint(const std::size_t charger_wp);
 
   /// Update the current battery level of the robot by specifying its state of
-  /// charge as a fraction of its total charge capacity
+  /// charge as a fraction of its total charge capacity, i.e. a value from 0.0
+  /// to 1.0.
   void update_battery_soc(const double battery_soc);
 
   /// Use this function to override the robot status. The string provided must

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -125,6 +125,23 @@ public:
   /// value that was given to the setter.
   rmf_utils::optional<rmf_traffic::Duration> maximum_delay() const;
 
+  /// Unique identifier for an activity that the robot is performing. Used by
+  /// the EasyFullControl API.
+  class ActivityIdentifier
+  {
+  public:
+
+    /// Compare whether two activity handles are referring to the same activity.
+    bool operator==(const ActivityIdentifier&) const;
+
+    class Implementation;
+  private:
+    ActivityIdentifier();
+    rmf_utils::unique_impl_ptr<Implementation> _pimpl;
+  };
+  using ActivityIdentifierPtr = std::shared_ptr<ActivityIdentifier>;
+  using ConstActivityIdentifierPtr = std::shared_ptr<const ActivityIdentifier>;
+
   /// The ActionExecution class should be used to manage the execution of and
   /// provide updates on ongoing actions.
   class ActionExecution
@@ -148,17 +165,6 @@ public:
     /// (warning tier)
     void blocked(std::optional<std::string> text);
 
-    /// Trigger this when you require a replan for your navigation or
-    /// docking request
-    bool replan();
-
-    /// Override the schedule to say that the robot will be following a certain
-    /// trajectory. This should not be used while tasks with automatic schedule
-    /// updating are running, or else the traffic schedule will have jumbled up
-    /// information, which can be disruptive to the overall traffic management.
-    void override_schedule(const std::string& map_name,
-      rmf_traffic::Trajectory trajectory);
-
     /// Trigger this when the action is successfully finished.
     /// No other functions in this ActionExecution instance will
     /// be usable after this.
@@ -166,6 +172,9 @@ public:
 
     /// Returns false if the Action has been killed or cancelled
     bool okay() const;
+
+    /// Activity identifier for this action. Used by the EasyFullControl API.
+    ConstActivityIdentifierPtr identifier() const;
 
     class Implementation;
   private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Transformation.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Transformation.hpp
@@ -48,10 +48,10 @@ public:
     Eigen::Vector2d translation);
 
   /// Get the rotation of this Transformation
-  const double rotation() const;
+  double rotation() const;
 
   /// Get the scale of this Transformation
-  const double scale() const;
+  double scale() const;
 
   /// Get the translation of this Transformation
   const Eigen::Vector2d& translation() const;
@@ -64,7 +64,7 @@ private:
 /// Helper function to transform between RMF and robot coordinate systems.
 /// Depending on the Transformation defined, this function can be used to
 /// transform robot coordinate system to RMF's coordinate system or vice versa.
-const Eigen::Vector3d transform(
+Eigen::Vector3d transform(
   const Transformation& transformation,
   const Eigen::Vector3d& pose);
 

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Transformation.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Transformation.hpp
@@ -56,17 +56,16 @@ public:
   /// Get the translation of this Transformation
   const Eigen::Vector2d& translation() const;
 
+  /// Apply this transformation to an (x, y, yaw) position
+  Eigen::Vector3d apply(const Eigen::Vector3d& position) const;
+
+  /// Apply the inverse of this transformation to an (x, y, yaw) position
+  Eigen::Vector3d apply_inverse(const Eigen::Vector3d& position) const;
+
   class Implementation;
 private:
   rmf_utils::impl_ptr<Implementation> _pimpl;
 };
-
-/// Helper function to transform between RMF and robot coordinate systems.
-/// Depending on the Transformation defined, this function can be used to
-/// transform robot coordinate system to RMF's coordinate system or vice versa.
-Eigen::Vector3d transform(
-  const Transformation& transformation,
-  const Eigen::Vector3d& pose);
 
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/rmf_rxcpp/RxCpp-4.1.0/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/rmf_fleet_adapter/rmf_rxcpp/RxCpp-4.1.0/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -917,8 +917,8 @@ private:
     int64_t ordinal;
 public:
 
-    schedulable_queue() 
-        : ordinal(0) 
+    schedulable_queue()
+        : ordinal(0)
     {
     }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.cpp
@@ -24,11 +24,10 @@ namespace rmf_fleet_adapter {
 
 //==============================================================================
 ScheduleManager::ScheduleManager(
-  rclcpp::Node& node,
+  rclcpp::Node&,
   rmf_traffic::schedule::Participant participant,
   rmf_traffic_ros2::schedule::Negotiation* negotiation)
-: _node(&node),
-  _participant(std::move(participant)),
+: _participant(std::move(participant)),
   _negotiator(nullptr)
 {
   if (negotiation)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.hpp
@@ -75,7 +75,6 @@ private:
         const ResponderPtr&)> callback;
   };
 
-  rclcpp::Node* _node;
   rmf_traffic::schedule::Participant _participant;
   Negotiator* _negotiator;
   std::shared_ptr<void> _negotiator_handle;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -838,10 +838,6 @@ std::string TaskManager::robot_status() const
 //==============================================================================
 auto TaskManager::expected_finish_state() const -> State
 {
-  rmf_task::State current_state =
-    _context->make_get_state()()
-    .time(rmf_traffic_ros2::convert(_context->node()->now()));
-
   std::lock_guard<std::mutex> lock(_mutex);
   if (!_direct_queue.empty())
   {
@@ -851,6 +847,9 @@ auto TaskManager::expected_finish_state() const -> State
   if (_active_task)
     return _context->current_task_end_state();
 
+  rmf_task::State current_state =
+    _context->make_get_state()()
+    .time(rmf_traffic_ros2::convert(_context->node()->now()));
   return current_state;
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -308,7 +308,7 @@ private:
   std::weak_ptr<agv::FleetUpdateHandle> _fleet_handle;
   rmf_task::ConstActivatorPtr _task_activator;
   ActiveTask _active_task;
-  bool _responsive_wait_enabled = true;
+  bool _responsive_wait_enabled = false;
   bool _emergency_active = false;
   std::optional<std::string> _emergency_pullover_interrupt_token;
   ActiveTask _emergency_pullover;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -278,7 +278,8 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
 
   return EasyFullControl::Implementation::make(
     fleet_handle,
-    config.skip_rotation_commands());
+    config.skip_rotation_commands(),
+    config.transformations_to_robot_coordinates());
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -363,7 +363,8 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
   return EasyFullControl::Implementation::make(
     fleet_handle,
     config.skip_rotation_commands(),
-    config.transformations_to_robot_coordinates());
+    config.transformations_to_robot_coordinates(),
+    config.default_responsive_wait());
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -210,8 +210,8 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
 {
   auto fleet_handle = this->add_fleet(
     config.fleet_name(),
-    config.vehicle_traits(),
-    config.graph(),
+    *config.vehicle_traits(),
+    *config.graph(),
     config.server_uri());
 
   auto planner_params_ok = fleet_handle->set_task_planner_params(
@@ -276,10 +276,7 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     "Finished configuring Easy Full Control adapter for fleet [%s]",
     config.fleet_name().c_str());
 
-  return EasyFullControl::Implementation::make(
-    config.vehicle_traits(),
-    config.graph(),
-    fleet_handle);
+  return EasyFullControl::Implementation::make(fleet_handle);
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -276,7 +276,9 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     "Finished configuring Easy Full Control adapter for fleet [%s]",
     config.fleet_name().c_str());
 
-  return EasyFullControl::Implementation::make(fleet_handle);
+  return EasyFullControl::Implementation::make(
+    fleet_handle,
+    config.skip_rotation_commands());
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -360,11 +360,21 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     "Finished configuring Easy Full Control adapter for fleet [%s]",
     config.fleet_name().c_str());
 
+  std::shared_ptr<TransformDictionary> tf_dict;
+  if (config.transformations_to_robot_coordinates().has_value())
+  {
+    tf_dict = std::make_shared<TransformDictionary>(
+      *config.transformations_to_robot_coordinates());
+  }
+
   return EasyFullControl::Implementation::make(
     fleet_handle,
     config.skip_rotation_commands(),
-    config.transformations_to_robot_coordinates(),
-    config.default_responsive_wait());
+    tf_dict,
+    config.default_responsive_wait(),
+    config.default_max_merge_waypoint_distance(),
+    config.default_max_merge_lane_distance(),
+    config.default_min_lane_length());
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -206,7 +206,7 @@ std::shared_ptr<Adapter> Adapter::make(
 
 //==============================================================================
 std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
-  EasyFullControl::Configuration config)
+  const EasyFullControl::Configuration& config)
 {
   auto fleet_handle = this->add_fleet(
     config.fleet_name(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -1345,7 +1345,7 @@ EasyFullControl::Configuration::Configuration(
 }
 
 //==============================================================================
-std::shared_ptr<EasyFullControl::Configuration>
+EasyFullControl::Configuration
 EasyFullControl::Configuration::from_config_files(
   const std::string& config_file,
   const std::string& nav_graph_path,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -264,7 +264,6 @@ public:
       if (on_waypoint.has_value())
       {
         const auto wp = on_waypoint->first;
-        // std::cout << "IMPL " << context->requester_id() << " " << __LINE__ << std::endl;
         starts.push_back(rmf_traffic::agv::Plan::Start(now, wp, yaw, p));
         for (std::size_t lane_id : graph.lanes_from(wp))
         {
@@ -289,7 +288,6 @@ public:
             continue;
           }
 
-          // std::cout << "IMPL " << context->requester_id() << " " << __LINE__ << std::endl;
           auto wp_exit = graph.get_lane(lane_id).exit().waypoint_index();
           starts.push_back(
             rmf_traffic::agv::Plan::Start(now, wp_exit, yaw, p, lane_id));
@@ -345,25 +343,21 @@ public:
           const auto& lane = graph.get_lane(lane_id);
           const auto wp0 = lane.entry().waypoint_index();
           const auto wp1 = lane.exit().waypoint_index();
-          // std::cout << "IMPL " << context->requester_id() << " " << __LINE__ << std::endl;
           starts.push_back(
             rmf_traffic::agv::Plan::Start(now, wp1, yaw, p, lane_id));
 
           if (const auto* reverse_lane = graph.lane_from(wp1, wp0))
           {
-            // std::cout << "IMPL " << context->requester_id() << " " << __LINE__ << std::endl;
             starts.push_back(rmf_traffic::agv::Plan::Start(
                 now, wp0, yaw, p, reverse_lane->index()));
           }
         }
         else
         {
-          // std::cout << "IMPL " << context->requester_id() << " " << __LINE__ << std::endl;
           starts = nav_params->compute_plan_starts(graph, map, location, now);
         }
       }
 
-      // std::cout << context->requester_id() << " SETTING LOCATIONS FROM " << __LINE__ << std::endl;
       if (!starts.empty())
       {
         context->set_location(starts);
@@ -804,19 +798,6 @@ void EasyCommandHandle::follow_new_path(
     return;
   }
 
-  std::cout << "initial path for " << context->requester_id() << ":";
-  for (std::size_t i=0; i < waypoints.size(); ++i)
-  {
-    const auto& wp = waypoints[i];
-    std::cout << "\n -- " << i << ". (";
-    if (wp.graph_index().has_value())
-      std::cout << *wp.graph_index();
-    else
-      std::cout << "null";
-    std::cout << ") " << wp.position().transpose();
-  }
-  std::cout << std::endl;
-
   RCLCPP_DEBUG(
     context->node()->get_logger(),
     "follow_new_path for robot [%s] with PlanId [%ld]",
@@ -898,8 +879,6 @@ void EasyCommandHandle::follow_new_path(
             {
               found_connection = true;
               i0 = i - 1;
-              std::cout << context->requester_id() << " SKIPPING IMPL " << __LINE__
-                << " | " << i0 << std::endl;
             }
             else
             {
@@ -909,8 +888,6 @@ void EasyCommandHandle::follow_new_path(
               {
                 found_connection = true;
                 i0 = 0;
-                std::cout << context->requester_id() << " SKIPPING IMPL " << __LINE__
-                  << " | " << i0 << std::endl;
               }
             }
           }
@@ -918,8 +895,6 @@ void EasyCommandHandle::follow_new_path(
           {
             found_connection = true;
             i0 = i;
-            std::cout << context->requester_id() << " SKIPPING IMPL " << __LINE__
-              << " | " << i0 << std::endl;
           }
         }
       }
@@ -942,8 +917,6 @@ void EasyCommandHandle::follow_new_path(
         {
           found_connection = true;
           i0 = i;
-          std::cout << context->requester_id() << " SKIPPING IMPL " << __LINE__
-            << " | " << i0 << std::endl;
         }
       }
     }
@@ -960,8 +933,6 @@ void EasyCommandHandle::follow_new_path(
             {
               found_connection = true;
               i0 = i - 1;
-              std::cout << context->requester_id() << " SKIPPING IMPL " << __LINE__
-                << " | " << i0 << std::endl;
             }
           }
         }
@@ -1057,8 +1028,6 @@ void EasyCommandHandle::follow_new_path(
             target_index = i2;
             target_position = wp2.position();
             skip_next = true;
-            // std::cout << "[" << context->requester_id() << "] skipping "
-            //   << *wp2.graph_index() << std::endl;
           }
         }
       }
@@ -1071,12 +1040,6 @@ void EasyCommandHandle::follow_new_path(
       wp1.graph_index(),
       speed_limit);
 
-    // std::cout << "[" << context->requester_id() << "] will pass through (";
-    // if (wp1.graph_index().has_value())
-    //   std::cout << *wp1.graph_index();
-    // else
-    //   std::cout << "null" ;
-    // std::cout << ") " << command_position.transpose() << std::endl;
     queue.push_back(
       EasyFullControl::CommandExecution::Implementation::make(
         context,
@@ -1405,7 +1368,6 @@ void EasyFullControl::EasyRobotUpdateHandle::update(
       const auto& nav_params = updater->nav_params;
       const auto now = context->now();
       auto starts = nav_params->compute_plan_starts(graph, state.map(), position, now);
-      // std::cout << context->requester_id() << " SETTING LOCATIONS FROM " << __LINE__ << std::endl;
       if (!starts.empty())
       {
         context->set_location(std::move(starts));

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -1790,10 +1790,10 @@ EasyFullControl::FleetConfiguration::from_config_files(
 
   // Action considerations
   std::unordered_map<std::string, ConsiderRequest> action_consideration;
-  if (task_capabilities["action"])
+  const auto& actions_yaml = rmf_fleet["actions"];
+  if (actions_yaml)
   {
-    const auto actions =
-      task_capabilities["action"].as<std::vector<std::string>>();
+    const auto actions = actions_yaml.as<std::vector<std::string>>();
     for (const std::string& action : actions)
     {
       action_consideration[action] = consider_all();
@@ -1802,7 +1802,8 @@ EasyFullControl::FleetConfiguration::from_config_files(
 
   // Finishing tasks
   std::string finishing_request_string;
-  if (!task_capabilities["finishing_request"])
+  const auto& finishing_request_yaml = rmf_fleet["finishing_request"];
+  if (!finishing_request_yaml)
   {
     std::cout
       << "Finishing request is not provided. The valid finishing requests "
@@ -1811,8 +1812,7 @@ EasyFullControl::FleetConfiguration::from_config_files(
   }
   else
   {
-    finishing_request_string =
-      task_capabilities["finishing_request"].as<std::string>();
+    finishing_request_string = finishing_request_yaml.as<std::string>();
   }
   rmf_task::ConstRequestFactoryPtr finishing_request;
   if (finishing_request_string == "charge")

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1256,6 +1256,12 @@ auto FleetUpdateHandle::Implementation::allocate_tasks(
 }
 
 //==============================================================================
+const std::string& FleetUpdateHandle::fleet_name() const
+{
+  return _pimpl->name;
+}
+
+//==============================================================================
 void FleetUpdateHandle::add_robot(
   std::shared_ptr<RobotCommandHandle> command,
   const std::string& name,
@@ -1997,10 +2003,10 @@ FleetUpdateHandle& FleetUpdateHandle::set_update_listener(
 
 //==============================================================================
 bool FleetUpdateHandle::set_task_planner_params(
-  std::shared_ptr<rmf_battery::agv::BatterySystem> battery_system,
-  std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
-  std::shared_ptr<rmf_battery::DevicePowerSink> tool_sink,
+  rmf_battery::agv::ConstBatterySystemPtr battery_system,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+  rmf_battery::ConstDevicePowerSinkPtr tool_sink,
   double recharge_threshold,
   double recharge_soc,
   bool account_for_battery_drain,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1565,6 +1565,12 @@ void FleetUpdateHandle::close_lanes(std::vector<std::size_t> lane_indices)
 
       self->_pimpl->task_parameters->planner(*self->_pimpl->planner);
       self->_pimpl->publish_lane_states();
+
+      RobotContext::GraphChange changes{lane_indices};
+      for (auto& [ctx, _] : self->_pimpl->task_managers)
+      {
+        ctx->notify_graph_change(changes);
+      }
     });
 }
 
@@ -1670,7 +1676,7 @@ auto FleetUpdateHandle::limit_lane_speeds(
         {
           RCLCPP_WARN(
             self->_pimpl->node->get_logger(),
-            "Ignoring speed limit request %f for lane %d in fleet %s as it is "
+            "Ignoring speed limit request %f for lane %lu in fleet %s as it is "
             "not greater than zero. If you would like to close the lane, use "
             "the FleetUpdateHandle::close_lanes(~) API instead.",
             request.speed_limit(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -784,7 +784,6 @@ std::optional<rmf_fleet_msgs::msg::Location> convert_location(
         .index(0);
     }
 
-    std::cout << "LOST && MISSING LOST INFO FOR " << context.requester_id() << std::endl;
     // TODO(MXG): We should emit some kind of critical error if there is no
     // location and also no lost information, because that means an issue ticket
     // has not been created.

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1374,7 +1374,7 @@ void FleetUpdateHandle::add_robot(
             using namespace std::chrono_literals;
             auto last_interrupt_time =
             std::make_shared<std::optional<rmf_traffic::Time>>(std::nullopt);
-            context->_negotiation_license =
+            auto negotiation_license =
             fleet->_pimpl->negotiation
             ->register_negotiator(
               context->itinerary().id(),
@@ -1416,6 +1416,7 @@ void FleetUpdateHandle::add_robot(
                   c->request_replan();
                 }
               });
+            context->_set_negotiation_license(std::move(negotiation_license));
           }
 
           RCLCPP_INFO(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -361,6 +361,16 @@ double RobotContext::current_battery_soc() const
 //==============================================================================
 RobotContext& RobotContext::current_battery_soc(const double battery_soc)
 {
+  if (battery_soc < 0.0 || battery_soc > 1.0)
+  {
+    RCLCPP_ERROR(
+      _node->get_logger(),
+      "Invalid battery state of charge given for [%s]: %0.3f",
+      requester_id().c_str(),
+      battery_soc);
+    return *this;
+  }
+
   _current_battery_soc = battery_soc;
   _battery_soc_publisher.get_subscriber().on_next(battery_soc);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -75,9 +75,15 @@ std::function<rmf_traffic::Time()> RobotContext::clock() const
 }
 
 //==============================================================================
-const std::vector<rmf_traffic::agv::Plan::Start>& RobotContext::location() const
+const rmf_traffic::agv::Plan::StartSet& RobotContext::location() const
 {
   return _location;
+}
+
+//==============================================================================
+void RobotContext::set_location(rmf_traffic::agv::Plan::StartSet location_)
+{
+  _location = std::move(location_);
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -85,22 +85,6 @@ void RobotContext::set_location(rmf_traffic::agv::Plan::StartSet location_)
 {
   _location = std::move(location_);
   filter_closed_lanes();
-  // std::cout << requester_id() << " locations: " << _location.size() << std::endl;
-  // const auto& graph = planner()->get_configuration().graph();
-  // for (const auto& l : _location)
-  // {
-  //   std::cout << " -- wp (" << l.waypoint() << ") "
-  //     << graph.get_waypoint(l.waypoint()).get_location().transpose();
-  //   if (l.location().has_value())
-  //     std::cout << " | " << l.location()->transpose();
-  //   else
-  //     std::cout << " | no position";
-  //   if (l.lane().has_value())
-  //     std::cout << " | lane " << *l.lane();
-  //   else
-  //     std::cout << " | no lane";
-  //   std::cout << std::endl;
-  // }
   if (_location.empty())
   {
     set_lost(std::nullopt);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -145,7 +145,7 @@ void RobotContext::filter_closed_lanes()
   if (const auto planner = *_planner)
   {
     const auto& closures = planner->get_configuration().lane_closures();
-    for (std::size_t i = 0; i < _location.size();)
+    for (std::size_t i = 0; i < _location.size(); )
     {
       if (_location[i].lane().has_value())
       {
@@ -392,9 +392,9 @@ std::function<rmf_task::State()> RobotContext::make_get_state()
       if (self->_most_recent_valid_location.empty())
       {
         throw std::runtime_error(
-          "Missing a _most_recent_valid_location for robot ["
-          + self->requester_id() + "]. This is an internal RMF error, "
-          "please report it to the RMF developers.");
+                "Missing a _most_recent_valid_location for robot ["
+                + self->requester_id() + "]. This is an internal RMF error, "
+                "please report it to the RMF developers.");
       }
 
       rmf_task::State state;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -55,7 +55,7 @@ using TransformDictionary = std::unordered_map<std::string, Transformation>;
 struct NavParams
 {
   bool skip_rotation_commands;
-  std::optional<TransformDictionary> transforms_to_robot_coords;
+  std::shared_ptr<TransformDictionary> transforms_to_robot_coords;
   double max_merge_waypoint_distance = 1e-3;
   double max_merge_lane_distance = 0.3;
   double min_lane_length = 1e-8;
@@ -67,7 +67,7 @@ struct NavParams
     const std::string& map,
     Eigen::Vector3d position)
   {
-    if (!transforms_to_robot_coords.has_value())
+    if (!transforms_to_robot_coords)
     {
       return position;
     }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -82,6 +82,11 @@ public:
   /// Set the current location for the robot in terms of a planner start set
   void set_location(rmf_traffic::agv::Plan::StartSet location_);
 
+  /// Filter closed lanes out of the planner start set. At least one start will
+  /// be retained so that the planner can offer some solution, even if all
+  /// plan starts are using closed lanes.
+  void filter_closed_lanes();
+
   /// Get a mutable reference to the schedule of this robot
   rmf_traffic::schedule::Participant& itinerary();
 
@@ -132,7 +137,17 @@ public:
   struct Empty {};
   const rxcpp::observable<Empty>& observe_replan_request() const;
 
+  /// Request this robot to replan
   void request_replan();
+
+  struct GraphChange
+  {
+    std::vector<std::size_t> closed_lanes;
+  };
+  const rxcpp::observable<GraphChange>& observe_graph_change() const;
+
+  /// Notify this robot that the graph has changed.
+  void notify_graph_change(GraphChange changes);
 
   /// Get a reference to the rclcpp node
   const std::shared_ptr<Node>& node();
@@ -281,6 +296,9 @@ private:
 
   rxcpp::subjects::subject<Empty> _replan_publisher;
   rxcpp::observable<Empty> _replan_obs;
+
+  rxcpp::subjects::subject<GraphChange> _graph_change_publisher;
+  rxcpp::observable<GraphChange> _graph_change_obs;
 
   std::shared_ptr<Node> _node;
   rxcpp::schedulers::worker _worker;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -352,10 +352,13 @@ public:
 
   const Reporting& reporting() const;
 
-private:
-  friend class FleetUpdateHandle;
-  friend class RobotUpdateHandle;
-  friend class rmf_fleet_adapter::TaskManager;
+  /// Set the task manager for this robot. This should only be called in the
+  /// TaskManager::make function.
+  void _set_task_manager(std::shared_ptr<TaskManager> mgr);
+
+  /// Set the negotiation license for this robot. This should only be called in
+  /// the FleetUpdateHandle::add_robot function.
+  void _set_negotiation_license(std::shared_ptr<void> license);
 
   RobotContext(
     std::shared_ptr<RobotCommandHandle> command_handle,
@@ -371,12 +374,11 @@ private:
     rmf_task::State state,
     std::shared_ptr<const rmf_task::TaskPlanner> task_planner);
 
-  /// Set the task manager for this robot. This should only be called in the
-  /// TaskManager::make function.
-  void _set_task_manager(std::shared_ptr<TaskManager> mgr);
+private:
 
   std::weak_ptr<RobotCommandHandle> _command_handle;
   std::vector<rmf_traffic::agv::Plan::Start> _location;
+  std::vector<rmf_traffic::agv::Plan::Start> _most_recent_valid_location;
   rmf_traffic::schedule::Participant _itinerary;
   std::shared_ptr<const Mirror> _schedule;
   std::shared_ptr<std::shared_ptr<const rmf_traffic::agv::Planner>> _planner;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -77,7 +77,10 @@ public:
 
   /// This is the current "location" of the robot, which can be used to initiate
   /// a planning job
-  const std::vector<rmf_traffic::agv::Plan::Start>& location() const;
+  const rmf_traffic::agv::Plan::StartSet& location() const;
+
+  /// Set the current location for the robot in terms of a planner start set
+  void set_location(rmf_traffic::agv::Plan::StartSet location_);
 
   /// Get a mutable reference to the schedule of this robot
   rmf_traffic::schedule::Participant& itinerary();

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -762,22 +762,6 @@ rmf_traffic::PlanId RobotUpdateHandle::Unstable::current_plan_id() const
 }
 
 //==============================================================================
-class RobotUpdateHandle::Unstable::Stubbornness::Implementation
-{
-public:
-  std::shared_ptr<void> stubbornness;
-
-  static Stubbornness make(std::shared_ptr<void> stubbornness)
-  {
-    Stubbornness output;
-    output._pimpl = rmf_utils::make_impl<Implementation>(
-      Implementation{stubbornness});
-
-    return output;
-  }
-};
-
-//==============================================================================
 void RobotUpdateHandle::Unstable::Stubbornness::release()
 {
   _pimpl->stubbornness = nullptr;
@@ -854,29 +838,6 @@ void RobotUpdateHandle::ActionExecution::blocked(
   _pimpl->data->state->update_status(rmf_task::Event::Status::Blocked);
   if (text.has_value())
     _pimpl->data->state->update_log().warn(*text);
-}
-
-//==============================================================================
-bool RobotUpdateHandle::ActionExecution::replan()
-{
-  _pimpl->data->request_replan = true;
-}
-
-//==============================================================================
-void RobotUpdateHandle::ActionExecution::override_schedule(
-  const std::string& map_name, rmf_traffic::Trajectory trajectory)
-{
-  //
-  if (_pimpl->data->handle.has_value())
-  {
-    auto updater = _pimpl->data->handle.value();
-    if (auto participant = updater->unstable().get_participant())
-    {
-      participant->set(
-        participant->assign_plan_id(),
-        {rmf_traffic::Route(map_name, trajectory)});
-    }
-  }
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -306,6 +306,19 @@ RobotUpdateHandle& RobotUpdateHandle::maximum_delay(
 }
 
 //==============================================================================
+bool RobotUpdateHandle::ActivityIdentifier::operator==(
+  const ActivityIdentifier& other) const
+{
+  return _pimpl == other._pimpl;
+}
+
+//==============================================================================
+RobotUpdateHandle::ActivityIdentifier::ActivityIdentifier()
+{
+  // Do nothing
+}
+
+//==============================================================================
 rmf_utils::optional<rmf_traffic::Duration>
 RobotUpdateHandle::maximum_delay() const
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -211,7 +211,17 @@ RobotUpdateHandle& RobotUpdateHandle::set_charger_waypoint(
 void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 {
   if (battery_soc < 0.0 || battery_soc > 1.0)
+  {
+    if (const auto context = _pimpl->get_context())
+    {
+      RCLCPP_ERROR(
+        context->node()->get_logger(),
+        "Invalid battery state of charge given for [%s]: %0.3f",
+        context->requester_id().c_str(),
+        battery_soc);
+    }
     return;
+  }
 
   if (const auto context = _pimpl->get_context())
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -994,7 +994,6 @@ void ScheduleOverride::overridden_update(
   }
 
   const auto now = rmf_traffic_ros2::convert(context->node()->now());
-  // const auto delay_thresh = std::chrono::seconds(1);
   const auto delay_thresh = std::chrono::milliseconds(100);
   if (closest_lane.has_value())
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -1030,7 +1030,7 @@ void ScheduleOverride::overridden_update(
     // based on the agent being at that waypoint. This is a very fallible
     // estimation, but it's the best we can do with limited information.
     std::optional<std::pair<rmf_traffic::Time, double>> closest_time;
-    for (std::size_t i=0; i < route.trajectory().size(); ++i)
+    for (std::size_t i = 0; i < route.trajectory().size(); ++i)
     {
       const auto& wp = route.trajectory().at(i);
       const Eigen::Vector2d p_wp = wp.position().block<2, 1>(0, 0);
@@ -1052,7 +1052,7 @@ void ScheduleOverride::overridden_update(
   }
 
   const auto& itin = context->itinerary().itinerary();
-  for (std::size_t i=0; i < itin.size(); ++i)
+  for (std::size_t i = 0; i < itin.size(); ++i)
   {
     const auto& traj = itin[i].trajectory();
     const auto t_it = traj.find(now);
@@ -1154,7 +1154,7 @@ std::optional<ScheduleOverride> ScheduleOverride::make(
       Eigen::Vector3d(0.0, 0.0, 0.0));
   }
   std::set<uint64_t> checkpoints;
-  for (uint64_t i=1; i < trajectory.size(); ++i)
+  for (uint64_t i = 1; i < trajectory.size(); ++i)
   {
     checkpoints.insert(i);
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -885,13 +885,9 @@ void RobotUpdateHandle::ActionExecution::finished()
   if (_pimpl->data)
   {
     _pimpl->data->worker.schedule(
-      [data = _pimpl->data](const rxcpp::schedulers::schedulable&)
+      [finished = _pimpl->data->finished](const rxcpp::schedulers::schedulable&)
       {
-        if (data->finished)
-        {
-          data->finished();
-          data->finished = nullptr;
-        }
+        finished.trigger();
       });
   }
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -210,19 +210,6 @@ RobotUpdateHandle& RobotUpdateHandle::set_charger_waypoint(
 //==============================================================================
 void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 {
-  if (battery_soc < 0.0 || battery_soc > 1.0)
-  {
-    if (const auto context = _pimpl->get_context())
-    {
-      RCLCPP_ERROR(
-        context->node()->get_logger(),
-        "Invalid battery state of charge given for [%s]: %0.3f",
-        context->requester_id().c_str(),
-        battery_soc);
-    }
-    return;
-  }
-
   if (const auto context = _pimpl->get_context())
   {
     context->worker().schedule(
@@ -236,10 +223,8 @@ void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 //==============================================================================
 void RobotUpdateHandle::override_status(std::optional<std::string> status)
 {
-
   if (const auto context = _pimpl->get_context())
   {
-
     if (status.has_value())
     {
       // Here we capture [this] to avoid potential costly copy of
@@ -880,6 +865,13 @@ void RobotUpdateHandle::ActionExecution::finished()
 bool RobotUpdateHandle::ActionExecution::okay() const
 {
   return _pimpl->data->okay;
+}
+
+//==============================================================================
+auto RobotUpdateHandle::ActionExecution::identifier() const
+-> ConstActivityIdentifierPtr
+{
+  return _pimpl->identifier;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Transformation.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Transformation.cpp
@@ -47,13 +47,13 @@ Transformation::Transformation(
 }
 
 //==============================================================================
-const double Transformation::rotation() const
+double Transformation::rotation() const
 {
   return _pimpl->rotation;
 }
 
 //==============================================================================
-const double Transformation::scale() const
+double Transformation::scale() const
 {
   return _pimpl->scale;
 }
@@ -65,7 +65,7 @@ const Eigen::Vector2d& Transformation::translation() const
 }
 
 //==============================================================================
-const Eigen::Vector3d transform(
+Eigen::Vector3d transform(
   const Transformation& transformation,
   const Eigen::Vector3d& pose)
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -32,27 +32,32 @@ public:
   std::shared_ptr<FleetUpdateHandle> fleet_handle;
   // Map robot name to its EasyCommandHandle
   std::unordered_map<std::string, EasyCommandHandlePtr> cmd_handles;
-  // TODO(YV): Get these constants from EasyCommandHandle::Configuration
-  std::shared_ptr<NavParams> nav_params;
+  NavParams nav_params;
   bool default_responsive_wait;
 
   static std::shared_ptr<EasyFullControl> make(
     std::shared_ptr<FleetUpdateHandle> fleet_handle,
     bool skip_rotation_commands,
-    std::optional<TransformDictionary> transforms_to_robot_coords,
-    bool default_responsive_wait)
+    std::shared_ptr<TransformDictionary> transforms_to_robot_coords,
+    bool default_responsive_wait,
+    double default_max_merge_waypoint_distance,
+    double default_max_merge_lane_distance,
+    double default_min_lane_length)
   {
     auto handle = std::shared_ptr<EasyFullControl>(new EasyFullControl);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
-        Implementation{
-          fleet_handle,
-          {},
-          std::make_shared<NavParams>(NavParams{
-            skip_rotation_commands,
-            std::move(transforms_to_robot_coords)
-          }),
-          default_responsive_wait
-        });
+      Implementation{
+        fleet_handle,
+        {},
+        NavParams{
+          skip_rotation_commands,
+          std::move(transforms_to_robot_coords),
+          default_max_merge_waypoint_distance,
+          default_max_merge_lane_distance,
+          default_min_lane_length
+        },
+        default_responsive_wait
+      });
     return handle;
   }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -24,11 +24,13 @@ namespace agv {
 
 class EasyCommandHandle;
 using EasyCommandHandlePtr = std::shared_ptr<EasyCommandHandle>;
+using TransformDictionary = std::unordered_map<std::string, Transformation>;
 
 //==============================================================================
 struct NavParams
 {
   bool skip_rotation_commands;
+  std::optional<TransformDictionary> transforms_to_robot_coords;
   double max_merge_waypoint_distance = 0.3;
   double max_merge_lane_distance = 0.1;
   double min_lane_length = 1e-8;
@@ -46,14 +48,18 @@ public:
 
   static std::shared_ptr<EasyFullControl> make(
     std::shared_ptr<FleetUpdateHandle> fleet_handle,
-    bool skip_rotation_commands)
+    bool skip_rotation_commands,
+    std::optional<TransformDictionary> transforms_to_robot_coords)
   {
     auto handle = std::shared_ptr<EasyFullControl>(new EasyFullControl);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
         Implementation{
           fleet_handle,
           {},
-          std::make_shared<NavParams>(NavParams{skip_rotation_commands})
+          std::make_shared<NavParams>(NavParams{
+            skip_rotation_commands,
+            std::move(transforms_to_robot_coords)
+          })
         });
     return handle;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -34,11 +34,13 @@ public:
   std::unordered_map<std::string, EasyCommandHandlePtr> cmd_handles;
   // TODO(YV): Get these constants from EasyCommandHandle::Configuration
   std::shared_ptr<NavParams> nav_params;
+  bool default_responsive_wait;
 
   static std::shared_ptr<EasyFullControl> make(
     std::shared_ptr<FleetUpdateHandle> fleet_handle,
     bool skip_rotation_commands,
-    std::optional<TransformDictionary> transforms_to_robot_coords)
+    std::optional<TransformDictionary> transforms_to_robot_coords,
+    bool default_responsive_wait)
   {
     auto handle = std::shared_ptr<EasyFullControl>(new EasyFullControl);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
@@ -48,7 +50,8 @@ public:
           std::make_shared<NavParams>(NavParams{
             skip_rotation_commands,
             std::move(transforms_to_robot_coords)
-          })
+          }),
+          default_responsive_wait
         });
     return handle;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -28,6 +28,7 @@ using EasyCommandHandlePtr = std::shared_ptr<EasyCommandHandle>;
 //==============================================================================
 struct NavParams
 {
+  bool skip_rotation_commands;
   double max_merge_waypoint_distance = 0.3;
   double max_merge_lane_distance = 0.1;
   double min_lane_length = 1e-8;
@@ -44,14 +45,15 @@ public:
   std::shared_ptr<NavParams> nav_params;
 
   static std::shared_ptr<EasyFullControl> make(
-    std::shared_ptr<FleetUpdateHandle> fleet_handle)
+    std::shared_ptr<FleetUpdateHandle> fleet_handle,
+    bool skip_rotation_commands)
   {
     auto handle = std::shared_ptr<EasyFullControl>(new EasyFullControl);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
         Implementation{
           fleet_handle,
           {},
-          std::make_shared<NavParams>()
+          std::make_shared<NavParams>(NavParams{skip_rotation_commands})
         });
     return handle;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_fleet_adapter/agv/EasyFullControl.hpp>
+
+#include "internal_FleetUpdateHandle.hpp"
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+class EasyCommandHandle;
+using EasyCommandHandlePtr = std::shared_ptr<EasyCommandHandle>;
+
+//==============================================================================
+struct NavParams
+{
+  double max_merge_waypoint_distance = 0.3;
+  double max_merge_lane_distance = 0.1;
+  double min_lane_length = 1e-8;
+};
+
+//==============================================================================
+class EasyFullControl::Implementation
+{
+public:
+  std::shared_ptr<const VehicleTraits> traits;
+  std::shared_ptr<const Graph> graph;
+  std::shared_ptr<FleetUpdateHandle> fleet_handle;
+  // Map robot name to its EasyCommandHandle
+  std::unordered_map<std::string, EasyCommandHandlePtr> cmd_handles;
+  // TODO(YV): Get these constants from EasyCommandHandle::Configuration
+  NavParams nav_params;
+
+  static std::shared_ptr<EasyFullControl> make(
+    std::shared_ptr<const VehicleTraits> traits,
+    std::shared_ptr<const Graph> graph,
+    std::shared_ptr<FleetUpdateHandle> fleet_handle)
+  {
+    auto handle = std::shared_ptr<EasyFullControl>(new EasyFullControl);
+    handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
+        Implementation{traits, graph, fleet_handle, {}});
+    return handle;
+  }
+
+  const std::shared_ptr<Node>& node() const
+  {
+    return FleetUpdateHandle::Implementation::get(*fleet_handle).node;
+  }
+};
+
+} // namespace agv
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -34,6 +34,24 @@ struct NavParams
   double max_merge_waypoint_distance = 0.3;
   double max_merge_lane_distance = 0.1;
   double min_lane_length = 1e-8;
+
+  std::optional<Eigen::Vector3d> to_rmf_coordinates(
+    const std::string& map,
+    Eigen::Vector3d position)
+  {
+    if (!transforms_to_robot_coords.has_value())
+    {
+      return position;
+    }
+
+    const auto tf_it = transforms_to_robot_coords->find(map);
+    if (tf_it == transforms_to_robot_coords->end())
+    {
+      return std::nullopt;
+    }
+
+    return tf_it->second.apply_inverse(position);
+  }
 };
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -37,22 +37,22 @@ struct NavParams
 class EasyFullControl::Implementation
 {
 public:
-  std::shared_ptr<const VehicleTraits> traits;
-  std::shared_ptr<const Graph> graph;
   std::shared_ptr<FleetUpdateHandle> fleet_handle;
   // Map robot name to its EasyCommandHandle
   std::unordered_map<std::string, EasyCommandHandlePtr> cmd_handles;
   // TODO(YV): Get these constants from EasyCommandHandle::Configuration
-  NavParams nav_params;
+  std::shared_ptr<NavParams> nav_params;
 
   static std::shared_ptr<EasyFullControl> make(
-    std::shared_ptr<const VehicleTraits> traits,
-    std::shared_ptr<const Graph> graph,
     std::shared_ptr<FleetUpdateHandle> fleet_handle)
   {
     auto handle = std::shared_ptr<EasyFullControl>(new EasyFullControl);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
-        Implementation{traits, graph, fleet_handle, {}});
+        Implementation{
+          fleet_handle,
+          {},
+          std::make_shared<NavParams>()
+        });
     return handle;
   }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -24,35 +24,6 @@ namespace agv {
 
 class EasyCommandHandle;
 using EasyCommandHandlePtr = std::shared_ptr<EasyCommandHandle>;
-using TransformDictionary = std::unordered_map<std::string, Transformation>;
-
-//==============================================================================
-struct NavParams
-{
-  bool skip_rotation_commands;
-  std::optional<TransformDictionary> transforms_to_robot_coords;
-  double max_merge_waypoint_distance = 0.3;
-  double max_merge_lane_distance = 0.1;
-  double min_lane_length = 1e-8;
-
-  std::optional<Eigen::Vector3d> to_rmf_coordinates(
-    const std::string& map,
-    Eigen::Vector3d position)
-  {
-    if (!transforms_to_robot_coords.has_value())
-    {
-      return position;
-    }
-
-    const auto tf_it = transforms_to_robot_coords->find(map);
-    if (tf_it == transforms_to_robot_coords->end())
-    {
-      return std::nullopt;
-    }
-
-    return tf_it->second.apply_inverse(position);
-  }
-};
 
 //==============================================================================
 class EasyFullControl::Implementation

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -582,16 +582,6 @@ public:
   /// invalid if one of the assignments has already begun execution.
   bool is_valid_assignments(Assignments& assignments) const;
 
-  static Implementation& get(FleetUpdateHandle& fleet)
-  {
-    return *fleet._pimpl;
-  }
-
-  static const Implementation& get(const FleetUpdateHandle& fleet)
-  {
-    return *fleet._pimpl;
-  }
-
   void publish_fleet_state_topic() const;
 
   void publish_lane_states() const;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -539,6 +539,16 @@ public:
     return handle;
   }
 
+  static Implementation& get(FleetUpdateHandle& handle)
+  {
+    return *handle._pimpl;
+  }
+
+  static const Implementation& get(const FleetUpdateHandle& handle)
+  {
+    return *handle._pimpl;
+  }
+
   void publish_nav_graph() const;
 
   void dock_summary_cb(const DockSummary::SharedPtr& msg);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -95,6 +95,11 @@ public:
   {
     return *self._pimpl;
   }
+
+  static const Implementation& get(const ActivityIdentifier& self)
+  {
+    return *self._pimpl;
+  }
 };
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -30,6 +30,60 @@
 namespace rmf_fleet_adapter {
 namespace agv {
 
+class TriggerOnce {
+public:
+  TriggerOnce(std::function<void()> callback)
+    : _callback(std::make_shared(std::make_shared(std::move(callback))))
+  {
+    // Do nothing
+  }
+
+  void trigger() const
+  {
+    if (!_callback)
+    {
+      return;
+    }
+
+    // We don't use a mutex because we assume this will always be triggered
+    // inside the shared worker.
+    std::shared_ptr<std::function<void()>> inner = *_callback;
+    if (inner)
+    {
+      if (*inner)
+      {
+        (*inner)();
+      }
+
+      *inner = nullptr;
+    }
+  }
+
+private:
+  std::shared_ptr<std::shared_ptr<std::function<void()>>> _callback;
+};
+
+using LocationUpdateFn = std::function<void(
+  const std::string& map,
+  Eigen::Vector3d location)>;
+
+//==============================================================================
+class ActivityIdentifier::Implementation
+{
+public:
+  /// A function that EasyFullControl will use to update the robot location info
+  /// when this activity is being executed.
+  LocationUpdateFn update_fn;
+
+  static std::shared_ptr<ActivityIdentifier> make(LocationUpdateFn update_fn_)
+  {
+    auto identifier = std::shared_ptr<ActivityIdentifier>(new ActivityIdentifier);
+    identifier->_pimpl = rmf_utils::make_unique_impl<Implementation>(
+      Implementation{update_fn_});
+    return identifier;
+  }
+};
+
 //==============================================================================
 class RobotUpdateHandle::ActionExecution::Implementation
 {
@@ -38,13 +92,12 @@ public:
   struct Data
   {
     rxcpp::schedulers::worker worker;
-    std::function<void()> finished;
+    TriggerOnce finished;
     std::shared_ptr<rmf_task::events::SimpleEventState> state;
     std::optional<rmf_traffic::Duration> remaining_time;
     bool request_replan;
     std::optional<std::shared_ptr<RobotUpdateHandle>> handle;
     bool okay;
-    // TODO: Consider adding a mutex to lock read/write
 
     Data(
       rxcpp::schedulers::worker worker_,
@@ -52,9 +105,9 @@ public:
       std::shared_ptr<rmf_task::events::SimpleEventState> state_,
       std::optional<rmf_traffic::Duration> remaining_time_ = std::nullopt,
       std::optional<std::shared_ptr<RobotUpdateHandle>> handle_ = std::nullopt)
+      : finished(std::move(finished_))
     {
       worker = std::move(worker_);
-      finished = std::move(finished_);
       state = std::move(state_);
       remaining_time = remaining_time_;
       request_replan = false;
@@ -64,8 +117,12 @@ public:
 
     ~Data()
     {
-      if (finished)
-        finished();
+      worker.schedule(
+        [finished = std::move(this->finished)](
+          const rxcpp::schedulers::schedulable&)
+        {
+          finished.trigger();
+        });
     }
   };
 
@@ -73,12 +130,16 @@ public:
   {
     ActionExecution execution;
     execution._pimpl = rmf_utils::make_impl<Implementation>(
-      Implementation{std::move(data)});
+      Implementation{
+        std::move(data)},
+        ActivityIdentifier::Implementation::make(nullptr)
+      });
 
     return execution;
   }
 
   std::shared_ptr<Data> data;
+  std::shared_ptr<const ActivityIdentifier> identifier;
 };
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -32,11 +32,12 @@
 namespace rmf_fleet_adapter {
 namespace agv {
 
-class TriggerOnce {
+class TriggerOnce
+{
 public:
   TriggerOnce(std::function<void()> callback)
-    : _callback(std::make_shared<std::shared_ptr<std::function<void()>>>(
-      std::make_shared<std::function<void()>>(std::move(callback))))
+  : _callback(std::make_shared<std::shared_ptr<std::function<void()>>>(
+        std::make_shared<std::function<void()>>(std::move(callback))))
   {
     // Do nothing
   }
@@ -109,8 +110,8 @@ struct ScheduleOverride
 
 //==============================================================================
 using LocationUpdateFn = std::function<void(
-  const std::string& map,
-  Eigen::Vector3d location)>;
+      const std::string& map,
+      Eigen::Vector3d location)>;
 
 //==============================================================================
 class RobotUpdateHandle::ActivityIdentifier::Implementation
@@ -122,7 +123,8 @@ public:
 
   static std::shared_ptr<ActivityIdentifier> make(LocationUpdateFn update_fn_)
   {
-    auto identifier = std::shared_ptr<ActivityIdentifier>(new ActivityIdentifier);
+    auto identifier =
+      std::shared_ptr<ActivityIdentifier>(new ActivityIdentifier);
     identifier->_pimpl = rmf_utils::make_unique_impl<Implementation>(
       Implementation{update_fn_});
     return identifier;
@@ -214,12 +216,12 @@ public:
       std::function<void()> finished_,
       std::shared_ptr<rmf_task::events::SimpleEventState> state_,
       std::optional<rmf_traffic::Duration> remaining_time_ = std::nullopt)
-      : w_context(context_),
-        finished(std::move(finished_)),
-        state(std::move(state_)),
-        remaining_time(remaining_time_),
-        request_replan(false),
-        okay(true)
+    : w_context(context_),
+      finished(std::move(finished_)),
+      state(std::move(state_)),
+      remaining_time(remaining_time_),
+      request_replan(false),
+      okay(true)
     {
       // Do nothing
     }
@@ -242,9 +244,9 @@ public:
     auto update_fn = [data](
       const std::string& map,
       Eigen::Vector3d location)
-    {
-      data->update_location(map, location);
-    };
+      {
+        data->update_location(map, location);
+      };
 
     ActionExecution execution;
     execution._pimpl = rmf_utils::make_impl<Implementation>(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
@@ -188,7 +188,8 @@ auto GoToPlace::Active::make(
     active->_context->observe_graph_change()
     .observe_on(rxcpp::identity_same_worker(active->_context->worker()))
     .subscribe(
-    [w = active->weak_from_this()](const agv::RobotContext::GraphChange& changes)
+    [w = active->weak_from_this()](
+      const agv::RobotContext::GraphChange& changes)
     {
       const auto self = w.lock();
       if (!self)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
@@ -111,6 +111,12 @@ auto GoToPlace::Standby::begin(
 {
   if (!_active)
   {
+    RCLCPP_INFO(
+      _context->node()->get_logger(),
+      "Beginning a new go_to_place [%lu] for robot [%s]",
+      _goal.waypoint(),
+      _context->requester_id().c_str());
+
     _active = Active::make(
       _assign_id,
       _context,
@@ -194,6 +200,10 @@ auto GoToPlace::Active::make(
       {
         // If we're currently replanning, we should restart the replanning
         // because the upcoming solution might involve a closed lane
+        RCLCPP_INFO(
+          self->_context->node()->get_logger(),
+          "Requesting replan for [%s] to account for a newly closed lane",
+          self->_context->requester_id().c_str());
         self->_context->request_replan();
         return;
       }
@@ -214,6 +224,10 @@ auto GoToPlace::Active::make(
             {
               // The current plan is using (or did use) a lane which has closed,
               // so let's replan.
+              RCLCPP_INFO(
+                self->_context->node()->get_logger(),
+                "Requesting replan for [%s] to avoid a newly closed lane",
+                self->_context->requester_id().c_str());
               self->_context->request_replan();
               return;
             }
@@ -224,6 +238,10 @@ auto GoToPlace::Active::make(
       {
         // Strange that there isn't an execution and also isn't a
         // _find_path_service, but let's just request a replan.
+        RCLCPP_INFO(
+          self->_context->node()->get_logger(),
+          "Requesting replan for [%s] to account for a newly closed lane (v2)",
+          self->_context->requester_id().c_str());
         self->_context->request_replan();
       }
     });
@@ -302,6 +320,11 @@ auto GoToPlace::Active::interrupt(std::function<void()> task_is_interrupted)
 //==============================================================================
 void GoToPlace::Active::cancel()
 {
+  RCLCPP_INFO(
+    _context->node()->get_logger(),
+    "Canceling go_to_place [%lu] for robot [%s]",
+    _goal.waypoint(),
+    _context->requester_id().c_str());
   _stop_and_clear();
   _state->update_status(Status::Canceled);
   _state->update_log().info("Received signal to cancel");
@@ -476,6 +499,12 @@ void GoToPlace::Active::_execute_plan(
     _finished();
     return;
   }
+
+  RCLCPP_INFO(
+    _context->node()->get_logger(),
+    "Executing go_to_place [%lu] for robot [%s]",
+    _goal.waypoint(),
+    _context->requester_id().c_str());
 
   _execution = ExecutePlan::make(
     _context, plan_id, std::move(plan), std::move(full_itinerary),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.hpp
@@ -139,6 +139,7 @@ public:
     rclcpp::TimerBase::SharedPtr _retry_timer;
 
     rmf_rxcpp::subscription_guard _replan_request_subscription;
+    rmf_rxcpp::subscription_guard _graph_change_subscription;
 
     bool _is_interrupted = false;
   };

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/PerformAction.cpp
@@ -260,7 +260,7 @@ void PerformAction::Active::_execute_action()
     };
 
   auto data = std::make_shared<ExecutionData>(
-    _context->worker(), std::move(finished), _state, std::nullopt);
+    _context, std::move(finished), _state, std::nullopt);
   _execution_data = data;
 
   auto action_execution =

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ResponsiveWait.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ResponsiveWait.cpp
@@ -242,6 +242,10 @@ auto ResponsiveWait::Active::interrupt(
 //==============================================================================
 void ResponsiveWait::Active::cancel()
 {
+  RCLCPP_INFO(
+    _context->node()->get_logger(),
+    "Canceling responsive wait for [%s]",
+    _context->requester_id().c_str());
   _state->update_status(Status::Canceled);
   _state->update_log().info("Received signal to cancel");
   _cancelled = true;
@@ -269,8 +273,10 @@ ResponsiveWait::Active::Active(Description description)
 //==============================================================================
 void ResponsiveWait::Active::_next_cycle()
 {
+  std::cout << "NEXT CYCLE " << _context->requester_id() << std::endl;
   if (_cancelled)
   {
+    std::cout << "FINISHED " << _context->requester_id() << std::endl;
     _finished();
     return;
   }
@@ -287,6 +293,11 @@ void ResponsiveWait::Active::_next_cycle()
     return;
   }
 
+  RCLCPP_INFO(
+    _context->node()->get_logger(),
+    "Beginning next responsive wait cycle for [%s] and waypoint %lu",
+    _context->requester_id().c_str(),
+    _description.waiting_point);
   _begin_movement();
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ResponsiveWait.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ResponsiveWait.cpp
@@ -273,10 +273,8 @@ ResponsiveWait::Active::Active(Description description)
 //==============================================================================
 void ResponsiveWait::Active::_next_cycle()
 {
-  std::cout << "NEXT CYCLE " << _context->requester_id() << std::endl;
   if (_cancelled)
   {
-    std::cout << "FINISHED " << _context->requester_id() << std::endl;
     _finished();
     return;
   }
@@ -293,7 +291,7 @@ void ResponsiveWait::Active::_next_cycle()
     return;
   }
 
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     _context->node()->get_logger(),
     "Beginning next responsive wait cycle for [%s] and waypoint %lu",
     _context->requester_id().c_str(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/WaitForTraffic.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/WaitForTraffic.cpp
@@ -212,27 +212,7 @@ void WaitForTraffic::Active::_consider_going()
   bool all_dependencies_reached = true;
   for (const auto& dep : _dependencies)
   {
-    if (dep.deprecated())
-    {
-      const auto other =
-        _context->schedule()->snapshot()
-        ->get_participant(dep.dependency().on_participant);
-      if (!other)
-      {
-        _state->update_log().info(
-          "Replanning because a traffic dependency was dropped from the "
-          "schedule");
-      }
-      else
-      {
-        _state->update_log().info(
-          "Replanning because [robot:" + other->name() + "] changed its plan");
-      }
-
-      return _replan();
-    }
-
-    if (!dep.reached())
+    if (!dep.reached() && !dep.deprecated())
       all_dependencies_reached = false;
   }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
@@ -259,7 +259,7 @@ void MoveRobot::Action::operator()(const Subscriber& s)
             plan_id, new_cumulative_delay, 100ms);
 
           const auto& itin = context->itinerary().itinerary();
-          for (std::size_t i=0; i < itin.size(); ++i)
+          for (std::size_t i = 0; i < itin.size(); ++i)
           {
             const auto& traj = itin[i].trajectory();
             const auto t_it = traj.find(now);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
@@ -157,6 +157,11 @@ void MoveRobot::Action::operator()(const Subscriber& s)
       // The RobotCommandHandle seems to have frozen up. Perhaps a bug in the
       // user's code has caused the RobotCommandHandle to drop the command. We
       // will request a replan.
+      RCLCPP_WARN(
+        self->_context->node()->get_logger(),
+        "Requesting replan for [%s] because its command handle seems to be "
+        "unresponsive",
+        self->_context->requester_id().c_str());
       self->_context->request_replan();
     });
 

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -299,6 +299,24 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def("error", &ActionExecution::error, py::arg("text"))
   .def("delayed", &ActionExecution::delayed, py::arg("text"))
   .def("blocked", &ActionExecution::blocked, py::arg("text"))
+  .def(
+    "override_schedule",
+    [&](
+      ActionExecution& self,
+      std::string map,
+      std::vector<Eigen::Vector3d> path,
+      double hold)
+    {
+      std::cout << "CALLING OVERRIDE_SCHEDULE BINDING: "
+        << map << ": " << path.size() << " | " << hold << std::endl;
+      return self.override_schedule(
+        map,
+        path,
+        rmf_traffic::time::from_seconds(hold));
+    },
+    py::arg("map"),
+    py::arg("path"),
+    py::arg("hold") = 0.0)
   .def("finished", &ActionExecution::finished)
   .def("okay", &ActionExecution::okay)
   .def_property_readonly("identifier", &ActionExecution::identifier);
@@ -777,7 +795,22 @@ PYBIND11_MODULE(rmf_adapter, m) {
   py::class_<agv::EasyFullControl::CommandExecution>(m_easy_full_control, "CommandExecution")
   .def("finished", &agv::EasyFullControl::CommandExecution::finished)
   .def("okay", &agv::EasyFullControl::CommandExecution::okay)
-  .def("override_schedule", &agv::EasyFullControl::CommandExecution::override_schedule)
+  .def(
+    "override_schedule",
+    [](
+      ActionExecution& self,
+      std::string map,
+      std::vector<Eigen::Vector3d> path,
+      double hold)
+    {
+      return self.override_schedule(
+        std::move(map),
+        std::move(path),
+        rmf_traffic::time::from_seconds(hold));
+    },
+    py::arg("map"),
+    py::arg("path"),
+    py::arg("hold") = 0.0)
   .def_property_readonly("identifier", &agv::EasyFullControl::CommandExecution::identifier);
 
   py::class_<agv::EasyFullControl::Destination>(m_easy_full_control, "Destination")

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -334,6 +334,9 @@ PYBIND11_MODULE(rmf_adapter, m) {
   py::class_<agv::FleetUpdateHandle,
     std::shared_ptr<agv::FleetUpdateHandle>>(
     m, "FleetUpdateHandle")
+  .def_property_readonly(
+    "fleet_name",
+    &agv::FleetUpdateHandle::fleet_name)
   // NOTE(CH3): Might have to publicise this constructor if required
   // Otherwise, it's constructable via agv::TestScenario
   // .def(py::init<>())  // Private constructor!

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -726,7 +726,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def("override_schedule", &agv::EasyFullControl::CommandExecution::override_schedule)
   .def_property_readonly("identifier", &agv::EasyFullControl::CommandExecution::identifier);
 
-  py::class_<agv::EasyFullControl::Configuration>(m_easy_full_control, "Configuration")
+  py::class_<agv::EasyFullControl::FleetConfiguration>(m_easy_full_control, "FleetConfiguration")
   .def(py::init([]( // Lambda function to convert reference to shared ptr
         std::string& fleet_name,
         std::optional<std::unordered_map<std::string, agv::Transformation>> transformations_to_robot_coordinates,
@@ -762,7 +762,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
           {
             finishing_request = nullptr;
           }
-          return agv::EasyFullControl::Configuration(
+          return agv::EasyFullControl::FleetConfiguration(
               fleet_name,
               std::move(transformations_to_robot_coordinates),
               std::make_shared<rmf_traffic::agv::VehicleTraits>(traits),
@@ -801,76 +801,76 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("server_uri") = std::nullopt,
     py::arg("max_delay") = rmf_traffic::time::from_seconds(10.0),
     py::arg("update_interval") = rmf_traffic::time::from_seconds(0.5))
-  .def_static("from_config_files", &agv::EasyFullControl::Configuration::from_config_files,
+  .def_static("from_config_files", &agv::EasyFullControl::FleetConfiguration::from_config_files,
     py::arg("config_file"),
     py::arg("nav_graph_path"),
     py::arg("server_uri"))
   .def_property(
     "fleet_name",
-    &agv::EasyFullControl::Configuration::fleet_name,
-    &agv::EasyFullControl::Configuration::set_fleet_name)
+    &agv::EasyFullControl::FleetConfiguration::fleet_name,
+    &agv::EasyFullControl::FleetConfiguration::set_fleet_name)
   .def_property(
     "vehicle_traits",
-    &agv::EasyFullControl::Configuration::vehicle_traits,
-    &agv::EasyFullControl::Configuration::set_vehicle_traits)
+    &agv::EasyFullControl::FleetConfiguration::vehicle_traits,
+    &agv::EasyFullControl::FleetConfiguration::set_vehicle_traits)
   .def_property_readonly(
     "transformations_to_robot_coordinates",
-    &agv::EasyFullControl::Configuration::transformations_to_robot_coordinates)
+    &agv::EasyFullControl::FleetConfiguration::transformations_to_robot_coordinates)
   .def(
     "add_robot_coordinates_transformation",
-    &agv::EasyFullControl::Configuration::add_robot_coordinate_transformation)
+    &agv::EasyFullControl::FleetConfiguration::add_robot_coordinate_transformation)
   .def_property(
     "graph",
-    &agv::EasyFullControl::Configuration::graph,
-    &agv::EasyFullControl::Configuration::set_graph)
+    &agv::EasyFullControl::FleetConfiguration::graph,
+    &agv::EasyFullControl::FleetConfiguration::set_graph)
   .def_property(
     "battery_system",
-    &agv::EasyFullControl::Configuration::battery_system,
-    &agv::EasyFullControl::Configuration::set_battery_system)
+    &agv::EasyFullControl::FleetConfiguration::battery_system,
+    &agv::EasyFullControl::FleetConfiguration::set_battery_system)
   .def_property(
     "motion_sink",
-    &agv::EasyFullControl::Configuration::motion_sink,
-    &agv::EasyFullControl::Configuration::set_motion_sink)
+    &agv::EasyFullControl::FleetConfiguration::motion_sink,
+    &agv::EasyFullControl::FleetConfiguration::set_motion_sink)
   .def_property(
     "ambient_sink",
-    &agv::EasyFullControl::Configuration::ambient_sink,
-    &agv::EasyFullControl::Configuration::set_ambient_sink)
+    &agv::EasyFullControl::FleetConfiguration::ambient_sink,
+    &agv::EasyFullControl::FleetConfiguration::set_ambient_sink)
   .def_property(
     "tool_sink",
-    &agv::EasyFullControl::Configuration::tool_sink,
-    &agv::EasyFullControl::Configuration::set_tool_sink)
+    &agv::EasyFullControl::FleetConfiguration::tool_sink,
+    &agv::EasyFullControl::FleetConfiguration::set_tool_sink)
   .def_property(
     "recharge_threshold",
-    &agv::EasyFullControl::Configuration::recharge_threshold,
-    &agv::EasyFullControl::Configuration::set_recharge_threshold)
+    &agv::EasyFullControl::FleetConfiguration::recharge_threshold,
+    &agv::EasyFullControl::FleetConfiguration::set_recharge_threshold)
   .def_property(
     "recharge_soc",
-    &agv::EasyFullControl::Configuration::recharge_soc,
-    &agv::EasyFullControl::Configuration::set_recharge_soc)
+    &agv::EasyFullControl::FleetConfiguration::recharge_soc,
+    &agv::EasyFullControl::FleetConfiguration::set_recharge_soc)
   .def_property(
     "account_for_battery_drain",
-    &agv::EasyFullControl::Configuration::account_for_battery_drain,
-    &agv::EasyFullControl::Configuration::set_account_for_battery_drain)
+    &agv::EasyFullControl::FleetConfiguration::account_for_battery_drain,
+    &agv::EasyFullControl::FleetConfiguration::set_account_for_battery_drain)
   .def_property(
     "finishing_request",
-    &agv::EasyFullControl::Configuration::finishing_request,
-    &agv::EasyFullControl::Configuration::set_finishing_request)
+    &agv::EasyFullControl::FleetConfiguration::finishing_request,
+    &agv::EasyFullControl::FleetConfiguration::set_finishing_request)
   .def_property(
     "skip_rotation_commands",
-    &agv::EasyFullControl::Configuration::skip_rotation_commands,
-    &agv::EasyFullControl::Configuration::set_skip_rotation_commands)
+    &agv::EasyFullControl::FleetConfiguration::skip_rotation_commands,
+    &agv::EasyFullControl::FleetConfiguration::set_skip_rotation_commands)
   .def_property(
     "server_uri",
-    &agv::EasyFullControl::Configuration::server_uri,
-    &agv::EasyFullControl::Configuration::set_server_uri)
+    &agv::EasyFullControl::FleetConfiguration::server_uri,
+    &agv::EasyFullControl::FleetConfiguration::set_server_uri)
   .def_property(
     "max_delay",
-    &agv::EasyFullControl::Configuration::max_delay,
-    &agv::EasyFullControl::Configuration::set_max_delay)
+    &agv::EasyFullControl::FleetConfiguration::max_delay,
+    &agv::EasyFullControl::FleetConfiguration::set_max_delay)
   .def_property(
     "update_interval",
-    &agv::EasyFullControl::Configuration::update_interval,
-    &agv::EasyFullControl::Configuration::set_update_interval);
+    &agv::EasyFullControl::FleetConfiguration::update_interval,
+    &agv::EasyFullControl::FleetConfiguration::set_update_interval);
 
   // EASY FULL CONTROL RobotState ===============================================
   py::class_<agv::EasyFullControl::InitializeRobot>(m_easy_full_control, "InitializeRobot")

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -840,7 +840,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
         bool skip_rotation_commands,
         std::optional<std::string> server_uri,
         rmf_traffic::Duration max_delay,
-        rmf_traffic::Duration update_interval)
+        rmf_traffic::Duration update_interval,
+        bool default_responsive_wait)
         {
           rmf_task::ConstRequestFactoryPtr finishing_request;
           if (finishing_request_string == "charge")
@@ -876,7 +877,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
               skip_rotation_commands,
               server_uri,
               max_delay,
-              update_interval);
+              update_interval,
+              default_responsive_wait);
         }
         ),
     py::arg("fleet_name"),
@@ -897,7 +899,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("skip_rotation_commands") = true,
     py::arg("server_uri") = std::nullopt,
     py::arg("max_delay") = rmf_traffic::time::from_seconds(10.0),
-    py::arg("update_interval") = rmf_traffic::time::from_seconds(0.5))
+    py::arg("update_interval") = rmf_traffic::time::from_seconds(0.5),
+    py::arg("default_responsive_wait") = false)
   .def_static("from_config_files", &agv::EasyFullControl::FleetConfiguration::from_config_files,
     py::arg("config_file"),
     py::arg("nav_graph_path"),
@@ -979,7 +982,11 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property(
     "update_interval",
     &agv::EasyFullControl::FleetConfiguration::update_interval,
-    &agv::EasyFullControl::FleetConfiguration::set_update_interval);
+    &agv::EasyFullControl::FleetConfiguration::set_update_interval)
+  .def_property(
+    "default_responsive_wait",
+    &agv::EasyFullControl::FleetConfiguration::default_responsive_wait,
+    &agv::EasyFullControl::FleetConfiguration::set_default_responsive_wait);
 
   // Transformation =============================================================
   py::class_<agv::Transformation>(m, "Transformation")

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -55,6 +55,7 @@ std::unordered_map<std::string, ConsiderRequest> convert(
   }
 }
 
+using ActivityIdentifier = agv::RobotUpdateHandle::ActivityIdentifier;
 using ActionExecution = agv::RobotUpdateHandle::ActionExecution;
 using RobotInterruption = agv::RobotUpdateHandle::Interruption;
 using IssueTicket = agv::RobotUpdateHandle::IssueTicket;
@@ -281,6 +282,13 @@ PYBIND11_MODULE(rmf_adapter, m) {
 
   // ACTION EXECUTOR   =======================================================
   auto m_robot_update_handle = m.def_submodule("robot_update_handle");
+
+  py::class_<ActivityIdentifier>(
+    m_robot_update_handle, "ActivityIdentifier")
+  .def("is_same", [](ActivityIdentifier& lhs, ActivityIdentifier& rhs)
+    {
+      return lhs == rhs;
+    });
 
   py::class_<ActionExecution>(
     m_robot_update_handle, "ActionExecution")
@@ -772,7 +780,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property_readonly("xy", &agv::EasyFullControl::Destination::xy)
   .def_property_readonly("yaw", &agv::EasyFullControl::Destination::yaw)
   .def_property_readonly("graph_index", &agv::EasyFullControl::Destination::graph_index)
-  .def_property_readonly("dock", &agv::EasyFullControl::Destination::dock);
+  .def_property_readonly("dock", &agv::EasyFullControl::Destination::dock)
+  .def_property_readonly("speed_limit", &agv::EasyFullControl::Destination::speed_limit);
 
   py::class_<agv::EasyFullControl::FleetConfiguration>(m_easy_full_control, "FleetConfiguration")
   .def(py::init([]( // Lambda function to convert reference to shared ptr
@@ -873,6 +882,9 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property_readonly(
     "known_robot_configurations",
     &agv::EasyFullControl::FleetConfiguration::known_robot_configurations)
+  .def_property_readonly(
+    "known_robots",
+    &agv::EasyFullControl::FleetConfiguration::known_robots)
   .def(
     "add_known_robot_configuration",
     &agv::EasyFullControl::FleetConfiguration::add_known_robot_configuration)

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -307,8 +307,6 @@ PYBIND11_MODULE(rmf_adapter, m) {
       std::vector<Eigen::Vector3d> path,
       double hold)
     {
-      std::cout << "CALLING OVERRIDE_SCHEDULE BINDING: "
-        << map << ": " << path.size() << " | " << hold << std::endl;
       return self.override_schedule(
         map,
         path,

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -283,7 +283,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
   // ACTION EXECUTOR   =======================================================
   auto m_robot_update_handle = m.def_submodule("robot_update_handle");
 
-  py::class_<ActivityIdentifier>(
+  py::class_<ActivityIdentifier, std::shared_ptr<ActivityIdentifier>>(
     m_robot_update_handle, "ActivityIdentifier")
   .def("is_same", [](ActivityIdentifier& lhs, ActivityIdentifier& rhs)
     {
@@ -717,7 +717,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
 
   auto m_easy_full_control = m.def_submodule("easy_full_control");
 
-  py::class_<agv::EasyFullControl::EasyRobotUpdateHandle>(m_easy_full_control, "EasyRobotUpdateHandle")
+  py::class_<
+    agv::EasyFullControl::EasyRobotUpdateHandle,
+    std::shared_ptr<agv::EasyFullControl::EasyRobotUpdateHandle>
+  >(m_easy_full_control, "EasyRobotUpdateHandle")
   .def("update", &agv::EasyFullControl::EasyRobotUpdateHandle::update)
   .def("more", [](agv::EasyFullControl::EasyRobotUpdateHandle& self)
     {
@@ -867,7 +870,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_static("from_config_files", &agv::EasyFullControl::FleetConfiguration::from_config_files,
     py::arg("config_file"),
     py::arg("nav_graph_path"),
-    py::arg("server_uri"))
+    py::arg("server_uri") = std::nullopt)
   .def_property(
     "fleet_name",
     &agv::EasyFullControl::FleetConfiguration::fleet_name,

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -738,6 +738,12 @@ PYBIND11_MODULE(rmf_adapter, m) {
     std::shared_ptr<agv::EasyFullControl::EasyRobotUpdateHandle>
   >(m_easy_full_control, "EasyRobotUpdateHandle")
   .def("update", &agv::EasyFullControl::EasyRobotUpdateHandle::update)
+  .def("max_merge_waypoint_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::max_merge_waypoint_distance)
+  .def("set_max_merge_waypoint_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::set_max_merge_waypoint_distance)
+  .def("max_merge_lane_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::max_merge_lane_distance)
+  .def("set_max_merge_lane_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::set_max_merge_lane_distance)
+  .def("min_lane_length", &agv::EasyFullControl::EasyRobotUpdateHandle::min_lane_length)
+  .def("set_min_lane_length", &agv::EasyFullControl::EasyRobotUpdateHandle::set_min_lane_length)
   .def("more", [](agv::EasyFullControl::EasyRobotUpdateHandle& self)
     {
       return self.more();
@@ -766,7 +772,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
 
   py::class_<agv::EasyFullControl::RobotConfiguration>(m_easy_full_control, "RobotConfiguration")
   .def(py::init<std::vector<std::string>>(),
-    py::arg("comaptible_chargers"))
+    py::arg("compatible_chargers"))
   .def_property(
     "compatible_chargers",
     &agv::EasyFullControl::RobotConfiguration::compatible_chargers,
@@ -841,7 +847,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
         std::optional<std::string> server_uri,
         rmf_traffic::Duration max_delay,
         rmf_traffic::Duration update_interval,
-        bool default_responsive_wait)
+        bool default_responsive_wait,
+        double default_max_merge_waypoint_distance,
+        double default_max_merge_lane_distance,
+        double default_min_lane_length)
         {
           rmf_task::ConstRequestFactoryPtr finishing_request;
           if (finishing_request_string == "charge")
@@ -878,7 +887,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
               server_uri,
               max_delay,
               update_interval,
-              default_responsive_wait);
+              default_responsive_wait,
+              default_max_merge_waypoint_distance,
+              default_max_merge_lane_distance,
+              default_min_lane_length);
         }
         ),
     py::arg("fleet_name"),
@@ -900,7 +912,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("server_uri") = std::nullopt,
     py::arg("max_delay") = rmf_traffic::time::from_seconds(10.0),
     py::arg("update_interval") = rmf_traffic::time::from_seconds(0.5),
-    py::arg("default_responsive_wait") = false)
+    py::arg("default_responsive_wait") = false,
+    py::arg("default_max_merge_waypoint_distance") = 1e-3,
+    py::arg("default_max_merge_lane_distance") = 0.3,
+    py::arg("default_min_lane_length") = 1e-8)
   .def_static("from_config_files", &agv::EasyFullControl::FleetConfiguration::from_config_files,
     py::arg("config_file"),
     py::arg("nav_graph_path"),
@@ -986,7 +1001,19 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property(
     "default_responsive_wait",
     &agv::EasyFullControl::FleetConfiguration::default_responsive_wait,
-    &agv::EasyFullControl::FleetConfiguration::set_default_responsive_wait);
+    &agv::EasyFullControl::FleetConfiguration::set_default_responsive_wait)
+  .def_property(
+    "default_max_merge_waypoint_distance",
+    &agv::EasyFullControl::FleetConfiguration::default_max_merge_waypoint_distance,
+    &agv::EasyFullControl::FleetConfiguration::set_default_max_merge_waypoint_distance)
+  .def_property(
+    "default_max_merge_lane_distance",
+    &agv::EasyFullControl::FleetConfiguration::default_max_merge_lane_distance,
+    &agv::EasyFullControl::FleetConfiguration::set_default_max_merge_lane_distance)
+  .def_property(
+    "default_min_lane_length",
+    &agv::EasyFullControl::FleetConfiguration::default_min_lane_length,
+    &agv::EasyFullControl::FleetConfiguration::set_default_min_lane_length);
 
   // Transformation =============================================================
   py::class_<agv::Transformation>(m, "Transformation")

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Negotiation.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Negotiation.cpp
@@ -934,14 +934,13 @@ public:
     const Version conflict_version,
     const Negotiation::Table& table)
   {
-    Proposal msg;
-    msg.conflict_version = conflict_version;
-    msg.proposal_version = table.version();
-
-    assert(table.submission());
-    msg.itinerary = convert(*table.submission());
-    msg.for_participant = table.participant();
-    msg.to_accommodate = convert(table.sequence());
+    Proposal msg = rmf_traffic_msgs::build<Proposal>()
+      .conflict_version(conflict_version)
+      .proposal_version(table.version())
+      .for_participant(table.participant())
+      .to_accommodate(convert(table.sequence()))
+      .plan_id(table.proposal().back().plan)
+      .itinerary(convert(*table.submission()));
 
     // Make sure to pop the back off of msg.to_accommodate, because we don't
     // want to include this table's final sequence key. That final key is


### PR DESCRIPTION
This PR significantly revises the implementation of the `EasyFullControl` API by making it reactive instead of running in a thread. It also tweaks the API itself in a way that I believe is much simpler for system integrators, especially for users of the Python bindings. I've also revised the API to be future-proof by using more PIMPL classes instead of basic data types.

In the process of testing this new API, I encountered pre-existing several bugs that had been reported before but were difficult to reproduce. This PR includes fixes for the following issues:
* https://github.com/open-rmf/rmf/issues/373
* https://github.com/open-rmf/rmf/issues/356
* Crashing if a task auction happens while a robot is far from its navigation graph

I'm creating this as a separate PR that targets #235 so that reviewers can have a more clear idea of what changes are being introduced and why.

To test out this PR, it should be used in conjunction with https://github.com/open-rmf/rmf_demos/pull/188