### PR TITLE
include cstdint header

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -18,6 +18,7 @@
 #ifndef RMF_FLEET_ADAPTER__STANDARDNAMES_HPP
 #define RMF_FLEET_ADAPTER__STANDARDNAMES_HPP
 
+#include <cstdint>
 #include <string>
 
 namespace rmf_fleet_adapter {


### PR DESCRIPTION
Rolling job on Noble is failing. See https://build.ros2.org/job/Rbin_uN64__rmf_fleet_adapter__ubuntu_noble_amd64__binary/4/consoleFull

```bash
14:33:17 In file included from /tmp/binarydeb/ros-rolling-rmf-fleet-adapter-2.5.0/src/mutex_group_supervisor/main.cpp:18:
14:33:17 /tmp/binarydeb/ros-rolling-rmf-fleet-adapter-2.5.0/include/rmf_fleet_adapter/StandardNames.hpp:76:7: error: ‘uint64_t’ does not name a type
14:33:17    76 | const uint64_t Unclaimed = (uint64_t)(-1);
14:33:17       |       ^~~~~~~~
14:33:17 /tmp/binarydeb/ros-rolling-rmf-fleet-adapter-2.5.0/include/rmf_fleet_adapter/StandardNames.hpp:22:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
14:33:17    21 | #include <string>
14:33:17   +++ |+#include <cstdint>
14:33:17    22 | 
14:33:17 /tmp/binarydeb/ros-rolling-rmf-fleet-adapter-2.5.0/src/mutex_group_supervisor/main.cpp:42:47: error: ‘Unclaimed’ is not a member of ‘rmf_fleet_adapter’; did you mean ‘Unclaimed’?
14:33:17    42 | const uint64_t Unclaimed = rmf_fleet_adapter::Unclaimed;
14:33:17       |                                               ^~~~~~~~~
14:33:17 /tmp/binarydeb/ros-rolling-rmf-fleet-adapter-2.5.0/src/mutex_group_supervisor/main.cpp:42:16: note: ‘Unclaimed’ declared here
14:33:17    42 | const uint64_t Unclaimed = rmf_fleet_adapter::Unclaimed;
```