### PR TITLE
Apply inverse transforms in Transformation class

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -81,6 +81,22 @@ struct NavParams
     return tf_it->second.apply_inverse(position);
   }
 
+  std::optional<Eigen::Vector3d> to_robot_coordinates(
+    const std::string& map,
+    Eigen::Vector3d position)
+  {
+    if (!transforms_to_robot_coords)
+      return position;
+
+    const auto tf_it = transforms_to_robot_coords->find(map);
+    if (tf_it == transforms_to_robot_coords->end())
+    {
+      return std::nullopt;
+    }
+
+    return tf_it->second.apply(position);
+  }
+
   rmf_traffic::agv::Plan::StartSet compute_plan_starts(
     const rmf_traffic::agv::Graph& graph,
     const std::string& map_name,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Transformation.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Transformation.cpp
@@ -99,7 +99,7 @@ Eigen::Vector3d Transformation::apply(
 Eigen::Vector3d Transformation::apply_inverse(
   const Eigen::Vector3d& position) const
 {
-  Eigen::Vector2d p = _pimpl->transform * position.block<2, 1>(0, 0);
+  Eigen::Vector2d p = _pimpl->transform_inv * position.block<2, 1>(0, 0);
   double angle = rmf_utils::wrap_to_pi(position[2] - _pimpl->rotation);
   return Eigen::Vector3d(p[0], p[1], angle);
 }


### PR DESCRIPTION
This PR updates the transformation implementation in EasyFullControl between robot and RMF coordinates, and also fixes a bug in the `apply_inverse` function inside the Transformation class.

These updates are required for users relying on the transformation implementation in EFC, especially those using RMF binaries.