### PR TITLE
Improve linking time (#297)

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -73,27 +73,31 @@ add_library(rmf_fleet_adapter SHARED
   ${rmf_fleet_adapter_srcs}
 )
 
+ament_target_dependencies(rmf_fleet_adapter
+  PUBLIC
+    rmf_traffic_ros2
+    rmf_task_ros2
+    yaml-cpp
+    rmf_fleet_msgs
+    rmf_task_msgs
+    rmf_door_msgs
+    rmf_lift_msgs
+    rmf_dispenser_msgs
+    rmf_ingestor_msgs
+    rmf_building_map_msgs
+    rclcpp
+)
+
 target_link_libraries(rmf_fleet_adapter
   PUBLIC
-    rmf_traffic_ros2::rmf_traffic_ros2
-    rmf_battery::rmf_battery
     rmf_task::rmf_task
     rmf_task_sequence::rmf_task_sequence
-    rmf_task_ros2::rmf_task_ros2
-    yaml-cpp
-    ${rmf_fleet_msgs_LIBRARIES}
-    ${rclcpp_LIBRARIES}
-    ${rmf_task_msgs_LIBRARIES}
+    rmf_battery::rmf_battery
   PRIVATE
     rmf_rxcpp
     rmf_websocket::rmf_websocket
     nlohmann_json::nlohmann_json
     rmf_api_msgs::rmf_api_msgs
-    ${rmf_door_msgs_LIBRARIES}
-    ${rmf_lift_msgs_LIBRARIES}
-    ${rmf_dispenser_msgs_LIBRARIES}
-    ${rmf_ingestor_msgs_LIBRARIES}
-    ${rmf_building_map_msgs_LIBRARIES}
     nlohmann_json_schema_validator
 )
 
@@ -102,11 +106,6 @@ target_include_directories(rmf_fleet_adapter
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/rmf_api_generate_schema_headers/include> # for auto-generated schema headers
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${rmf_traffic_ros2_INCLUDE_DIRS}
-    ${rmf_fleet_msgs_INCLUDE_DIRS}
-    ${rclcpp_INCLUDE_DIRS}
-    ${rmf_task_msgs_INCLUDE_DIRS}
-    ${rmf_battery_INCLUDE_DIRS}
   PRIVATE
     ${rmf_door_msgs_INCLUDE_DIRS}
     ${rmf_lift_msgs_INCLUDE_DIRS}
@@ -140,36 +139,31 @@ if (BUILD_TESTING)
       test/test_Task.cpp
     TIMEOUT 300
   )
+  ament_target_dependencies(test_rmf_fleet_adapter
+    PUBLIC
+      rmf_task_msgs
+      rmf_door_msgs
+      rmf_lift_msgs
+      rmf_dispenser_msgs
+      rmf_ingestor_msgs
+      std_msgs
+      rmf_building_map_msgs
+      rmf_websocket
+  )
   target_include_directories(test_rmf_fleet_adapter
     PRIVATE
       # private includes of rmf_fleet_adapter
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rmf_fleet_adapter>
-      ${rmf_task_msgs_INCLUDE_DIRS}
-      ${rmf_door_msgs_INCLUDE_DIRS}
-      ${rmf_lift_msgs_INCLUDE_DIRS}
-      ${rmf_dispenser_msgs_INCLUDE_DIRS}
-      ${rmf_ingestor_msgs_INCLUDE_DIRS}
       ${rmf_api_msgs_INCLUDE_DIRS}
-      ${std_msgs_INCLUDE_DIRS}
-      ${rmf_building_map_msgs_INCLUDE_DIRS}
-      ${rmf_websocket_INCLUDE_DIR}
       ${nlohmann_json_schema_validator_INCLUDE_DIRS}
   )
   target_link_libraries(test_rmf_fleet_adapter
     PRIVATE
       # private libraries of rmf_fleet_adapter
       rmf_rxcpp
-      ${rmf_task_msgs_LIBRARIES}
-      ${rmf_door_msgs_LIBRARIES}
-      ${rmf_lift_msgs_LIBRARIES}
-      ${rmf_dispenser_msgs_LIBRARIES}
-      ${rmf_ingestor_msgs_LIBRARIES}
       rmf_fleet_adapter
       rmf_utils::rmf_utils
       rmf_api_msgs::rmf_api_msgs
-      ${std_msgs_LIBRARIES}
-      ${rmf_building_map_msgs_LIBRARIES}
-      ${rmf_websocket_INCLUDE_DIR}
       nlohmann_json_schema_validator
   )
 

--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -110,8 +110,15 @@ install(
 )
 
 install(
-  TARGETS rmf_task_ros2 rmf_task_dispatcher rmf_bidder_node
+  TARGETS rmf_task_ros2
   EXPORT rmf_task_ros2
+  RUNTIME DESTINATION lib/rmf_task_ros2
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+install(
+  TARGETS rmf_task_dispatcher rmf_bidder_node
   RUNTIME DESTINATION lib/rmf_task_ros2
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -254,13 +254,20 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+# Install executables
 install(
   TARGETS
-    rmf_traffic_ros2
     rmf_traffic_schedule
     rmf_traffic_schedule_monitor
     rmf_traffic_blockade
     update_participant
+  RUNTIME DESTINATION lib/rmf_traffic_ros2
+)
+
+# Install and export shared library
+install(
+  TARGETS
+    rmf_traffic_ros2
   EXPORT rmf_traffic_ros2
   RUNTIME DESTINATION lib/rmf_traffic_ros2
   LIBRARY DESTINATION lib


### PR DESCRIPTION
Backport #297 to Iron.

Corresponding changes to `rmf_visualization` were merged first https://github.com/open-rmf/rmf_visualization/pull/63 and bloomed but a buildfarm error is reported related to `rmf_traffic_ros2` targets https://build.ros2.org/job/Ibin_uJ64__rmf_visualization_schedule__ubuntu_jammy_amd64__binary/29/

Github actions did not flag the issue since our reusable CI job always uses the `main` branch of `rmf.repos` file. There is a PR open to switch the job to use the distro specific branch https://github.com/open-rmf/rmf_ci_templates/pull/8

Once this is merged, will bump version and bloom a release.