### PR TITLE
Configurable merge distances

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -140,22 +140,32 @@ public:
     RobotState state,
     ConstActivityIdentifierPtr current_activity);
 
-  /// Modify selected RobotConfiguration parameters using these functions.
+  /// Get the maximum allowed merge waypoint distance for this robot.
+  double max_merge_waypoint_distance() const;
+
+  /// Modify the maximum allowed merge distance between the robot and a waypoint.
   ///
   /// \param[in] max_merge_waypoint_distance
-  ///   The maximum allowed merge distance between the robot and a waypoint.
-  void set_merge_distances(
-    std::optional<double> max_merge_waypoint_distance,
-    std::optional<double> max_merge_lane_distance,
-    std::optional<double> min_lane_length); 
+  ///   The maximum merge waypoint distance for this robot.
+  void set_max_merge_waypoint_distance(double distance);
+
+  /// Get the maximum allowed merge lane distance for this robot.
+  double max_merge_lane_distance() const;
+
+  /// Modify the maximum allowed merge distance between the robot and a lane.
   ///
-  // /// \param[in] max_merge_lane_distance
-  // ///   The maximum allowed merge distance between the robot and a lane.
-  // void set_max_merge_lane_distance(double distance);
-  // ///
-  // /// \param[in] min_lane_length
-  // ///   The minimum length of a lane.
-  // void set_min_lane_length(double distance);
+  /// \param[in] max_merge_lane_distance
+  ///   The maximum merge lane distance for this robot.
+  void set_max_merge_lane_distance(double distance);
+
+  /// Get the minimum lane length for this robot.
+  double min_lane_length() const;
+
+  /// Modify the minimum lane length for this robot.
+  ///
+  /// \param[in] min_lane_length
+  ///   The minimum length of a lane.
+  void set_min_lane_length(double length);
 
   /// Get more options for updating the robot's state
   std::shared_ptr<RobotUpdateHandle> more();

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -140,6 +140,23 @@ public:
     RobotState state,
     ConstActivityIdentifierPtr current_activity);
 
+  /// Modify selected RobotConfiguration parameters using these functions.
+  ///
+  /// \param[in] max_merge_waypoint_distance
+  ///   The maximum allowed merge distance between the robot and a waypoint.
+  void set_merge_distances(
+    std::optional<double> max_merge_waypoint_distance,
+    std::optional<double> max_merge_lane_distance,
+    std::optional<double> min_lane_length); 
+  ///
+  // /// \param[in] max_merge_lane_distance
+  // ///   The maximum allowed merge distance between the robot and a lane.
+  // void set_max_merge_lane_distance(double distance);
+  // ///
+  // /// \param[in] min_lane_length
+  // ///   The minimum length of a lane.
+  // void set_min_lane_length(double distance);
+
   /// Get more options for updating the robot's state
   std::shared_ptr<RobotUpdateHandle> more();
 
@@ -216,7 +233,10 @@ public:
   /// conflicts.
   RobotConfiguration(
     std::vector<std::string> compatible_chargers,
-    std::optional<bool> responsive_wait = std::nullopt);
+    std::optional<bool> responsive_wait = std::nullopt,
+    std::optional<double> max_merge_waypoint_distance = 1e-3,
+    std::optional<double> max_merge_lane_distance = 0.3,
+    std::optional<double> min_lane_length = 1e-8);
 
   /// List of chargers that this robot is compatible with
   const std::vector<std::string>& compatible_chargers() const;
@@ -236,6 +256,37 @@ public:
   /// Toggle responsive wait on (true), off (false), or use fleet default
   /// (std::nullopt).
   void set_responsive_wait(std::optional<bool> enable);
+
+  /// Get the maximum merge distance between a robot and a waypoint. This refers
+  /// to the maximum distance allowed to consider a robot to be on a particular
+  /// waypoint.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default merge waypoint
+  /// distance will be used.
+  std::optional<double> max_merge_waypoint_distance() const;
+
+  /// Set the maximum merge distance between a robot and a waypoint.
+  void set_max_merge_waypoint_distance(std::optional<double> distance);
+
+  /// Get the maximum merge distance between a robot and a lane. This refers
+  /// to the maximum distance allowed to consider a robot to be on a particular
+  /// lane.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default merge lane
+  /// distance will be used.
+  std::optional<double> max_merge_lane_distance() const;
+
+  /// Set the maximum merge distance between a robot and a lane.
+  void set_max_merge_lane_distance(std::optional<double> distance);
+
+  /// Get the minimum lane length.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default minimum lane length
+  /// will be used.
+  std::optional<double> min_lane_length() const;
+
+  /// Set the minimum lane length.
+  void set_min_lane_length(std::optional<double> distance);
 
   class Implementation;
 private:
@@ -450,6 +501,15 @@ public:
   /// \param[in] default_responsive_wait
   ///   Should the robots in this fleet have responsive wait enabled (true) or
   ///   disabled (false) by default?
+  ///
+  /// \param[in] default_max_merge_waypoint_distance
+  ///   The maximum merge distance between a robot position and a waypoint.
+  ///
+  /// \param[in] default_max_merge_lane_distance
+  ///   The maximum merge distance between a robot position and a lane.
+  ///
+  /// \param[in] default_min_lane_length
+  ///   The minimum length that a lane should have.
   FleetConfiguration(
     const std::string& fleet_name,
     std::optional<std::unordered_map<std::string, Transformation>> transformations_to_robot_coordinates,
@@ -471,7 +531,10 @@ public:
     rmf_traffic::Duration max_delay = rmf_traffic::time::from_seconds(10.0),
     rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(
       0.5),
-    bool default_responsive_wait = false
+    bool default_responsive_wait = false,
+    double default_max_merge_waypoint_distance = 1e-3,
+    double default_max_merge_lane_distance = 0.3,
+    double min_lane_length = 1e-8
   );
 
   /// Create a FleetConfiguration object using a set of configuration parameters
@@ -648,6 +711,24 @@ public:
   /// Set whether robots in this fleet should have responsive wait enabled by
   /// default.
   void set_default_responsive_wait(bool enable);
+
+  /// Get the maximum merge distance between a robot position and a waypoint.
+  double default_max_merge_waypoint_distance() const;
+
+  /// Set the maximum merge distance between a robot position and a waypoint.
+  void set_default_max_merge_waypoint_distance(double distance);
+
+  /// Get the maximum merge distance between a robot position and a lane.
+  double default_max_merge_lane_distance() const;
+
+  /// Set the maximum merge distance between a robot position and a lane.
+  void set_default_max_merge_lane_distance(double distance);
+
+  /// Get the minimum lane length allowed.
+  double default_min_lane_length() const;
+
+  /// Set the minimum lane length.
+  void set_default_min_lane_length(double distance);
 
   class Implementation;
 private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -59,7 +59,8 @@ public:
   using ActionExecutor = RobotUpdateHandle::ActionExecutor;
   using ActivityIdentifier = RobotUpdateHandle::ActivityIdentifier;
   using ActivityIdentifierPtr = RobotUpdateHandle::ActivityIdentifierPtr;
-  using ConstActivityIdentifierPtr = RobotUpdateHandle::ConstActivityIdentifierPtr;
+  using ConstActivityIdentifierPtr =
+    RobotUpdateHandle::ConstActivityIdentifierPtr;
   using Stubbornness = RobotUpdateHandle::Unstable::Stubbornness;
   using ConsiderRequest = FleetUpdateHandle::ConsiderRequest;
 
@@ -522,8 +523,10 @@ public:
   ///   The minimum length that a lane should have.
   FleetConfiguration(
     const std::string& fleet_name,
-    std::optional<std::unordered_map<std::string, Transformation>> transformations_to_robot_coordinates,
-    std::unordered_map<std::string, RobotConfiguration> known_robot_configurations,
+    std::optional<std::unordered_map<std::string, Transformation>>
+    transformations_to_robot_coordinates,
+    std::unordered_map<std::string, RobotConfiguration>
+    known_robot_configurations,
     std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
     std::shared_ptr<const rmf_traffic::agv::Graph> graph,
     rmf_battery::agv::ConstBatterySystemPtr battery_system,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -363,7 +363,8 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
   std::shared_ptr<TransformDictionary> tf_dict;
   if (config.transformations_to_robot_coordinates().has_value())
   {
-    tf_dict = std::make_shared<TransformDictionary>(*config.transformations_to_robot_coordinates());
+    tf_dict = std::make_shared<TransformDictionary>(
+      *config.transformations_to_robot_coordinates());
   }
 
   return EasyFullControl::Implementation::make(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -364,7 +364,10 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     fleet_handle,
     config.skip_rotation_commands(),
     config.transformations_to_robot_coordinates(),
-    config.default_responsive_wait());
+    config.default_responsive_wait(),
+    config.default_max_merge_waypoint_distance(),
+    config.default_max_merge_lane_distance(),
+    config.default_min_lane_length());
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -360,10 +360,16 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     "Finished configuring Easy Full Control adapter for fleet [%s]",
     config.fleet_name().c_str());
 
+  std::shared_ptr<TransformDictionary> tf_dict;
+  if (config.transformations_to_robot_coordinates().has_value())
+  {
+    tf_dict = std::make_shared<TransformDictionary>(*config.transformations_to_robot_coordinates());
+  }
+
   return EasyFullControl::Implementation::make(
     fleet_handle,
     config.skip_rotation_commands(),
-    config.transformations_to_robot_coordinates(),
+    tf_dict,
     config.default_responsive_wait(),
     config.default_max_merge_waypoint_distance(),
     config.default_max_merge_lane_distance(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -68,10 +68,10 @@ EasyFullControl::RobotState::RobotState(
   Eigen::Vector3d position,
   double battery_soc)
 : _pimpl(rmf_utils::make_impl<Implementation>(Implementation{
-    std::move(map_name),
-    position,
-    battery_soc
-  }))
+      std::move(map_name),
+      position,
+      battery_soc
+    }))
 {
   // Do nothing
 }
@@ -131,12 +131,12 @@ EasyFullControl::RobotConfiguration::RobotConfiguration(
   std::optional<double> max_merge_lane_distance,
   std::optional<double> min_lane_length)
 : _pimpl(rmf_utils::make_impl<Implementation>(Implementation{
-    std::move(compatible_chargers),
-    responsive_wait,
-    max_merge_waypoint_distance,
-    max_merge_lane_distance,
-    min_lane_length
-  }))
+      std::move(compatible_chargers),
+      responsive_wait,
+      max_merge_waypoint_distance,
+      max_merge_lane_distance,
+      min_lane_length
+    }))
 {
   // Do nothing
 }
@@ -169,7 +169,8 @@ void EasyFullControl::RobotConfiguration::set_responsive_wait(
 }
 
 //==============================================================================
-std::optional<double> EasyFullControl::RobotConfiguration::max_merge_waypoint_distance() const
+std::optional<double> EasyFullControl::RobotConfiguration::
+max_merge_waypoint_distance() const
 {
   return _pimpl->max_merge_waypoint_distance;
 }
@@ -182,7 +183,8 @@ void EasyFullControl::RobotConfiguration::set_max_merge_waypoint_distance(
 }
 
 //==============================================================================
-std::optional<double> EasyFullControl::RobotConfiguration::max_merge_lane_distance() const
+std::optional<double> EasyFullControl::RobotConfiguration::
+max_merge_lane_distance() const
 {
   return _pimpl->max_merge_lane_distance;
 }
@@ -195,7 +197,8 @@ void EasyFullControl::RobotConfiguration::set_max_merge_lane_distance(
 }
 
 //==============================================================================
-std::optional<double> EasyFullControl::RobotConfiguration::min_lane_length() const
+std::optional<double> EasyFullControl::RobotConfiguration::min_lane_length()
+const
 {
   return _pimpl->min_lane_length;
 }
@@ -222,10 +225,10 @@ EasyFullControl::RobotCallbacks::RobotCallbacks(
   StopRequest stop,
   ActionExecutor action_executor)
 : _pimpl(rmf_utils::make_impl<Implementation>(Implementation{
-    std::move(navigate),
-    std::move(stop),
-    std::move(action_executor)
-  }))
+      std::move(navigate),
+      std::move(stop),
+      std::move(action_executor)
+    }))
 {
   // Do nothing
 }
@@ -382,8 +385,10 @@ public:
           }
 
           const auto& lane = graph.get_lane(lane_id);
-          const auto p0 = graph.get_waypoint(lane.entry().waypoint_index()).get_location();
-          const auto p1 = graph.get_waypoint(lane.exit().waypoint_index()).get_location();
+          const auto p0 =
+            graph.get_waypoint(lane.entry().waypoint_index()).get_location();
+          const auto p1 =
+            graph.get_waypoint(lane.exit().waypoint_index()).get_location();
           const auto lane_length = (p1 - p0).norm();
           const auto lane_u = (p1 - p0)/lane_length;
           const auto proj = (p - p0).dot(lane_u);
@@ -434,12 +439,14 @@ public:
 
       if (!waypoints.empty())
       {
-        const auto p_final = graph.get_waypoint(waypoints.back()).get_location();
+        const auto p_final =
+          graph.get_waypoint(waypoints.back()).get_location();
         const auto distance = (p_final - p).norm();
         double rotation = 0.0;
         if (final_orientation.has_value())
         {
-          rotation = std::fabs(rmf_utils::wrap_to_pi(location[2] - *final_orientation));
+          rotation =
+            std::fabs(rmf_utils::wrap_to_pi(location[2] - *final_orientation));
           const auto reversible =
             planner->get_configuration().vehicle_traits()
             .get_differential()->is_reversible();
@@ -456,9 +463,11 @@ public:
 
         const auto& traits = planner->get_configuration().vehicle_traits();
         const auto v = std::max(traits.linear().get_nominal_velocity(), 0.001);
-        const auto w = std::max(traits.rotational().get_nominal_velocity(), 0.001);
+        const auto w =
+          std::max(traits.rotational().get_nominal_velocity(), 0.001);
         const auto t = distance / v + rotation / w;
-        arrival_estimator(rmf_traffic::time::from_seconds(t) + planned_wait_time);
+        arrival_estimator(
+          rmf_traffic::time::from_seconds(t) + planned_wait_time);
       }
     }
   };
@@ -489,7 +498,8 @@ public:
           }
 
           // Prevent this activity from doing any further updates
-          ActivityIdentifier::Implementation::get(*identifier).update_fn = nullptr;
+          ActivityIdentifier::Implementation::get(
+            *identifier).update_fn = nullptr;
           if (data->schedule_override.has_value())
           {
             data->release_stubbornness();
@@ -549,8 +559,8 @@ public:
   {
     auto data = std::make_shared<Data>(data_);
     auto update_fn = [w_context = context->weak_from_this(), data](
-        const std::string& map,
-        Eigen::Vector3d location)
+      const std::string& map,
+      Eigen::Vector3d location)
       {
         if (auto context = w_context.lock())
         {
@@ -845,7 +855,7 @@ void EasyCommandHandle::stop()
 
   /// Prevent any further specialized updates.
   EasyFullControl::ActivityIdentifier::Implementation
-    ::get(*activity_identifier).update_fn = nullptr;
+  ::get(*activity_identifier).update_fn = nullptr;
 
   this->current_progress = nullptr;
   this->handle_stop(activity_identifier);
@@ -1090,7 +1100,8 @@ void EasyCommandHandle::follow_new_path(
           {
             target_index = i2;
             target_position = wp2.position();
-            if (std::abs(wp1.position()[2] - wp2.position()[2])*180.0 / M_PI < 1e-2)
+            if (std::abs(wp1.position()[2] -
+              wp2.position()[2])*180.0 / M_PI < 1e-2)
             {
               // The plan had a wait between these points.
               planned_wait_time += wp2.time() - wp1.time();
@@ -1132,7 +1143,7 @@ void EasyCommandHandle::follow_new_path(
         {
           handle_nav_request(destination, execution);
         }
-      ));
+    ));
 
     i0 = target_index;
     i1 = i0 + 1;
@@ -1381,7 +1392,8 @@ public:
     std::shared_ptr<NavParams> params_,
     rxcpp::schedulers::worker worker_)
   {
-    auto handle = std::shared_ptr<EasyRobotUpdateHandle>(new EasyRobotUpdateHandle);
+    auto handle = std::shared_ptr<EasyRobotUpdateHandle>(
+      new EasyRobotUpdateHandle);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
       std::move(params_), std::move(worker_));
     return handle;
@@ -1406,7 +1418,7 @@ void EasyFullControl::EasyRobotUpdateHandle::update(
       }
 
       auto context = RobotUpdateHandle::Implementation
-        ::get(*updater->handle).get_context();
+      ::get(*updater->handle).get_context();
 
       context->current_battery_soc(state.battery_state_of_charge());
 
@@ -1416,7 +1428,7 @@ void EasyFullControl::EasyRobotUpdateHandle::update(
       if (current_activity)
       {
         const auto update_fn =
-          ActivityIdentifier::Implementation::get(*current_activity).update_fn;
+        ActivityIdentifier::Implementation::get(*current_activity).update_fn;
         if (update_fn)
         {
           update_fn(state.map(), position);
@@ -1436,7 +1448,8 @@ void EasyFullControl::EasyRobotUpdateHandle::update(
       const auto& graph = planner->get_configuration().graph();
       const auto& nav_params = updater->nav_params;
       const auto now = context->now();
-      auto starts = nav_params->compute_plan_starts(graph, state.map(), position, now);
+      auto starts =
+      nav_params->compute_plan_starts(graph, state.map(), position, now);
       if (!starts.empty())
       {
         context->set_location(std::move(starts));
@@ -1449,7 +1462,8 @@ void EasyFullControl::EasyRobotUpdateHandle::update(
 }
 
 //==============================================================================
-double EasyFullControl::EasyRobotUpdateHandle::max_merge_waypoint_distance() const
+double EasyFullControl::EasyRobotUpdateHandle::max_merge_waypoint_distance()
+const
 {
   auto updater = _pimpl->updater;
   if (!updater->handle)
@@ -1458,7 +1472,8 @@ double EasyFullControl::EasyRobotUpdateHandle::max_merge_waypoint_distance() con
     return updater->nav_params->max_merge_waypoint_distance;
   }
 
-  auto context = RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
+  auto context =
+    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
   return context->nav_params()->max_merge_waypoint_distance;
 }
 
@@ -1471,7 +1486,8 @@ void EasyFullControl::EasyRobotUpdateHandle::set_max_merge_waypoint_distance(
   {
     return;
   }
-  auto context = RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
+  auto context =
+    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
   const auto nav_params = context->nav_params();
   auto new_nav_params = std::make_shared<NavParams>(*nav_params);
   new_nav_params->max_merge_waypoint_distance = distance;
@@ -1487,7 +1503,8 @@ double EasyFullControl::EasyRobotUpdateHandle::max_merge_lane_distance() const
     // If no handle is configured, return the default fleet value
     return updater->nav_params->max_merge_lane_distance;
   }
-  auto context = RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
+  auto context =
+    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
   return context->nav_params()->max_merge_lane_distance;
 }
 
@@ -1500,7 +1517,8 @@ void EasyFullControl::EasyRobotUpdateHandle::set_max_merge_lane_distance(
   {
     return;
   }
-  auto context = RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
+  auto context =
+    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
   const auto nav_params = context->nav_params();
   auto new_nav_params = std::make_shared<NavParams>(*nav_params);
   new_nav_params->max_merge_lane_distance = distance;
@@ -1516,7 +1534,8 @@ double EasyFullControl::EasyRobotUpdateHandle::min_lane_length() const
     // If no handle is configured, return the default fleet value
     return updater->nav_params->min_lane_length;
   }
-  auto context = RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
+  auto context =
+    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
   return context->nav_params()->min_lane_length;
 }
 
@@ -1529,7 +1548,8 @@ void EasyFullControl::EasyRobotUpdateHandle::set_min_lane_length(
   {
     return;
   }
-  auto context = RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
+  auto context =
+    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
   const auto nav_params = context->nav_params();
   auto new_nav_params = std::make_shared<NavParams>(*nav_params);
   new_nav_params->min_lane_length = length;
@@ -1570,8 +1590,10 @@ class EasyFullControl::FleetConfiguration::Implementation
 {
 public:
   std::string fleet_name;
-  std::optional<std::unordered_map<std::string, Transformation>> transformations_to_robot_coordinates;
-  std::unordered_map<std::string, RobotConfiguration> known_robot_configurations;
+  std::optional<std::unordered_map<std::string,
+    Transformation>> transformations_to_robot_coordinates;
+  std::unordered_map<std::string,
+    RobotConfiguration> known_robot_configurations;
   std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits;
   std::shared_ptr<const rmf_traffic::agv::Graph> graph;
   rmf_battery::agv::ConstBatterySystemPtr battery_system;
@@ -1597,8 +1619,10 @@ public:
 //==============================================================================
 EasyFullControl::FleetConfiguration::FleetConfiguration(
   const std::string& fleet_name,
-  std::optional<std::unordered_map<std::string, Transformation>> transformations_to_robot_coordinates,
-  std::unordered_map<std::string, RobotConfiguration> known_robot_configurations,
+  std::optional<std::unordered_map<std::string, Transformation>>
+  transformations_to_robot_coordinates,
+  std::unordered_map<std::string, RobotConfiguration>
+  known_robot_configurations,
   std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
   std::shared_ptr<const rmf_traffic::agv::Graph> graph,
   rmf_battery::agv::ConstBatterySystemPtr battery_system,
@@ -1711,15 +1735,15 @@ EasyFullControl::FleetConfiguration::from_config_files(
   }
 
   auto traits = std::make_shared<VehicleTraits>(VehicleTraits{
-    {v_nom, a_nom},
-    {w_nom, b_nom},
-    rmf_traffic::Profile{
-      rmf_traffic::geometry::make_final_convex<rmf_traffic::geometry::Circle>(
-        footprint_rad),
-      rmf_traffic::geometry::make_final_convex<rmf_traffic::geometry::Circle>(
-        vicinity_rad)
-    }
-  });
+        {v_nom, a_nom},
+        {w_nom, b_nom},
+        rmf_traffic::Profile{
+          rmf_traffic::geometry::make_final_convex<rmf_traffic::geometry::Circle>(
+            footprint_rad),
+          rmf_traffic::geometry::make_final_convex<rmf_traffic::geometry::Circle>(
+            vicinity_rad)
+        }
+      });
   traits->get_differential()->set_reversible(reversible);
 
   // Graph
@@ -1752,16 +1776,18 @@ EasyFullControl::FleetConfiguration::from_config_files(
   // Mechanical system
   if (!rmf_fleet["mechanical_system"])
   {
-    std::cout << "Fleet [mechanical_system] information is not provided" << std::endl;
+    std::cout << "Fleet [mechanical_system] information is not provided"
+              << std::endl;
     return std::nullopt;
   }
 
-  if(
+  if (
     !rmf_fleet["mechanical_system"]["mass"] ||
     !rmf_fleet["mechanical_system"]["moment_of_inertia"] ||
     !rmf_fleet["mechanical_system"]["friction_coefficient"])
   {
-    std::cout << "Fleet [mechanical_system] information is not valid" << std::endl;
+    std::cout << "Fleet [mechanical_system] information is not valid"
+              << std::endl;
     return std::nullopt;
   }
 
@@ -1828,7 +1854,7 @@ EasyFullControl::FleetConfiguration::from_config_files(
   if (!rmf_fleet["account_for_battery_drain"])
   {
     std::cout << "[account_for_battery_drain] value is not provided, "
-      << "default to True" << std::endl;
+              << "default to True" << std::endl;
   }
   else
   {
@@ -2045,27 +2071,33 @@ EasyFullControl::FleetConfiguration::from_config_files(
   }
 
   double default_max_merge_waypoint_distance = 1e-3;
-  const YAML::Node& default_max_merge_waypoint_distance_yaml = rmf_fleet["max_merge_waypoint_distance"];
+  const YAML::Node& default_max_merge_waypoint_distance_yaml =
+    rmf_fleet["max_merge_waypoint_distance"];
   if (default_max_merge_waypoint_distance_yaml)
   {
-    default_max_merge_waypoint_distance = default_max_merge_waypoint_distance_yaml.as<double>();
+    default_max_merge_waypoint_distance =
+      default_max_merge_waypoint_distance_yaml.as<double>();
   }
 
   double default_max_merge_lane_distance = 0.3;
-  const YAML::Node& default_max_merge_lane_distance_yaml = rmf_fleet["max_merge_lane_distance"];
+  const YAML::Node& default_max_merge_lane_distance_yaml =
+    rmf_fleet["max_merge_lane_distance"];
   if (default_max_merge_lane_distance_yaml)
   {
-    default_max_merge_waypoint_distance = default_max_merge_waypoint_distance_yaml.as<double>();
+    default_max_merge_waypoint_distance =
+      default_max_merge_waypoint_distance_yaml.as<double>();
   }
 
   double default_min_lane_length = 1e-8;
   const YAML::Node& default_min_lane_length_yaml = rmf_fleet["min_lane_length"];
   if (default_min_lane_length_yaml)
   {
-    default_min_lane_length = default_min_lane_length_yaml.as<double>();
+    default_min_lane_length =
+      default_min_lane_length_yaml.as<double>();
   }
 
-  std::unordered_map<std::string, RobotConfiguration> known_robot_configurations;
+  std::unordered_map<std::string,
+    RobotConfiguration> known_robot_configurations;
   const YAML::Node& robots = rmf_fleet["robots"];
   if (robots)
   {
@@ -2119,7 +2151,8 @@ EasyFullControl::FleetConfiguration::from_config_files(
         std::optional<double> max_merge_waypoint_distance = std::nullopt;
         if (max_merge_waypoint_distance_yaml)
         {
-          max_merge_waypoint_distance = max_merge_waypoint_distance_yaml.as<double>();
+          max_merge_waypoint_distance =
+            max_merge_waypoint_distance_yaml.as<double>();
         }
 
         const YAML::Node& max_merge_lane_distance_yaml =
@@ -2138,8 +2171,11 @@ EasyFullControl::FleetConfiguration::from_config_files(
           min_lane_length = min_lane_length_yaml.as<double>();
         }
 
-        auto config = RobotConfiguration({std::move(charger)}, responsive_wait,
-          max_merge_waypoint_distance, max_merge_lane_distance, min_lane_length);
+        auto config = RobotConfiguration({std::move(charger)},
+            responsive_wait,
+            max_merge_waypoint_distance,
+            max_merge_lane_distance,
+            min_lane_length);
         known_robot_configurations.insert_or_assign(robot_name, config);
       }
     }
@@ -2185,7 +2221,8 @@ void EasyFullControl::FleetConfiguration::set_fleet_name(std::string value)
 
 //==============================================================================
 const std::optional<TransformDictionary>&
-EasyFullControl::FleetConfiguration::transformations_to_robot_coordinates() const
+EasyFullControl::FleetConfiguration::transformations_to_robot_coordinates()
+const
 {
   return _pimpl->transformations_to_robot_coordinates;
 }
@@ -2201,7 +2238,7 @@ void EasyFullControl::FleetConfiguration::add_robot_coordinate_transformation(
   }
 
   _pimpl->transformations_to_robot_coordinates
-    ->insert_or_assign(std::move(map), transformation);
+  ->insert_or_assign(std::move(map), transformation);
 }
 
 //==============================================================================
@@ -2358,7 +2395,8 @@ bool EasyFullControl::FleetConfiguration::account_for_battery_drain() const
 }
 
 //==============================================================================
-void EasyFullControl::FleetConfiguration::set_account_for_battery_drain(bool value)
+void EasyFullControl::FleetConfiguration::set_account_for_battery_drain(
+  bool value)
 {
   _pimpl->account_for_battery_drain = value;
 }
@@ -2418,7 +2456,8 @@ void EasyFullControl::FleetConfiguration::set_skip_rotation_commands(bool value)
 }
 
 //==============================================================================
-std::optional<std::string> EasyFullControl::FleetConfiguration::server_uri() const
+std::optional<std::string> EasyFullControl::FleetConfiguration::server_uri()
+const
 {
   return _pimpl->server_uri;
 }
@@ -2437,13 +2476,15 @@ rmf_traffic::Duration EasyFullControl::FleetConfiguration::max_delay() const
 }
 
 //==============================================================================
-void EasyFullControl::FleetConfiguration::set_max_delay(rmf_traffic::Duration value)
+void EasyFullControl::FleetConfiguration::set_max_delay(
+  rmf_traffic::Duration value)
 {
   _pimpl->max_delay = value;
 }
 
 //==============================================================================
-rmf_traffic::Duration EasyFullControl::FleetConfiguration::update_interval() const
+rmf_traffic::Duration EasyFullControl::FleetConfiguration::update_interval()
+const
 {
   return _pimpl->update_interval;
 }
@@ -2469,20 +2510,22 @@ void EasyFullControl::FleetConfiguration::set_default_responsive_wait(
 }
 
 //==============================================================================
-double EasyFullControl::FleetConfiguration::default_max_merge_waypoint_distance() const
+double EasyFullControl::FleetConfiguration::default_max_merge_waypoint_distance()
+const
 {
   return _pimpl->default_max_merge_waypoint_distance;
 }
 
 //==============================================================================
-void EasyFullControl::FleetConfiguration::set_default_max_merge_waypoint_distance(
-  double distance)
+void EasyFullControl::FleetConfiguration::
+set_default_max_merge_waypoint_distance(double distance)
 {
   _pimpl->default_max_merge_waypoint_distance = distance;
 }
 
 //==============================================================================
-double EasyFullControl::FleetConfiguration::default_max_merge_lane_distance() const
+double EasyFullControl::FleetConfiguration::default_max_merge_lane_distance()
+const
 {
   return _pimpl->default_max_merge_lane_distance;
 }
@@ -2531,7 +2574,8 @@ auto EasyFullControl::add_robot(
 {
   const auto node = _pimpl->node();
 
-  auto worker = FleetUpdateHandle::Implementation::get(*_pimpl->fleet_handle).worker;
+  auto worker =
+    FleetUpdateHandle::Implementation::get(*_pimpl->fleet_handle).worker;
   auto easy_updater = EasyRobotUpdateHandle::Implementation::make(
     _pimpl->nav_params, worker);
 
@@ -2611,11 +2655,13 @@ auto EasyFullControl::add_robot(
   auto robot_nav_params = std::make_shared<NavParams>(*_pimpl->nav_params);
   if (configuration.max_merge_waypoint_distance().has_value())
   {
-    robot_nav_params->max_merge_waypoint_distance = *configuration.max_merge_waypoint_distance();
+    robot_nav_params->max_merge_waypoint_distance =
+      *configuration.max_merge_waypoint_distance();
   }
   if (configuration.max_merge_lane_distance().has_value())
   {
-    robot_nav_params->max_merge_lane_distance = *configuration.max_merge_lane_distance();
+    robot_nav_params->max_merge_lane_distance =
+      *configuration.max_merge_lane_distance();
   }
 
   if (configuration.min_lane_length().has_value())
@@ -2693,7 +2739,7 @@ auto EasyFullControl::add_robot(
     ](const RobotUpdateHandlePtr& updater)
     {
       auto context = RobotUpdateHandle::Implementation::get(*updater)
-        .get_context();
+      .get_context();
 
       context->worker().schedule(
         [
@@ -2713,7 +2759,7 @@ auto EasyFullControl::add_robot(
           cmd_handle->w_context = context;
           context->set_nav_params(nav_params);
           EasyRobotUpdateHandle::Implementation::get(*easy_updater)
-            .updater->handle = handle;
+          .updater->handle = handle;
           handle->set_action_executor(action_executor);
           handle->set_charger_waypoint(charger_index);
           handle->enable_responsive_wait(enable_responsive_wait);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -1465,95 +1465,40 @@ void EasyFullControl::EasyRobotUpdateHandle::update(
 double EasyFullControl::EasyRobotUpdateHandle::max_merge_waypoint_distance()
 const
 {
-  auto updater = _pimpl->updater;
-  if (!updater->handle)
-  {
-    // If no handle is configured, return the default fleet value
-    return updater->nav_params->max_merge_waypoint_distance;
-  }
-
-  auto context =
-    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
-  return context->nav_params()->max_merge_waypoint_distance;
+  return _pimpl->updater->nav_params->max_merge_waypoint_distance;
 }
 
 //==============================================================================
 void EasyFullControl::EasyRobotUpdateHandle::set_max_merge_waypoint_distance(
   double distance)
 {
-  auto updater = _pimpl->updater;
-  if (!updater->handle)
-  {
-    return;
-  }
-  auto context =
-    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
-  const auto nav_params = context->nav_params();
-  auto new_nav_params = std::make_shared<NavParams>(*nav_params);
-  new_nav_params->max_merge_waypoint_distance = distance;
-  context->set_nav_params(new_nav_params);
+  _pimpl->updater->nav_params->max_merge_waypoint_distance = distance;
 }
 
 //==============================================================================
 double EasyFullControl::EasyRobotUpdateHandle::max_merge_lane_distance() const
 {
-  auto updater = _pimpl->updater;
-  if (!updater->handle)
-  {
-    // If no handle is configured, return the default fleet value
-    return updater->nav_params->max_merge_lane_distance;
-  }
-  auto context =
-    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
-  return context->nav_params()->max_merge_lane_distance;
+  return _pimpl->updater->nav_params->max_merge_lane_distance;
 }
 
 //==============================================================================
 void EasyFullControl::EasyRobotUpdateHandle::set_max_merge_lane_distance(
   double distance)
 {
-  auto updater = _pimpl->updater;
-  if (!updater->handle)
-  {
-    return;
-  }
-  auto context =
-    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
-  const auto nav_params = context->nav_params();
-  auto new_nav_params = std::make_shared<NavParams>(*nav_params);
-  new_nav_params->max_merge_lane_distance = distance;
-  context->set_nav_params(new_nav_params);
+  _pimpl->updater->nav_params->max_merge_lane_distance = distance;
 }
 
 //==============================================================================
 double EasyFullControl::EasyRobotUpdateHandle::min_lane_length() const
 {
-  auto updater = _pimpl->updater;
-  if (!updater->handle)
-  {
-    // If no handle is configured, return the default fleet value
-    return updater->nav_params->min_lane_length;
-  }
-  auto context =
-    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
-  return context->nav_params()->min_lane_length;
+  return _pimpl->updater->nav_params->min_lane_length;
 }
 
 //==============================================================================
 void EasyFullControl::EasyRobotUpdateHandle::set_min_lane_length(
   double length)
 {
-  auto updater = _pimpl->updater;
-  if (!updater->handle)
-  {
-    return;
-  }
-  auto context =
-    RobotUpdateHandle::Implementation::get(*_pimpl->updater->handle).get_context();
-  const auto nav_params = context->nav_params();
-  auto new_nav_params = std::make_shared<NavParams>(*nav_params);
-  new_nav_params->min_lane_length = length;
-  context->set_nav_params(new_nav_params);
+  _pimpl->updater->nav_params->min_lane_length = length;
 }
 
 //==============================================================================
@@ -2576,8 +2521,9 @@ auto EasyFullControl::add_robot(
 
   auto worker =
     FleetUpdateHandle::Implementation::get(*_pimpl->fleet_handle).worker;
+  auto robot_nav_params = std::make_shared<NavParams>(_pimpl->nav_params);
   auto easy_updater = EasyRobotUpdateHandle::Implementation::make(
-    _pimpl->nav_params, worker);
+    robot_nav_params, worker);
 
   const auto& fleet_impl =
     FleetUpdateHandle::Implementation::get(*_pimpl->fleet_handle);
@@ -2637,7 +2583,7 @@ auto EasyFullControl::add_robot(
   rmf_traffic::Time now = std::chrono::steady_clock::time_point(
     std::chrono::nanoseconds(node->now().nanoseconds()));
 
-  const auto position_opt = _pimpl->nav_params->to_rmf_coordinates(
+  const auto position_opt = robot_nav_params->to_rmf_coordinates(
     initial_state.map(), initial_state.position());
   if (!position_opt.has_value())
   {
@@ -2652,7 +2598,6 @@ auto EasyFullControl::add_robot(
     return nullptr;
   }
 
-  auto robot_nav_params = std::make_shared<NavParams>(*_pimpl->nav_params);
   if (configuration.max_merge_waypoint_distance().has_value())
   {
     robot_nav_params->max_merge_waypoint_distance =

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -794,7 +794,7 @@ public:
     const std::string& map,
     Eigen::Vector3d position) const
   {
-    if (!nav_params->transforms_to_robot_coords.has_value())
+    if (!nav_params->transforms_to_robot_coords)
     {
       return position;
     }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -145,7 +145,7 @@ void RobotContext::filter_closed_lanes()
   if (const auto planner = *_planner)
   {
     const auto& closures = planner->get_configuration().lane_closures();
-    for (std::size_t i = 0; i < _location.size();)
+    for (std::size_t i = 0; i < _location.size(); )
     {
       if (_location[i].lane().has_value())
       {
@@ -392,9 +392,9 @@ std::function<rmf_task::State()> RobotContext::make_get_state()
       if (self->_most_recent_valid_location.empty())
       {
         throw std::runtime_error(
-          "Missing a _most_recent_valid_location for robot ["
-          + self->requester_id() + "]. This is an internal RMF error, "
-          "please report it to the RMF developers.");
+                "Missing a _most_recent_valid_location for robot ["
+                + self->requester_id() + "]. This is an internal RMF error, "
+                "please report it to the RMF developers.");
       }
 
       rmf_task::State state;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -55,7 +55,7 @@ using TransformDictionary = std::unordered_map<std::string, Transformation>;
 struct NavParams
 {
   bool skip_rotation_commands;
-  std::optional<TransformDictionary> transforms_to_robot_coords;
+  std::shared_ptr<TransformDictionary> transforms_to_robot_coords;
   double max_merge_waypoint_distance = 1e-3;
   double max_merge_lane_distance = 0.3;
   double min_lane_length = 1e-8;
@@ -67,7 +67,7 @@ struct NavParams
     const std::string& map,
     Eigen::Vector3d position)
   {
-    if (!transforms_to_robot_coords.has_value())
+    if (!transforms_to_robot_coords)
     {
       return position;
     }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -1030,7 +1030,7 @@ void ScheduleOverride::overridden_update(
     // based on the agent being at that waypoint. This is a very fallible
     // estimation, but it's the best we can do with limited information.
     std::optional<std::pair<rmf_traffic::Time, double>> closest_time;
-    for (std::size_t i=0; i < route.trajectory().size(); ++i)
+    for (std::size_t i = 0; i < route.trajectory().size(); ++i)
     {
       const auto& wp = route.trajectory().at(i);
       const Eigen::Vector2d p_wp = wp.position().block<2, 1>(0, 0);
@@ -1052,7 +1052,7 @@ void ScheduleOverride::overridden_update(
   }
 
   const auto& itin = context->itinerary().itinerary();
-  for (std::size_t i=0; i < itin.size(); ++i)
+  for (std::size_t i = 0; i < itin.size(); ++i)
   {
     const auto& traj = itin[i].trajectory();
     const auto t_it = traj.find(now);
@@ -1154,7 +1154,7 @@ std::optional<ScheduleOverride> ScheduleOverride::make(
       Eigen::Vector3d(0.0, 0.0, 0.0));
   }
   std::set<uint64_t> checkpoints;
-  for (uint64_t i=1; i < trajectory.size(); ++i)
+  for (uint64_t i = 1; i < trajectory.size(); ++i)
   {
     checkpoints.insert(i);
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -32,14 +32,13 @@ public:
   std::shared_ptr<FleetUpdateHandle> fleet_handle;
   // Map robot name to its EasyCommandHandle
   std::unordered_map<std::string, EasyCommandHandlePtr> cmd_handles;
-  // TODO(YV): Get these constants from EasyCommandHandle::Configuration
   NavParams nav_params;
   bool default_responsive_wait;
 
   static std::shared_ptr<EasyFullControl> make(
     std::shared_ptr<FleetUpdateHandle> fleet_handle,
     bool skip_rotation_commands,
-    std::optional<TransformDictionary> transforms_to_robot_coords,
+    std::shared_ptr<TransformDictionary> transforms_to_robot_coords,
     bool default_responsive_wait,
     double default_max_merge_waypoint_distance,
     double default_max_merge_lane_distance,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -50,18 +50,18 @@ public:
   {
     auto handle = std::shared_ptr<EasyFullControl>(new EasyFullControl);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
-        Implementation{
-          fleet_handle,
-          {},
-          std::make_shared<NavParams>(NavParams{
-            skip_rotation_commands,
-            std::move(transforms_to_robot_coords),
-            default_max_merge_waypoint_distance,
-            default_max_merge_lane_distance,
-            default_min_lane_length
-          }),
-          default_responsive_wait
-        });
+      Implementation{
+        fleet_handle,
+        {},
+        std::make_shared<NavParams>(NavParams{
+          skip_rotation_commands,
+          std::move(transforms_to_robot_coords),
+          default_max_merge_waypoint_distance,
+          default_max_merge_lane_distance,
+          default_min_lane_length
+        }),
+        default_responsive_wait
+      });
     return handle;
   }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -35,12 +35,18 @@ public:
   // TODO(YV): Get these constants from EasyCommandHandle::Configuration
   std::shared_ptr<NavParams> nav_params;
   bool default_responsive_wait;
+  double default_max_merge_waypoint_distance;
+  double default_max_merge_lane_distance;
+  double default_min_lane_length;
 
   static std::shared_ptr<EasyFullControl> make(
     std::shared_ptr<FleetUpdateHandle> fleet_handle,
     bool skip_rotation_commands,
     std::optional<TransformDictionary> transforms_to_robot_coords,
-    bool default_responsive_wait)
+    bool default_responsive_wait,
+    double default_max_merge_waypoint_distance,
+    double default_max_merge_lane_distance,
+    double default_min_lane_length)
   {
     auto handle = std::shared_ptr<EasyFullControl>(new EasyFullControl);
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
@@ -49,7 +55,10 @@ public:
           {},
           std::make_shared<NavParams>(NavParams{
             skip_rotation_commands,
-            std::move(transforms_to_robot_coords)
+            std::move(transforms_to_robot_coords),
+            default_max_merge_waypoint_distance,
+            default_max_merge_lane_distance,
+            default_min_lane_length
           }),
           default_responsive_wait
         });

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_EasyFullControl.hpp
@@ -33,11 +33,8 @@ public:
   // Map robot name to its EasyCommandHandle
   std::unordered_map<std::string, EasyCommandHandlePtr> cmd_handles;
   // TODO(YV): Get these constants from EasyCommandHandle::Configuration
-  std::shared_ptr<NavParams> nav_params;
+  NavParams nav_params;
   bool default_responsive_wait;
-  double default_max_merge_waypoint_distance;
-  double default_max_merge_lane_distance;
-  double default_min_lane_length;
 
   static std::shared_ptr<EasyFullControl> make(
     std::shared_ptr<FleetUpdateHandle> fleet_handle,
@@ -53,13 +50,13 @@ public:
       Implementation{
         fleet_handle,
         {},
-        std::make_shared<NavParams>(NavParams{
+        NavParams{
           skip_rotation_commands,
           std::move(transforms_to_robot_coords),
           default_max_merge_waypoint_distance,
           default_max_merge_lane_distance,
           default_min_lane_length
-        }),
+        },
         default_responsive_wait
       });
     return handle;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -32,11 +32,12 @@
 namespace rmf_fleet_adapter {
 namespace agv {
 
-class TriggerOnce {
+class TriggerOnce
+{
 public:
   TriggerOnce(std::function<void()> callback)
-    : _callback(std::make_shared<std::shared_ptr<std::function<void()>>>(
-      std::make_shared<std::function<void()>>(std::move(callback))))
+  : _callback(std::make_shared<std::shared_ptr<std::function<void()>>>(
+        std::make_shared<std::function<void()>>(std::move(callback))))
   {
     // Do nothing
   }
@@ -109,8 +110,8 @@ struct ScheduleOverride
 
 //==============================================================================
 using LocationUpdateFn = std::function<void(
-  const std::string& map,
-  Eigen::Vector3d location)>;
+      const std::string& map,
+      Eigen::Vector3d location)>;
 
 //==============================================================================
 class RobotUpdateHandle::ActivityIdentifier::Implementation
@@ -122,7 +123,8 @@ public:
 
   static std::shared_ptr<ActivityIdentifier> make(LocationUpdateFn update_fn_)
   {
-    auto identifier = std::shared_ptr<ActivityIdentifier>(new ActivityIdentifier);
+    auto identifier =
+      std::shared_ptr<ActivityIdentifier>(new ActivityIdentifier);
     identifier->_pimpl = rmf_utils::make_unique_impl<Implementation>(
       Implementation{update_fn_});
     return identifier;
@@ -214,12 +216,12 @@ public:
       std::function<void()> finished_,
       std::shared_ptr<rmf_task::events::SimpleEventState> state_,
       std::optional<rmf_traffic::Duration> remaining_time_ = std::nullopt)
-      : w_context(context_),
-        finished(std::move(finished_)),
-        state(std::move(state_)),
-        remaining_time(remaining_time_),
-        request_replan(false),
-        okay(true)
+    : w_context(context_),
+      finished(std::move(finished_)),
+      state(std::move(state_)),
+      remaining_time(remaining_time_),
+      request_replan(false),
+      okay(true)
     {
       // Do nothing
     }
@@ -242,9 +244,9 @@ public:
     auto update_fn = [data](
       const std::string& map,
       Eigen::Vector3d location)
-    {
-      data->update_location(map, location);
-    };
+      {
+        data->update_location(map, location);
+      };
 
     ActionExecution execution;
     execution._pimpl = rmf_utils::make_impl<Implementation>(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
@@ -188,7 +188,8 @@ auto GoToPlace::Active::make(
     active->_context->observe_graph_change()
     .observe_on(rxcpp::identity_same_worker(active->_context->worker()))
     .subscribe(
-    [w = active->weak_from_this()](const agv::RobotContext::GraphChange& changes)
+    [w = active->weak_from_this()](
+      const agv::RobotContext::GraphChange& changes)
     {
       const auto self = w.lock();
       if (!self)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
@@ -259,7 +259,7 @@ void MoveRobot::Action::operator()(const Subscriber& s)
             plan_id, new_cumulative_delay, 100ms);
 
           const auto& itin = context->itinerary().itinerary();
-          for (std::size_t i=0; i < itin.size(); ++i)
+          for (std::size_t i = 0; i < itin.size(); ++i)
           {
             const auto& traj = itin[i].trajectory();
             const auto t_it = traj.find(now);

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -738,6 +738,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
     std::shared_ptr<agv::EasyFullControl::EasyRobotUpdateHandle>
   >(m_easy_full_control, "EasyRobotUpdateHandle")
   .def("update", &agv::EasyFullControl::EasyRobotUpdateHandle::update)
+  .def("set_merge_distances", &agv::EasyFullControl::EasyRobotUpdateHandle::set_merge_distances)
+  // .def("set_max_merge_waypoint_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::set_max_merge_waypoint_distance)
+  // .def("set_max_merge_lane_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::set_max_merge_lane_distance)
+  // .def("set_min_lane_length", &agv::EasyFullControl::EasyRobotUpdateHandle::set_min_lane_length)
   .def("more", [](agv::EasyFullControl::EasyRobotUpdateHandle& self)
     {
       return self.more();
@@ -766,7 +770,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
 
   py::class_<agv::EasyFullControl::RobotConfiguration>(m_easy_full_control, "RobotConfiguration")
   .def(py::init<std::vector<std::string>>(),
-    py::arg("comaptible_chargers"))
+    py::arg("compatible_chargers"))
   .def_property(
     "compatible_chargers",
     &agv::EasyFullControl::RobotConfiguration::compatible_chargers,
@@ -841,7 +845,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
         std::optional<std::string> server_uri,
         rmf_traffic::Duration max_delay,
         rmf_traffic::Duration update_interval,
-        bool default_responsive_wait)
+        bool default_responsive_wait,
+        double default_max_merge_waypoint_distance,
+        double default_max_merge_lane_distance,
+        double default_min_lane_length)
         {
           rmf_task::ConstRequestFactoryPtr finishing_request;
           if (finishing_request_string == "charge")
@@ -878,7 +885,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
               server_uri,
               max_delay,
               update_interval,
-              default_responsive_wait);
+              default_responsive_wait,
+              default_max_merge_waypoint_distance,
+              default_max_merge_lane_distance,
+              default_min_lane_length);
         }
         ),
     py::arg("fleet_name"),
@@ -900,7 +910,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("server_uri") = std::nullopt,
     py::arg("max_delay") = rmf_traffic::time::from_seconds(10.0),
     py::arg("update_interval") = rmf_traffic::time::from_seconds(0.5),
-    py::arg("default_responsive_wait") = false)
+    py::arg("default_responsive_wait") = false,
+    py::arg("default_max_merge_waypoint_distance") = 1e-3,
+    py::arg("default_max_merge_lane_distance") = 0.3,
+    py::arg("default_min_lane_length") = 1e-8)
   .def_static("from_config_files", &agv::EasyFullControl::FleetConfiguration::from_config_files,
     py::arg("config_file"),
     py::arg("nav_graph_path"),
@@ -986,7 +999,19 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property(
     "default_responsive_wait",
     &agv::EasyFullControl::FleetConfiguration::default_responsive_wait,
-    &agv::EasyFullControl::FleetConfiguration::set_default_responsive_wait);
+    &agv::EasyFullControl::FleetConfiguration::set_default_responsive_wait)
+  .def_property(
+    "default_max_merge_waypoint_distance",
+    &agv::EasyFullControl::FleetConfiguration::default_max_merge_waypoint_distance,
+    &agv::EasyFullControl::FleetConfiguration::set_default_max_merge_waypoint_distance)
+  .def_property(
+    "default_max_merge_lane_distance",
+    &agv::EasyFullControl::FleetConfiguration::default_max_merge_lane_distance,
+    &agv::EasyFullControl::FleetConfiguration::set_default_max_merge_lane_distance)
+  .def_property(
+    "default_min_lane_length",
+    &agv::EasyFullControl::FleetConfiguration::default_min_lane_length,
+    &agv::EasyFullControl::FleetConfiguration::set_default_min_lane_length);
 
   // Transformation =============================================================
   py::class_<agv::Transformation>(m, "Transformation")

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -738,10 +738,12 @@ PYBIND11_MODULE(rmf_adapter, m) {
     std::shared_ptr<agv::EasyFullControl::EasyRobotUpdateHandle>
   >(m_easy_full_control, "EasyRobotUpdateHandle")
   .def("update", &agv::EasyFullControl::EasyRobotUpdateHandle::update)
-  .def("set_merge_distances", &agv::EasyFullControl::EasyRobotUpdateHandle::set_merge_distances)
-  // .def("set_max_merge_waypoint_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::set_max_merge_waypoint_distance)
-  // .def("set_max_merge_lane_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::set_max_merge_lane_distance)
-  // .def("set_min_lane_length", &agv::EasyFullControl::EasyRobotUpdateHandle::set_min_lane_length)
+  .def("max_merge_waypoint_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::max_merge_waypoint_distance)
+  .def("set_max_merge_waypoint_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::set_max_merge_waypoint_distance)
+  .def("max_merge_lane_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::max_merge_lane_distance)
+  .def("set_max_merge_lane_distance", &agv::EasyFullControl::EasyRobotUpdateHandle::set_max_merge_lane_distance)
+  .def("min_lane_length", &agv::EasyFullControl::EasyRobotUpdateHandle::min_lane_length)
+  .def("set_min_lane_length", &agv::EasyFullControl::EasyRobotUpdateHandle::set_min_lane_length)
   .def("more", [](agv::EasyFullControl::EasyRobotUpdateHandle& self)
     {
       return self.more();


### PR DESCRIPTION
This PR supplements #286 to add a few more configurable parameters to the fleet adapter:
- `max_merge_waypoint_distance`
- `max_merge_lane_distance`
- `min_lane_length`

As suggested, a default fleet value for each parameter can be configured in the fleet's config.yaml ([example](https://github.com/open-rmf/rmf_demos/blob/xiyu/configurable_merge_distance/rmf_demos/config/office/tinyRobot_config.yaml#L35-L37)), and robot-specific distances can be set as well ([example](https://github.com/open-rmf/rmf_demos/blob/xiyu/configurable_merge_distance/rmf_demos/config/office/tinyRobot_config.yaml#L42-L44)). To modify these values live, the `EasyRobotUpdateHandle` API is updated to accommodate getting and setting them.

These values are currently set independently since it might be more preferable to retrieve them individually, but I am wondering if it is better to take the params as optional values into a single function instead similar to `RobotContext`, such as
```cpp
void EasyFullControl::EasyRobotUpdateHandle::set_nav_params(
  std::optional<double> max_merge_waypoint_distance,
  std::optional<double> max_merge_lane_distance,
  std::optional<double> min_lane_length)
{
  // modify value if has_value()
  // ...
  context->set_nav_params(new_nav_params);
}
```