### PR TITLE
Fix interaction between emergency pullover and finishing task

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1383,8 +1383,8 @@ void TaskManager::_begin_pullover()
 {
   _finished_waiting = false;
   auto task_id = "emergency_pullover." + _context->name() + "."
-  + _context->group() + "-"
-  + std::to_string(_count_emergency_pullover++);
+    + _context->group() + "-"
+    + std::to_string(_count_emergency_pullover++);
   _context->current_task_id(task_id);
 
   // TODO(MXG): Consider subscribing to the emergency pullover update

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -382,6 +382,10 @@ private:
   /// Callback for task timer which begins next task if its deployment time has passed
   void _begin_next_task();
 
+  /// Begin performing an emergency pullover. This should only be called when an
+  /// emergency is active.
+  void _begin_pullover();
+
   // Interrupts that were issued when there was no active task. They will be
   // applied when a task becomes active.
   //


### PR DESCRIPTION
When an emergency pullover interrupts a finishing task, the robots that were doing the finishing task would not resume the finishing task correctly.

With this PR, finishing tasks will resume correctly after an emergency pullover is released.