### PR TITLE
Explicitly specify all qos depth

### DIFF
--- a/rmf_fleet_adapter/src/close_lanes/main.cpp
+++ b/rmf_fleet_adapter/src/close_lanes/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
   const auto publisher =
     node->create_publisher<rmf_fleet_msgs::msg::LaneRequest>(
     rmf_fleet_adapter::LaneClosureRequestTopicName,
-    rclcpp::SystemDefaultsQoS().transient_local());
+    rclcpp::SystemDefaultsQoS().keep_last(10).transient_local());
 
   publisher->publish(request);
 
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
   const auto listener =
     node->create_subscription<rmf_fleet_msgs::msg::ClosedLanes>(
     rmf_fleet_adapter::ClosedLaneTopicName,
-    rclcpp::SystemDefaultsQoS().transient_local(),
+    rclcpp::SystemDefaultsQoS().keep_last(10).transient_local(),
     [&request_complete, fleet_name, close_lanes = std::move(close_lanes)](
       std::unique_ptr<rmf_fleet_msgs::msg::ClosedLanes> msg)
     {

--- a/rmf_fleet_adapter/src/door_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/door_supervisor/Node.cpp
@@ -28,7 +28,7 @@ const std::string DoorSupervisorRequesterID = "door_supervisor";
 Node::Node()
 : rclcpp::Node("door_supervisor")
 {
-  const auto default_qos = rclcpp::SystemDefaultsQoS();
+  const auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
 
   _door_request_pub = create_publisher<DoorRequest>(
     FinalDoorRequestTopicName, default_qos);

--- a/rmf_fleet_adapter/src/experimental_lift_watchdog/main.cpp
+++ b/rmf_fleet_adapter/src/experimental_lift_watchdog/main.cpp
@@ -43,7 +43,7 @@ public:
       });
 
     permission_subscription = create_subscription<std_msgs::msg::Bool>(
-      "experimental_lift_permission", rclcpp::SystemDefaultsQoS(),
+      "experimental_lift_permission", rclcpp::SystemDefaultsQoS().keep_last(10),
       [=](std::shared_ptr<std_msgs::msg::Bool> msg)
       {
         permission_callback(msg);

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -1358,11 +1358,13 @@ std::shared_ptr<Connections> make_fleet(
 
   connections->path_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::PathRequest>(
-    rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
+    rmf_fleet_adapter::PathRequestTopicName,
+    rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->mode_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::ModeRequest>(
-    rmf_fleet_adapter::ModeRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
+    rmf_fleet_adapter::ModeRequestTopicName,
+    rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->fleet_state_sub = node->create_subscription<
     rmf_fleet_msgs::msg::FleetState>(

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -1027,7 +1027,7 @@ std::shared_ptr<Connections> make_fleet(
   connections->lane_closure_request_sub =
     adapter->node()->create_subscription<rmf_fleet_msgs::msg::LaneRequest>(
     rmf_fleet_adapter::LaneClosureRequestTopicName,
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().keep_last(10),
     [w = connections->weak_from_this(), fleet_name](
       rmf_fleet_msgs::msg::LaneRequest::UniquePtr request_msg)
     {
@@ -1071,7 +1071,7 @@ std::shared_ptr<Connections> make_fleet(
     adapter->node()->create_subscription<
     rmf_fleet_msgs::msg::SpeedLimitRequest>(
     rmf_fleet_adapter::SpeedLimitRequestTopicName,
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().keep_last(10),
     [w = connections->weak_from_this(), fleet_name](
       rmf_fleet_msgs::msg::SpeedLimitRequest::ConstSharedPtr request_msg)
     {
@@ -1099,7 +1099,7 @@ std::shared_ptr<Connections> make_fleet(
   connections->interrupt_request_sub =
     adapter->node()->create_subscription<rmf_fleet_msgs::msg::InterruptRequest>(
     rmf_fleet_adapter::InterruptRequestTopicName,
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().keep_last(10),
     [w = connections->weak_from_this(), fleet_name](
       rmf_fleet_msgs::msg::InterruptRequest::UniquePtr request_msg)
     {
@@ -1128,7 +1128,7 @@ std::shared_ptr<Connections> make_fleet(
   connections->mode_request_sub =
     adapter->node()->create_subscription<rmf_fleet_msgs::msg::ModeRequest>(
     "/action_execution_notice",
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().keep_last(10),
     [w = connections->weak_from_this(), fleet_name](
       rmf_fleet_msgs::msg::ModeRequest::UniquePtr msg)
     {
@@ -1358,16 +1358,16 @@ std::shared_ptr<Connections> make_fleet(
 
   connections->path_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::PathRequest>(
-    rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS());
+    rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->mode_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::ModeRequest>(
-    rmf_fleet_adapter::ModeRequestTopicName, rclcpp::SystemDefaultsQoS());
+    rmf_fleet_adapter::ModeRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->fleet_state_sub = node->create_subscription<
     rmf_fleet_msgs::msg::FleetState>(
     rmf_fleet_adapter::FleetStateTopicName,
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().keep_last(10),
     [c = std::weak_ptr<Connections>(connections), fleet_name](
       const rmf_fleet_msgs::msg::FleetState::SharedPtr msg)
     {

--- a/rmf_fleet_adapter/src/interrupt_robot/main.cpp
+++ b/rmf_fleet_adapter/src/interrupt_robot/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
   const auto publisher =
     node->create_publisher<Request>(
     rmf_fleet_adapter::InterruptRequestTopicName,
-    rclcpp::SystemDefaultsQoS());
+    rclcpp::SystemDefaultsQoS().keep_last(10));
 
   publisher->publish(request);
 

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -27,8 +27,8 @@ namespace lift_supervisor {
 Node::Node()
 : rclcpp::Node("rmf_lift_supervisor")
 {
-  const auto default_qos = rclcpp::SystemDefaultsQoS();
-  const auto transient_qos = rclcpp::SystemDefaultsQoS()
+  const auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
+  const auto transient_qos = rclcpp::SystemDefaultsQoS().keep_last(10)
     .reliable().keep_last(100).transient_local();
 
   _lift_request_pub = create_publisher<LiftRequest>(

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -27,8 +27,8 @@ namespace lift_supervisor {
 Node::Node()
 : rclcpp::Node("rmf_lift_supervisor")
 {
-  const auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
-  const auto transient_qos = rclcpp::SystemDefaultsQoS().keep_last(10)
+  const auto default_qos = rclcpp::SystemDefaultsQoS();
+  const auto transient_qos = rclcpp::SystemDefaultsQoS()
     .reliable().keep_last(100).transient_local();
 
   _lift_request_pub = create_publisher<LiftRequest>(

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -27,7 +27,7 @@ namespace lift_supervisor {
 Node::Node()
 : rclcpp::Node("rmf_lift_supervisor")
 {
-  const auto default_qos = rclcpp::SystemDefaultsQoS();
+  const auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
   const auto transient_qos = rclcpp::SystemDefaultsQoS()
     .reliable().keep_last(100).transient_local();
 

--- a/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
+++ b/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
@@ -797,15 +797,18 @@ std::shared_ptr<Connections> make_fleet(
 
   connections->path_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::PathRequest>(
-    rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
+    rmf_fleet_adapter::PathRequestTopicName,
+    rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->pause_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::PauseRequest>(
-    rmf_fleet_adapter::PauseRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
+    rmf_fleet_adapter::PauseRequestTopicName,
+    rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->mode_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::ModeRequest>(
-    rmf_fleet_adapter::ModeRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
+    rmf_fleet_adapter::ModeRequestTopicName,
+    rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->fleet_state_sub = node->create_subscription<
     rmf_fleet_msgs::msg::FleetState>(

--- a/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
+++ b/rmf_fleet_adapter/src/mock_traffic_light/main.cpp
@@ -797,20 +797,20 @@ std::shared_ptr<Connections> make_fleet(
 
   connections->path_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::PathRequest>(
-    rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS());
+    rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->pause_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::PauseRequest>(
-    rmf_fleet_adapter::PauseRequestTopicName, rclcpp::SystemDefaultsQoS());
+    rmf_fleet_adapter::PauseRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->mode_request_pub = node->create_publisher<
     rmf_fleet_msgs::msg::ModeRequest>(
-    rmf_fleet_adapter::ModeRequestTopicName, rclcpp::SystemDefaultsQoS());
+    rmf_fleet_adapter::ModeRequestTopicName, rclcpp::SystemDefaultsQoS().keep_last(10));
 
   connections->fleet_state_sub = node->create_subscription<
     rmf_fleet_msgs::msg::FleetState>(
     rmf_fleet_adapter::FleetStateTopicName,
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().keep_last(10),
     [c = std::weak_ptr<Connections>(connections), fleet_name](
       const rmf_fleet_msgs::msg::FleetState::SharedPtr msg)
     {
@@ -850,7 +850,7 @@ std::shared_ptr<Connections> make_fleet(
   connections->loop_sub = node->create_subscription<
     rmf_task_msgs::msg::Loop>(
     rmf_fleet_adapter::LoopRequestTopicName,
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().keep_last(10),
     [c = std::weak_ptr<Connections>(connections), fleet_name](
       const rmf_task_msgs::msg::Loop::SharedPtr msg)
     {

--- a/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp
+++ b/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp
@@ -47,7 +47,7 @@ public:
   Node()
   : rclcpp::Node("mutex_group_supervisor")
   {
-    const auto qos = rclcpp::SystemDefaultsQoS().keep_last(10)
+    const auto qos = rclcpp::SystemDefaultsQoS()
       .reliable()
       .transient_local()
       .keep_last(100);

--- a/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp
+++ b/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp
@@ -47,7 +47,7 @@ public:
   Node()
   : rclcpp::Node("mutex_group_supervisor")
   {
-    const auto qos = rclcpp::SystemDefaultsQoS()
+    const auto qos = rclcpp::SystemDefaultsQoS().keep_last(10)
       .reliable()
       .transient_local()
       .keep_last(100);

--- a/rmf_fleet_adapter/src/open_lanes/main.cpp
+++ b/rmf_fleet_adapter/src/open_lanes/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
   const auto publisher =
     node->create_publisher<rmf_fleet_msgs::msg::LaneRequest>(
     rmf_fleet_adapter::LaneClosureRequestTopicName,
-    rclcpp::SystemDefaultsQoS().transient_local());
+    rclcpp::SystemDefaultsQoS().keep_last(10).transient_local());
 
   publisher->publish(request);
 
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
   const auto listener =
     node->create_subscription<rmf_fleet_msgs::msg::ClosedLanes>(
     rmf_fleet_adapter::ClosedLaneTopicName,
-    rclcpp::SystemDefaultsQoS().transient_local(),
+    rclcpp::SystemDefaultsQoS().keep_last(10).transient_local(),
     [&request_complete, fleet_name, open_lanes = std::move(open_lanes)](
       std::unique_ptr<rmf_fleet_msgs::msg::ClosedLanes> msg)
     {

--- a/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
@@ -73,7 +73,7 @@ std::shared_ptr<FleetAdapterNode> FleetAdapterNode::make()
       // Don't subscribe until everything else is ready
       node->_fleet_state_subscription =
         node->create_subscription<FleetState>(
-        FleetStateTopicName, rclcpp::SystemDefaultsQoS(),
+        FleetStateTopicName, rclcpp::SystemDefaultsQoS().keep_last(10),
         [self = node.get()](FleetState::UniquePtr msg)
         {
           self->fleet_state_update(std::move(msg));

--- a/rmf_fleet_adapter/src/read_only_blockade/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/read_only_blockade/FleetAdapterNode.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<FleetAdapterNode> FleetAdapterNode::make()
 
       node->_fleet_state_subscription =
         node->create_subscription<FleetState>(
-        FleetStateTopicName, rclcpp::SystemDefaultsQoS(),
+        FleetStateTopicName, rclcpp::SystemDefaultsQoS().keep_last(10),
         [self = node.get()](FleetState::UniquePtr msg)
         {
           self->fleet_state_update(std::move(msg));

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<Node> Node::make(
   auto node = std::shared_ptr<Node>(
     new Node(std::move(worker), node_name, options));
 
-  auto default_qos = rclcpp::SystemDefaultsQoS();
+  auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
   default_qos.keep_last(100);
   auto transient_qos = rclcpp::SystemDefaultsQoS()
     .reliable().keep_last(100).transient_local();

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -34,9 +34,9 @@ std::shared_ptr<Node> Node::make(
   auto node = std::shared_ptr<Node>(
     new Node(std::move(worker), node_name, options));
 
-  auto default_qos = rclcpp::SystemDefaultsQoS();
+  auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
   default_qos.keep_last(100);
-  auto transient_qos = rclcpp::SystemDefaultsQoS()
+  auto transient_qos = rclcpp::SystemDefaultsQoS().keep_last(10)
     .reliable().keep_last(100).transient_local();
 
   node->_door_state_obs =
@@ -95,7 +95,7 @@ std::shared_ptr<Node> Node::make(
     node->create_publisher<FleetState>(
     FleetStateTopicName, default_qos);
 
-  auto transient_local_qos = rclcpp::SystemDefaultsQoS()
+  auto transient_local_qos = rclcpp::SystemDefaultsQoS().keep_last(10)
     .reliable()
     .transient_local()
     .keep_last(100);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -34,9 +34,9 @@ std::shared_ptr<Node> Node::make(
   auto node = std::shared_ptr<Node>(
     new Node(std::move(worker), node_name, options));
 
-  auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
+  auto default_qos = rclcpp::SystemDefaultsQoS();
   default_qos.keep_last(100);
-  auto transient_qos = rclcpp::SystemDefaultsQoS().keep_last(10)
+  auto transient_qos = rclcpp::SystemDefaultsQoS()
     .reliable().keep_last(100).transient_local();
 
   node->_door_state_obs =
@@ -95,7 +95,7 @@ std::shared_ptr<Node> Node::make(
     node->create_publisher<FleetState>(
     FleetStateTopicName, default_qos);
 
-  auto transient_local_qos = rclcpp::SystemDefaultsQoS().keep_last(10)
+  auto transient_local_qos = rclcpp::SystemDefaultsQoS()
     .reliable()
     .transient_local()
     .keep_last(100);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -34,8 +34,7 @@ std::shared_ptr<Node> Node::make(
   auto node = std::shared_ptr<Node>(
     new Node(std::move(worker), node_name, options));
 
-  auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
-  default_qos.keep_last(100);
+  auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(100);
   auto transient_qos = rclcpp::SystemDefaultsQoS()
     .reliable().keep_last(100).transient_local();
 

--- a/rmf_fleet_adapter/src/robot_state_aggregator/RobotStateAggregator.cpp
+++ b/rmf_fleet_adapter/src/robot_state_aggregator/RobotStateAggregator.cpp
@@ -43,7 +43,7 @@ public:
   : rclcpp::Node("robot_state_aggregator", options)
   {
     RCLCPP_DEBUG(get_logger(), "RobotStateAggregator called");
-    const auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
+    const auto default_qos = rclcpp::SystemDefaultsQoS();
     const auto state_qos = rclcpp::SystemDefaultsQoS().keep_last(100);
 
 #ifdef FAILOVER_MODE

--- a/rmf_fleet_adapter/src/robot_state_aggregator/RobotStateAggregator.cpp
+++ b/rmf_fleet_adapter/src/robot_state_aggregator/RobotStateAggregator.cpp
@@ -43,7 +43,7 @@ public:
   : rclcpp::Node("robot_state_aggregator", options)
   {
     RCLCPP_DEBUG(get_logger(), "RobotStateAggregator called");
-    const auto default_qos = rclcpp::SystemDefaultsQoS();
+    const auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
     const auto state_qos = rclcpp::SystemDefaultsQoS().keep_last(100);
 
 #ifdef FAILOVER_MODE

--- a/rmf_fleet_adapter/test/dump_fleet_states.cpp
+++ b/rmf_fleet_adapter/test/dump_fleet_states.cpp
@@ -60,7 +60,7 @@ public:
   : rclcpp::Node("dump_test_fleet_states")
   {
     fleet_state_publisher = create_publisher<FleetState>(
-      "/fleet_states", rclcpp::SystemDefaultsQoS());
+      "/fleet_states", rclcpp::SystemDefaultsQoS().keep_last(10));
 
     timer = create_wall_timer(
       std::chrono::milliseconds(period_ms), [&]() { update(); });

--- a/rmf_fleet_adapter/test/tasks/test_Delivery.cpp
+++ b/rmf_fleet_adapter/test/tasks/test_Delivery.cpp
@@ -62,7 +62,7 @@ public:
     dispenser->_request_sub =
       dispenser->_node->create_subscription<DispenserRequest>(
       rmf_fleet_adapter::DispenserRequestTopicName,
-      rclcpp::SystemDefaultsQoS(),
+      rclcpp::SystemDefaultsQoS().keep_last(10),
       [me = dispenser->weak_from_this()](DispenserRequest::SharedPtr msg)
       {
         if (const auto self = me.lock())
@@ -72,7 +72,7 @@ public:
     dispenser->_result_pub =
       dispenser->_node->create_publisher<DispenserResult>(
       rmf_fleet_adapter::DispenserResultTopicName,
-      rclcpp::SystemDefaultsQoS());
+      rclcpp::SystemDefaultsQoS().keep_last(10));
 
     return dispenser;
   }
@@ -171,7 +171,7 @@ public:
     ingestor->_request_sub =
       ingestor->_node->create_subscription<IngestorRequest>(
       rmf_fleet_adapter::IngestorRequestTopicName,
-      rclcpp::SystemDefaultsQoS(),
+      rclcpp::SystemDefaultsQoS().keep_last(10),
       [me = ingestor->weak_from_this()](IngestorRequest::SharedPtr msg)
       {
         if (const auto self = me.lock())
@@ -180,7 +180,7 @@ public:
 
     ingestor->_state_pub = ingestor->_node->create_publisher<IngestorState>(
       rmf_fleet_adapter::IngestorStateTopicName,
-      rclcpp::SystemDefaultsQoS());
+      rclcpp::SystemDefaultsQoS().keep_last(10));
 
     using namespace std::chrono_literals;
     ingestor->_timer = ingestor->_node->create_wall_timer(

--- a/rmf_fleet_adapter/test/test_read_only_adapter.cpp
+++ b/rmf_fleet_adapter/test/test_read_only_adapter.cpp
@@ -54,16 +54,16 @@ public:
     // publisher to send FleetState messages to fleet adapter
     _fleet_state_pub = create_publisher<FleetState>(
       rmf_fleet_adapter::FleetStateTopicName,
-      rclcpp::SystemDefaultsQoS());
+      rclcpp::SystemDefaultsQoS().keep_last(10));
 
     // publisher to send String messages to rmf_schedule_visualizer node
     _viz_pub = create_publisher<String>(
-      _viz_name + "/debug", rclcpp::SystemDefaultsQoS());
+      _viz_name + "/debug", rclcpp::SystemDefaultsQoS().keep_last(10));
 
     // subscription to receive String messages which control execution of
     // this node
     _cmd_sub = create_subscription<String>(
-      "test_adapter_" + _fleet_name+"/cmd", rclcpp::SystemDefaultsQoS(),
+      "test_adapter_" + _fleet_name+"/cmd", rclcpp::SystemDefaultsQoS().keep_last(10),
       [&](String::UniquePtr msg)
       {
         // receive commands through ros2 msg

--- a/rmf_fleet_adapter/test/test_read_only_adapter.cpp
+++ b/rmf_fleet_adapter/test/test_read_only_adapter.cpp
@@ -63,7 +63,8 @@ public:
     // subscription to receive String messages which control execution of
     // this node
     _cmd_sub = create_subscription<String>(
-      "test_adapter_" + _fleet_name+"/cmd", rclcpp::SystemDefaultsQoS().keep_last(10),
+      "test_adapter_" + _fleet_name+"/cmd",
+      rclcpp::SystemDefaultsQoS().keep_last(10),
       [&](String::UniquePtr msg)
       {
         // receive commands through ros2 msg

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -261,7 +261,7 @@ public:
     // names
     api_request = node->create_subscription<ApiRequestMsg>(
       "task_api_requests",
-      rclcpp::SystemDefaultsQoS().reliable().transient_local(),
+      rclcpp::SystemDefaultsQoS().keep_last(10).reliable().transient_local(),
       [this](const ApiRequestMsg::UniquePtr msg)
       {
         this->handle_api_request(*msg);
@@ -269,7 +269,7 @@ public:
 
     api_response = node->create_publisher<ApiResponseMsg>(
       "task_api_responses",
-      rclcpp::SystemDefaultsQoS().reliable().transient_local());
+      rclcpp::SystemDefaultsQoS().keep_last(10).reliable().transient_local());
 
     // TODO(MXG): The smallest resolution this supports is 1 second. That
     // doesn't seem great.

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -261,7 +261,7 @@ public:
     // names
     api_request = node->create_subscription<ApiRequestMsg>(
       "task_api_requests",
-      rclcpp::SystemDefaultsQoS().keep_last(10).reliable().transient_local(),
+      rclcpp::SystemDefaultsQoS().reliable().transient_local(),
       [this](const ApiRequestMsg::UniquePtr msg)
       {
         this->handle_api_request(*msg);
@@ -269,7 +269,7 @@ public:
 
     api_response = node->create_publisher<ApiResponseMsg>(
       "task_api_responses",
-      rclcpp::SystemDefaultsQoS().keep_last(10).reliable().transient_local());
+      rclcpp::SystemDefaultsQoS().reliable().transient_local());
 
     // TODO(MXG): The smallest resolution this supports is 1 second. That
     // doesn't seem great.

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/blockade/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/blockade/Node.cpp
@@ -48,7 +48,7 @@ public:
     blockade_set_sub =
       create_subscription<SetMsg>(
       BlockadeSetTopicName,
-      rclcpp::SystemDefaultsQoS().best_effort(),
+      rclcpp::SystemDefaultsQoS().keep_last(10).best_effort(),
       [=](const SetMsg::UniquePtr msg)
       {
         this->blockade_set(*msg);
@@ -57,7 +57,7 @@ public:
     blockade_ready_sub =
       create_subscription<ReadyMsg>(
       BlockadeReadyTopicName,
-      rclcpp::SystemDefaultsQoS().best_effort(),
+      rclcpp::SystemDefaultsQoS().keep_last(10).best_effort(),
       [=](const ReadyMsg::UniquePtr msg)
       {
         this->blockade_ready(*msg);
@@ -66,7 +66,7 @@ public:
     blockade_reached_sub =
       create_subscription<ReachedMsg>(
       BlockadeReachedTopicName,
-      rclcpp::SystemDefaultsQoS().best_effort(),
+      rclcpp::SystemDefaultsQoS().keep_last(10).best_effort(),
       [=](const ReachedMsg::UniquePtr msg)
       {
         this->blockade_reached(*msg);
@@ -75,7 +75,7 @@ public:
     blockade_release_sub =
       create_subscription<ReleaseMsg>(
       BlockadeReleaseTopicName,
-      rclcpp::SystemDefaultsQoS().best_effort(),
+      rclcpp::SystemDefaultsQoS().keep_last(10).best_effort(),
       [=](const ReleaseMsg::UniquePtr msg)
       {
         this->blockade_release(*msg);
@@ -84,7 +84,7 @@ public:
     blockade_cancel_sub =
       create_subscription<CancelMsg>(
       BlockadeCancelTopicName,
-      rclcpp::SystemDefaultsQoS().best_effort(),
+      rclcpp::SystemDefaultsQoS().keep_last(10).best_effort(),
       [=](const CancelMsg::UniquePtr msg)
       {
         this->blockade_cancel(*msg);
@@ -92,7 +92,7 @@ public:
 
     heartbeat_pub = create_publisher<HeartbeatMsg>(
       BlockadeHeartbeatTopicName,
-      rclcpp::SystemDefaultsQoS().reliable());
+      rclcpp::SystemDefaultsQoS().keep_last(10).reliable());
 
     heartbeat_timer = create_wall_timer(
       std::chrono::seconds(1),

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/blockade/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/blockade/Writer.cpp
@@ -101,7 +101,7 @@ public:
   {
     heartbeat_sub = node.create_subscription<HeartbeatMsg>(
       BlockadeHeartbeatTopicName,
-      rclcpp::SystemDefaultsQoS().reliable(),
+      rclcpp::SystemDefaultsQoS().keep_last(10).reliable(),
       [&](const HeartbeatMsg::UniquePtr msg)
       {
         check_status(*msg);
@@ -271,23 +271,23 @@ public:
     {
       set_pub = node.create_publisher<Set>(
         BlockadeSetTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort());
+        rclcpp::SystemDefaultsQoS().keep_last(10).best_effort());
 
       ready_pub = node.create_publisher<Ready>(
         BlockadeReadyTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort());
+        rclcpp::SystemDefaultsQoS().keep_last(10).best_effort());
 
       reached_pub = node.create_publisher<Reached>(
         BlockadeReachedTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort());
+        rclcpp::SystemDefaultsQoS().keep_last(10).best_effort());
 
       release_pub = node.create_publisher<Release>(
         BlockadeReleaseTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort());
+        rclcpp::SystemDefaultsQoS().keep_last(10).best_effort());
 
       cancel_pub = node.create_publisher<Cancel>(
         BlockadeCancelTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort());
+        rclcpp::SystemDefaultsQoS().keep_last(10).best_effort());
     }
 
     using ParticipantId = rmf_traffic::blockade::ParticipantId;

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
@@ -117,7 +117,7 @@ public:
 
     schedule_startup_sub = node->create_subscription<ScheduleIdentity>(
       rmf_traffic_ros2::ScheduleStartupTopicName,
-      rclcpp::SystemDefaultsQoS().keep_last(10),
+      rclcpp::SystemDefaultsQoS(),
       [&](const ScheduleIdentity::SharedPtr msg)
       {
         handle_startup_event(*msg);

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/MirrorManager.cpp
@@ -117,7 +117,7 @@ public:
 
     schedule_startup_sub = node->create_subscription<ScheduleIdentity>(
       rmf_traffic_ros2::ScheduleStartupTopicName,
-      rclcpp::SystemDefaultsQoS(),
+      rclcpp::SystemDefaultsQoS().keep_last(10),
       [&](const ScheduleIdentity::SharedPtr msg)
       {
         handle_startup_event(*msg);

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -344,7 +344,7 @@ void ScheduleNode::setup_changes_services()
 void ScheduleNode::setup_itinerary_topics()
 {
   const auto itinerary_qos =
-    rclcpp::SystemDefaultsQoS().keep_last(10)
+    rclcpp::SystemDefaultsQoS()
     .reliable()
     .keep_last(100);
 
@@ -400,7 +400,7 @@ void ScheduleNode::setup_incosistency_pub()
   inconsistency_pub =
     create_publisher<InconsistencyMsg>(
     rmf_traffic_ros2::ScheduleInconsistencyTopicName,
-    rclcpp::SystemDefaultsQoS().keep_last(10).reliable());
+    rclcpp::SystemDefaultsQoS().reliable());
 }
 
 //==============================================================================
@@ -452,7 +452,7 @@ void ScheduleNode::setup_conflict_topics_and_thread()
     rmf_traffic_ros2::NegotiationConclusionTopicName, negotiation_qos);
 
   const auto single_reliable_transient_local =
-    rclcpp::SystemDefaultsQoS().keep_last(10)
+    rclcpp::SystemDefaultsQoS()
     .keep_last(1)
     .reliable()
     .transient_local();
@@ -634,7 +634,7 @@ void ScheduleNode::setup_redundancy()
   start_heartbeat();
 
   const auto permanent_reliable_single_transient_local =
-    rclcpp::SystemDefaultsQoS().keep_last(10)
+    rclcpp::SystemDefaultsQoS()
     .reliable()
     .keep_last(1)
     .transient_local();
@@ -656,7 +656,7 @@ void ScheduleNode::setup_redundancy()
   startup_pub->publish(node_id);
 
   const auto reliable_10_transient_local =
-    rclcpp::SystemDefaultsQoS().keep_last(10)
+    rclcpp::SystemDefaultsQoS()
     .reliable()
     .keep_last(10)
     .transient_local();

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -344,7 +344,7 @@ void ScheduleNode::setup_changes_services()
 void ScheduleNode::setup_itinerary_topics()
 {
   const auto itinerary_qos =
-    rclcpp::SystemDefaultsQoS()
+    rclcpp::SystemDefaultsQoS().keep_last(10)
     .reliable()
     .keep_last(100);
 
@@ -400,7 +400,7 @@ void ScheduleNode::setup_incosistency_pub()
   inconsistency_pub =
     create_publisher<InconsistencyMsg>(
     rmf_traffic_ros2::ScheduleInconsistencyTopicName,
-    rclcpp::SystemDefaultsQoS().reliable());
+    rclcpp::SystemDefaultsQoS().keep_last(10).reliable());
 }
 
 //==============================================================================
@@ -452,7 +452,7 @@ void ScheduleNode::setup_conflict_topics_and_thread()
     rmf_traffic_ros2::NegotiationConclusionTopicName, negotiation_qos);
 
   const auto single_reliable_transient_local =
-    rclcpp::SystemDefaultsQoS()
+    rclcpp::SystemDefaultsQoS().keep_last(10)
     .keep_last(1)
     .reliable()
     .transient_local();
@@ -634,7 +634,7 @@ void ScheduleNode::setup_redundancy()
   start_heartbeat();
 
   const auto permanent_reliable_single_transient_local =
-    rclcpp::SystemDefaultsQoS()
+    rclcpp::SystemDefaultsQoS().keep_last(10)
     .reliable()
     .keep_last(1)
     .transient_local();
@@ -656,7 +656,7 @@ void ScheduleNode::setup_redundancy()
   startup_pub->publish(node_id);
 
   const auto reliable_10_transient_local =
-    rclcpp::SystemDefaultsQoS()
+    rclcpp::SystemDefaultsQoS().keep_last(10)
     .reliable()
     .keep_last(10)
     .transient_local();

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -400,7 +400,7 @@ void ScheduleNode::setup_incosistency_pub()
   inconsistency_pub =
     create_publisher<InconsistencyMsg>(
     rmf_traffic_ros2::ScheduleInconsistencyTopicName,
-    rclcpp::SystemDefaultsQoS().reliable());
+    rclcpp::SystemDefaultsQoS().keep_last(10).reliable());
 }
 
 //==============================================================================

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -309,7 +309,7 @@ public:
       auto transport = std::shared_ptr<Transport>(new Transport(node));
 
       const auto itinerary_qos =
-        rclcpp::SystemDefaultsQoS().keep_last(10)
+        rclcpp::SystemDefaultsQoS()
         .reliable()
         .keep_last(100);
 
@@ -343,7 +343,7 @@ public:
 
       transport->schedule_startup_sub = node->create_subscription<ScheduleId>(
         rmf_traffic_ros2::ScheduleStartupTopicName,
-        rclcpp::SystemDefaultsQoS().keep_last(10),
+        rclcpp::SystemDefaultsQoS(),
         [w = transport->weak_from_this()](const ScheduleId::SharedPtr msg)
         {
           if (const auto self = w.lock())

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -343,7 +343,7 @@ public:
 
       transport->schedule_startup_sub = node->create_subscription<ScheduleId>(
         rmf_traffic_ros2::ScheduleStartupTopicName,
-        rclcpp::SystemDefaultsQoS(),
+        rclcpp::SystemDefaultsQoS().keep_last(10),
         [w = transport->weak_from_this()](const ScheduleId::SharedPtr msg)
         {
           if (const auto self = w.lock())

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -309,7 +309,7 @@ public:
       auto transport = std::shared_ptr<Transport>(new Transport(node));
 
       const auto itinerary_qos =
-        rclcpp::SystemDefaultsQoS()
+        rclcpp::SystemDefaultsQoS().keep_last(10)
         .reliable()
         .keep_last(100);
 
@@ -343,7 +343,7 @@ public:
 
       transport->schedule_startup_sub = node->create_subscription<ScheduleId>(
         rmf_traffic_ros2::ScheduleStartupTopicName,
-        rclcpp::SystemDefaultsQoS(),
+        rclcpp::SystemDefaultsQoS().keep_last(10),
         [w = transport->weak_from_this()](const ScheduleId::SharedPtr msg)
         {
           if (const auto self = w.lock())
@@ -367,7 +367,7 @@ public:
       transport->inconsistency_sub =
         node->create_subscription<InconsistencyMsg>(
         ScheduleInconsistencyTopicName,
-        rclcpp::SystemDefaultsQoS().reliable(),
+        rclcpp::SystemDefaultsQoS().keep_last(10).reliable(),
         [w = transport->weak_from_this()](const InconsistencyMsg::UniquePtr msg)
         {
           if (const auto self = w.lock())


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

Thanks to @luca-della-vedova for pointing out that using the system default qos might not be appropriate as that depends on the RMW implementation, particularly, for cyclone, it defaults to history depth 1, making it very likely for messages to be silently discarded.

This series of PRs explicitly set a history depth of 10 to all topics and services that does not already set the history depth, those that already set the history depth are untouched. In total 69 instances across rmf codebases are modified, I tested this briefly, so far I haven't encountered any problems yet.

@aaronchongth This might fix some of the "unexplained" issues.

For reference, this is the regex used

search: `(rclcpp::SystemDefaultsQoS\(\)(?![^;,]*keep_last\())((?:.|\n)*?[;,])`
replace: `$1.keep_last(10)$2`

### Implemented feature

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

### Implementation description

<!-- Describe the approach taken to implement the feature.
Provide a link to a detailed design document and discussion of that design.
Implementations without design documentation will not be accepted until design documentation has been provided and discussed.
Usually this is done via the feature request issue. -->
