### PR TITLE
Add Backward-ROS for improved logging in event of segfaults

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -11,6 +11,7 @@ add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(Threads REQUIRED)

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -36,6 +36,7 @@
   <depend>rmf_websocket</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>nlohmann_json_schema_validator_vendor</depend>
+  <depend>backward_ros</depend>
 
   <build_depend>eigen</build_depend>
   <build_depend>yaml-cpp</build_depend>

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -12,31 +12,33 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rclcpp</depend>
+
+  <depend>backward_ros</depend>
+  <depend>nlohmann_json_schema_validator_vendor</depend>
+  <depend>nlohmann-json-dev</depend>
   <depend>rclcpp_components</depend>
-  <depend>rmf_utils</depend>
-  <depend>rmf_door_msgs</depend>
-  <depend>rmf_ingestor_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rmf_api_msgs</depend>
+  <depend>rmf_battery</depend>
+  <depend>rmf_building_map_msgs</depend>
   <depend>rmf_dispenser_msgs</depend>
+  <depend>rmf_door_msgs</depend>
   <depend>rmf_fleet_msgs</depend>
+  <depend>rmf_ingestor_msgs</depend>
   <depend>rmf_lift_msgs</depend>
   <depend>rmf_task_msgs</depend>
-  <depend>rmf_traffic</depend>
-  <depend>rmf_traffic_ros2</depend>
   <depend>rmf_task_ros2</depend>
-  <depend>rmf_battery</depend>
-  <depend>rmf_task</depend>
   <depend>rmf_task_sequence</depend>
-  <depend>std_msgs</depend>
-  <depend>rmf_api_msgs</depend>
-  <depend>rmf_building_map_msgs</depend>
-  <depend condition="$RMF_ENABLE_FAILOVER == 1">stubborn_buddies</depend>
-  <depend condition="$RMF_ENABLE_FAILOVER == 1">stubborn_buddies_msgs</depend>
-
+  <depend>rmf_task</depend>
+  <depend>rmf_traffic_ros2</depend>
+  <depend>rmf_traffic</depend>
+  <depend>rmf_utils</depend>
   <depend>rmf_websocket</depend>
-  <depend>nlohmann-json-dev</depend>
-  <depend>nlohmann_json_schema_validator_vendor</depend>
-  <depend>backward_ros</depend>
+  <depend>std_msgs</depend>
+
+  <depend condition="$RMF_ENABLE_FAILOVER == 1">stubborn_buddies_msgs</depend>
+  <depend condition="$RMF_ENABLE_FAILOVER == 1">stubborn_buddies</depend>
+
 
   <build_depend>eigen</build_depend>
   <build_depend>yaml-cpp</build_depend>

--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 include(GNUInstallDirs)
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(rmf_api_msgs REQUIRED)
 find_package(rmf_traffic REQUIRED)
 find_package(rmf_traffic_ros2 REQUIRED)

--- a/rmf_task_ros2/package.xml
+++ b/rmf_task_ros2/package.xml
@@ -10,16 +10,16 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rmf_utils</depend>
-  <depend>rmf_api_msgs</depend>
-  <depend>rmf_traffic</depend>
-  <depend>rmf_traffic_ros2</depend>
-  <depend>rmf_task_msgs</depend>
-  <depend>rclcpp</depend>
-  <depend>rmf_websocket</depend>
-  <depend>nlohmann-json-dev</depend>
-  <depend>nlohmann_json_schema_validator_vendor</depend>
   <depend>backward_ros</depend>
+  <depend>nlohmann_json_schema_validator_vendor</depend>
+  <depend>nlohmann-json-dev</depend>
+  <depend>rclcpp</depend>
+  <depend>rmf_api_msgs</depend>
+  <depend>rmf_task_msgs</depend>
+  <depend>rmf_traffic_ros2</depend>
+  <depend>rmf_traffic</depend>
+  <depend>rmf_utils</depend>
+  <depend>rmf_websocket</depend>
 
   <build_depend>eigen</build_depend>
 

--- a/rmf_task_ros2/package.xml
+++ b/rmf_task_ros2/package.xml
@@ -19,6 +19,7 @@
   <depend>rmf_websocket</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>nlohmann_json_schema_validator_vendor</depend>
+  <depend>backward_ros</depend>
 
   <build_depend>eigen</build_depend>
 

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake)
 include(GNUInstallDirs)
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(rmf_traffic 3 REQUIRED)
 find_package(rmf_traffic_msgs REQUIRED)
 find_package(rmf_site_map_msgs REQUIRED)

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -22,6 +22,7 @@
   <depend>nlohmann-json-dev</depend>
   <depend>proj</depend>
   <depend>zlib</depend>
+  <depend>backward_ros</depend>
 
   <build_depend>uuid</build_depend>
   <exec_depend>uuid</exec_depend>

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -11,18 +11,18 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rmf_utils</depend>
-  <depend>rmf_traffic</depend>
-  <depend>rmf_traffic_msgs</depend>
-  <depend>rmf_fleet_msgs</depend>
-  <depend>rmf_site_map_msgs</depend>
-  <depend>rmf_building_map_msgs</depend>
-  <depend>rclcpp</depend>
-  <depend>yaml-cpp</depend>
+  <depend>backward_ros</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>proj</depend>
+  <depend>rclcpp</depend>
+  <depend>rmf_building_map_msgs</depend>
+  <depend>rmf_fleet_msgs</depend>
+  <depend>rmf_site_map_msgs</depend>
+  <depend>rmf_traffic_msgs</depend>
+  <depend>rmf_traffic</depend>
+  <depend>rmf_utils</depend>
+  <depend>yaml-cpp</depend>
   <depend>zlib</depend>
-  <depend>backward_ros</depend>
 
   <build_depend>uuid</build_depend>
   <exec_depend>uuid</exec_depend>


### PR DESCRIPTION
## New feature implementation

### Implemented feature

[`backward-ros`](https://github.com/pal-robotics/backward_ros/) provides a clean way to catch unhandled exceptions and segfaults and is able to print a stack trace when a program crashes. This PR adds `backward-ros` to rmf ros2 nodes so that we can trace causes for segfaults.

Note: This will only work for pure C++ nodes. If we want logging in downstream fleet adapters they will have to handle that themselves either using `backward-cpp` or `faulthandler` in python.

