### PR TITLE
Release other mutexes if robot started charging

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -94,6 +94,19 @@ WaitForCharge::Active::Active(
     .get_observable()
     .start_with(initial_msg);
 
+  // If the charging waypoint has a mutex group, release all other mutexes
+  std::unordered_set<std::string> retain_mutexes;
+  const auto charging_waypoint = _context->dedicated_charging_wp();
+  const auto& graph = _context->navigation_graph();
+  retain_mutexes.insert(
+    graph.get_waypoint(charging_waypoint).in_mutex_group());
+  _context->retain_mutex_groups(retain_mutexes);
+  RCLCPP_INFO(
+    _context->node()->get_logger(),
+    "Robot [%s] has begun charging, releasing all other mutexes. If there is "
+    "a mutex group on the dedicated charging waypoint, it will be retained.",
+    _context->name().c_str());
+
   _context->current_mode(rmf_fleet_msgs::msg::RobotMode::MODE_CHARGING);
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -101,11 +101,22 @@ WaitForCharge::Active::Active(
   retain_mutexes.insert(
     graph.get_waypoint(charging_waypoint).in_mutex_group());
   _context->retain_mutex_groups(retain_mutexes);
-  RCLCPP_INFO(
-    _context->node()->get_logger(),
-    "Robot [%s] has begun charging, releasing all other mutexes. If there is "
-    "a mutex group on the dedicated charging waypoint, it will be retained.",
-    _context->name().c_str());
+
+  if (retain_mutexes.begin()->empty())
+  {
+    RCLCPP_INFO(
+      _context->node()->get_logger(),
+      "Robot [%s] is waiting to charge. All its mutex groups will be released.",
+      _context->name().c_str());
+  }
+  else
+  {
+    RCLCPP_INFO(
+      _context->node()->get_logger(),
+      "Robot [%s] is waiting to charge. It will retain only the mutex group [%s].",
+      _context->name().c_str(),
+      retain_mutexes.begin()->c_str());
+  }
 
   _context->current_mode(rmf_fleet_msgs::msg::RobotMode::MODE_CHARGING);
 }


### PR DESCRIPTION
This PR aims to release any mutex groups a robot may be holding once it starts charging at its dedicated charging waypoint. This is to ensure that mutex groups won't be stuck with a stationary robot for an indefinite period of time, blocking other robots from moving into these mutexes.