### PR TITLE
Change QoS for adapter_lift_requests and lift_requests to transient l…

### DIFF
--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -28,12 +28,13 @@ Node::Node()
 : rclcpp::Node("rmf_lift_supervisor")
 {
   const auto default_qos = rclcpp::SystemDefaultsQoS();
+  const auto transient_qos = rclcpp::SystemDefaultsQoS().reliable().keep_last(10).transient_local();
 
   _lift_request_pub = create_publisher<LiftRequest>(
-    FinalLiftRequestTopicName, default_qos);
+    FinalLiftRequestTopicName, transient_qos);
 
   _adapter_lift_request_sub = create_subscription<LiftRequest>(
-    AdapterLiftRequestTopicName, default_qos,
+    AdapterLiftRequestTopicName, transient_qos,
     [&](LiftRequest::UniquePtr msg)
     {
       _adapter_lift_request_update(std::move(msg));

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -28,7 +28,8 @@ Node::Node()
 : rclcpp::Node("rmf_lift_supervisor")
 {
   const auto default_qos = rclcpp::SystemDefaultsQoS();
-  const auto transient_qos = rclcpp::SystemDefaultsQoS().reliable().keep_last(10).transient_local();
+  const auto transient_qos = rclcpp::SystemDefaultsQoS()
+    .reliable().keep_last(100).transient_local();
 
   _lift_request_pub = create_publisher<LiftRequest>(
     FinalLiftRequestTopicName, transient_qos);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -36,6 +36,7 @@ std::shared_ptr<Node> Node::make(
 
   auto default_qos = rclcpp::SystemDefaultsQoS();
   default_qos.keep_last(100);
+  auto transient_qos = rclcpp::SystemDefaultsQoS().reliable().keep_last(10).transient_local();
 
   node->_door_state_obs =
     node->create_observable<DoorState>(
@@ -55,7 +56,7 @@ std::shared_ptr<Node> Node::make(
 
   node->_lift_request_pub =
     node->create_publisher<LiftRequest>(
-    AdapterLiftRequestTopicName, default_qos);
+    AdapterLiftRequestTopicName, transient_qos);
 
   node->_task_summary_pub =
     node->create_publisher<TaskSummary>(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -36,7 +36,8 @@ std::shared_ptr<Node> Node::make(
 
   auto default_qos = rclcpp::SystemDefaultsQoS();
   default_qos.keep_last(100);
-  auto transient_qos = rclcpp::SystemDefaultsQoS().reliable().keep_last(10).transient_local();
+  auto transient_qos = rclcpp::SystemDefaultsQoS()
+    .reliable().keep_last(100).transient_local();
 
   node->_door_state_obs =
     node->create_observable<DoorState>(


### PR DESCRIPTION
This PR updates the QoS profile of LiftRequest messages for both `/adapter_lift_requests` and `/lift_requests`. The goal for this is to ensure that lift end session requests are reliably published and received by any lift adapters waiting to release control once the robot is done exiting the lift.