### PR TITLE
Cancel automatic pending tasks that are removed during new assignments

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -925,7 +925,7 @@ void TaskManager::set_queue(
     // assignments.
     std::vector<std::string> new_automatic_task_ids;
     const std::vector<std::string> cancellation_labels =
-      {"New task assignments received."};
+    {"New task assignments received."};
     for (const auto& a : assignments)
     {
       if (a.request()->booking()->automatic())

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -923,23 +923,21 @@ void TaskManager::set_queue(
 
     // Cancel pending automatic tasks that will be removed from the new
     // assignments.
-    std::vector<std::string> new_automatic_task_ids;
+    std::unordered_set<std::string> new_automatic_task_ids;
     const std::vector<std::string> cancellation_labels =
     {"New task assignments received."};
     for (const auto& a : assignments)
     {
       if (a.request()->booking()->automatic())
       {
-        new_automatic_task_ids.push_back(a.request()->booking()->id());
+        new_automatic_task_ids.insert(a.request()->booking()->id());
       }
     }
     for (const auto& a : _queue)
     {
       if (a.request()->booking()->automatic() &&
-        std::find(
-          new_automatic_task_ids.begin(),
-          new_automatic_task_ids.end(),
-          a.request()->booking()->id()) == new_automatic_task_ids.end())
+        new_automatic_task_ids.find(a.request()->booking()->id()) ==
+        new_automatic_task_ids.end())
       {
         _publish_canceled_pending_task(a, cancellation_labels);
       }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -920,6 +920,31 @@ void TaskManager::set_queue(
     {
       return;
     }
+
+    // Cancel pending automatic tasks that will be removed from the new
+    // assignments.
+    std::vector<std::string> new_automatic_task_ids;
+    const std::vector<std::string> cancellation_labels =
+      {"New task assignments received."};
+    for (const auto& a : assignments)
+    {
+      if (a.request()->booking()->automatic())
+      {
+        new_automatic_task_ids.push_back(a.request()->booking()->id());
+      }
+    }
+    for (const auto& a : _queue)
+    {
+      if (a.request()->booking()->automatic() &&
+        std::find(
+          new_automatic_task_ids.begin(),
+          new_automatic_task_ids.end(),
+          a.request()->booking()->id()) == new_automatic_task_ids.end())
+      {
+        _publish_canceled_pending_task(a, cancellation_labels);
+      }
+    }
+
     _queue = assignments;
     _publish_task_queue();
   }


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Not exactly a bug, but at the moment pending automatic tasks are just removed from the queue without cancellation.
The original automatic task will remain as `queued` forever on the end of the `api-server`.

This publishes the cancellation of those pending tasks that will be removed when new assignments happen.