### PR TITLE
Add support of fleet-level task

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -491,9 +491,9 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
         {make_error_str(5, "Invalid request format", e.what())}
       });
   }
-  
+
   // If a fleet_name was specified in the request, only proceed if the value matches
-  // the name of this fleet. 
+  // the name of this fleet.
   if (request_msg.contains("fleet_name") &&
     request_msg["fleet_name"].template get<std::string>() != name)
   {
@@ -502,7 +502,7 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       "Ignoring BidNotice request as it is for fleet [%s].",
       request_msg["fleet_name"].template get<std::string>().c_str());
     return;
-  } 
+  }
   
   std::vector<std::string> errors = {};
   const auto new_request = convert(task_id, request_msg, errors);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -492,7 +492,18 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
         {make_error_str(5, "Invalid request format", e.what())}
       });
   }
+  
+  std::optional<std::string> fleet_name = std::nullopt;
+  const auto fleet_name_it = request_msg.find("fleet_name");
+  if (fleet_name_it != request_msg.end())
+  {
+    fleet_name = fleet_name_it->get<std::string>();
+  }
 
+  if (fleet_name.has_value()  && fleet_name.value() != name ){
+    return;
+  }
+  
   std::vector<std::string> errors = {};
   const auto new_request = convert(task_id, request_msg, errors);
   if (!new_request)
@@ -503,6 +514,9 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
         errors
       });
   }
+
+  
+
 
   calculate_bid = std::make_shared<AllocateTasks>(
     new_request,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -493,16 +493,17 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       });
   }
   
-  std::optional<std::string> fleet_name = std::nullopt;
-  const auto fleet_name_it = request_msg.find("fleet_name");
-  if (fleet_name_it != request_msg.end())
+  // If a fleet_name was specified in the request, only proceed if the value matches
+  // the name of this fleet. 
+  if (request_msg.contains("fleet_name") &&
+    request_msg["fleet_name"].template get<std::string>() != name)
   {
-    fleet_name = fleet_name_it->get<std::string>();
-  }
-
-  if (fleet_name.has_value()  && fleet_name.value() != name ){
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Ignoring BidNotice request as it is for fleet [%s].",
+      request_msg["fleet_name"].template get<std::string>().c_str());
     return;
-  }
+  } 
   
   std::vector<std::string> errors = {};
   const auto new_request = convert(task_id, request_msg, errors);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -503,7 +503,7 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       request_msg["fleet_name"].template get<std::string>().c_str());
     return;
   }
-  
+
   std::vector<std::string> errors = {};
   const auto new_request = convert(task_id, request_msg, errors);
   if (!new_request)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -427,7 +427,6 @@ public:
   std::shared_ptr<Node> node;
 };
 
-
 //==============================================================================
 void FleetUpdateHandle::Implementation::bid_notice_cb(
   const BidNoticeMsg& bid_notice,
@@ -515,9 +514,6 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
         errors
       });
   }
-
-  
-
 
   calculate_bid = std::make_shared<AllocateTasks>(
     new_request,


### PR DESCRIPTION
Fleet-level task is implemented by ignoring `bid_notice` msg in `bid_notice_cb` if the `fleet_name` in the task_request does not match the fleet's name. 
