### PR TITLE
Stabilize commissioning feature

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -419,11 +419,13 @@ public:
     /// Construct a Commission description with all default values.
     /// - accept_dispatched_tasks: true
     /// - accept_direct_tasks: true
+    /// - is_performing_idle_behavior: true
     Commission();
 
     /// Construct a Commission description that accepts no tasks at all.
     /// - accept_dispatch_tasks: false
     /// - accept_direct_tasks: false
+    /// - is_performing_idle_behavior: false
     static Commission decommission();
 
     /// Set whether this commission should accept dispatched tasks.
@@ -437,6 +439,14 @@ public:
 
     /// Check whether this commission is accepting direct tasks.
     bool is_accepting_direct_tasks() const;
+
+    /// Set whether this commission should perform idle behaviors (formerly
+    /// referred to as "finishing tasks").
+    Commission& perform_idle_behavior(bool decision=true);
+
+    /// Check whether this commission is performing idle behaviors (formerly
+    /// referred to as "finishing tasks").
+    bool is_performing_idle_behavior() const;
 
     class Implementation;
   private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -429,20 +429,20 @@ public:
     static Commission decommission();
 
     /// Set whether this commission should accept dispatched tasks.
-    Commission& accept_dispatched_tasks(bool decision=true);
+    Commission& accept_dispatched_tasks(bool decision = true);
 
     /// Check whether this commission is accepting dispatched tasks.
     bool is_accepting_dispatched_tasks() const;
 
     /// Set whether this commission should accept direct tasks
-    Commission& accept_direct_tasks(bool decision=true);
+    Commission& accept_direct_tasks(bool decision = true);
 
     /// Check whether this commission is accepting direct tasks.
     bool is_accepting_direct_tasks() const;
 
     /// Set whether this commission should perform idle behaviors (formerly
     /// referred to as "finishing tasks").
-    Commission& perform_idle_behavior(bool decision=true);
+    Commission& perform_idle_behavior(bool decision = true);
 
     /// Check whether this commission is performing idle behaviors (formerly
     /// referred to as "finishing tasks").

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -411,6 +411,54 @@ public:
   /// If the robot is holding onto a session with a lift, release that session.
   void release_lift();
 
+  /// A description of whether the robot should accept dispatched and/or direct
+  /// tasks.
+  class Commission
+  {
+  public:
+    /// Construct a Commission description with all default values.
+    /// - accept_dispatched_tasks: true
+    /// - accept_direct_tasks: true
+    Commission();
+
+    /// Construct a Commission description that accepts no tasks at all.
+    /// - accept_dispatch_tasks: false
+    /// - accept_direct_tasks: false
+    static Commission decommission();
+
+    /// Set whether this commission should accept dispatched tasks.
+    Commission& accept_dispatched_tasks(bool decision=true);
+
+    /// Check whether this commission is accepting dispatched tasks.
+    bool is_accepting_dispatched_tasks() const;
+
+    /// Set whether this commission should accept direct tasks
+    Commission& accept_direct_tasks(bool decision=true);
+
+    /// Check whether this commission is accepting direct tasks.
+    bool is_accepting_direct_tasks() const;
+
+    class Implementation;
+  private:
+    rmf_utils::impl_ptr<Implementation> _pimpl;
+  };
+
+  /// Set the current commission for the robot.
+  void set_commission(Commission commission);
+
+  /// Get the current commission for the robot. If the robot has been dropped
+  /// from the fleet, this will return Commission::decommission().
+  Commission commission() const;
+
+  /// Tell the fleet adapter to reassign all the tasks that have been dispatched
+  /// to this robot. To prevent the tasks from being reassigned back to this
+  /// robot use .set_commission(Commission::decommission())
+  ///
+  /// In the current implementation, tasks will only be reassigned to robots
+  /// in the same fleet that the task was originally assigned to. This behavior
+  /// could change in the future.
+  void reassign_dispatched_tasks();
+
   class Implementation;
 
   /// This API is experimental and will not be supported in the future. Users
@@ -420,15 +468,18 @@ public:
   public:
     /// True if this robot is allowed to accept new tasks. False if the robot
     /// will not accept any new tasks.
+    [[deprecated("Use commission instead")]]
     bool is_commissioned() const;
 
     /// Stop this robot from accepting any new tasks. It will continue to
     /// perform tasks that are already in its queue. To reassign those tasks,
     /// you will need to use the task request API to cancel the tasks and
     /// re-request them.
+    [[deprecated("Use set_commission instead")]]
     void decommission();
 
     /// Allow this robot to resume accepting new tasks.
+    [[deprecated("Use set_commission instead")]]
     void recommission();
 
     /// Get the schedule participant of this robot

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -2518,6 +2518,8 @@ void TaskManager::_handle_commission_request(
     commission.perform_idle_behavior(idle_it->get<bool>());
   }
 
+  _context->set_commission(commission);
+
   nlohmann::json response_json;
   response_json["commission"] = simple_success_json();
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -64,6 +64,7 @@
 #include <rmf_api_msgs/schemas/undo_skip_phase_request.hpp>
 #include <rmf_api_msgs/schemas/undo_skip_phase_response.hpp>
 #include <rmf_api_msgs/schemas/error.hpp>
+#include <rmf_api_msgs/schemas/commission.hpp>
 #include <rmf_api_msgs/schemas/robot_commission_request.hpp>
 #include <rmf_api_msgs/schemas/robot_commission_response.hpp>
 
@@ -227,7 +228,10 @@ TaskManagerPtr TaskManager::make(
     rmf_api_msgs::schemas::skip_phase_response,
     rmf_api_msgs::schemas::task_request,
     rmf_api_msgs::schemas::undo_skip_phase_request,
-    rmf_api_msgs::schemas::undo_skip_phase_response
+    rmf_api_msgs::schemas::undo_skip_phase_response,
+    rmf_api_msgs::schemas::commission,
+    rmf_api_msgs::schemas::robot_commission_request,
+    rmf_api_msgs::schemas::robot_commission_response,
   };
 
   for (const auto& schema : schemas)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -2515,7 +2515,7 @@ void TaskManager::_handle_commission_request(
 
   static const auto response_validator =
     std::make_shared<nlohmann::json_schema::json_validator>(
-      _make_validator(rmf_api_msgs::schemas::robot_commission_response));
+    _make_validator(rmf_api_msgs::schemas::robot_commission_response));
 
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1018,6 +1018,13 @@ nlohmann::json TaskManager::submit_direct_request(
   const auto& fleet = _context->group();
   const auto& robot = _context->name();
 
+  if (!_context->commission().is_accepting_direct_tasks())
+  {
+    return _make_error_response(
+      20, "Uncommissioned", "The robot [" + robot + "] in fleet ["
+      + fleet + "] is not commissioned to perform direct tasks.");
+  }
+
   const auto& impl =
     agv::FleetUpdateHandle::Implementation::get(*fleet_handle);
   std::vector<std::string> errors;
@@ -1490,6 +1497,13 @@ std::function<void()> TaskManager::_robot_interruption_callback()
 //==============================================================================
 void TaskManager::_begin_waiting()
 {
+  if (!_context->commission().is_performing_idle_behavior())
+  {
+    // This robot is not supposed to perform its idle behavior, so we
+    // immediately from here.
+    return;
+  }
+
   if (_idle_task)
   {
     const auto request = _idle_task->make_request(_context->make_get_state()());

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -122,7 +122,9 @@ public:
 
   /// Send all dispatched requests that are still in the queue back to the fleet
   /// handle for reassignment.
-  void reassign_dispatched_requests();
+  void reassign_dispatched_requests(
+    std::function<void()> on_success,
+    std::function<void(std::vector<std::string>)> on_failure);
 
   std::optional<std::string> current_task_id() const;
 
@@ -540,6 +542,10 @@ private:
     const std::string& request_id);
 
   void _handle_direct_request(
+    const nlohmann::json& request_json,
+    const std::string& request_id);
+
+  void _handle_commission_request(
     const nlohmann::json& request_json,
     const std::string& request_id);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -361,7 +361,7 @@ private:
   // TODO: Eliminate the need for a mutex by redesigning the use of the task
   // manager so that modifications of shared data only happen on designated
   // rxcpp worker
-  mutable std::mutex _mutex;
+  mutable std::recursive_mutex _mutex;
   rclcpp::TimerBase::SharedPtr _task_timer;
   rclcpp::TimerBase::SharedPtr _retreat_timer;
   rclcpp::TimerBase::SharedPtr _update_timer;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -40,6 +40,18 @@
 
 namespace rmf_fleet_adapter {
 
+struct PendingTimeInfo
+{
+  int64_t unix_millis_finish_time;
+  int64_t original_estimate_millis;
+};
+
+struct PendingInfo
+{
+  rmf_task::Task::Description::Info info;
+  std::optional<PendingTimeInfo> time;
+};
+
 //==============================================================================
 /// This task manager is a first attempt at managing multiple tasks per fleet.
 /// This is a simple implementation that only makes a modest attempt at being
@@ -326,6 +338,11 @@ private:
   uint16_t _count_emergency_pullover = 0;
   // Queue for dispatched tasks
   std::vector<Assignment> _queue;
+  std::unordered_map<
+    rmf_task::ConstRequestPtr,
+    PendingInfo
+  > _pending_task_info;
+
   // An ID to keep track of the FIFO order of direct tasks
   std::size_t _next_sequence_number;
   // Queue for directly assigned tasks

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -443,6 +443,12 @@ private:
     const Assignment& assignment,
     std::vector<std::string> labels);
 
+  /// Take all dispatched assignments out of the queue, leaving the queue empty.
+  std::vector<Assignment> _drain_dispatched_assignments();
+
+  /// Take all direct assignments out of the queue, leaving the queue empty.
+  std::vector<Assignment> _drain_direct_assignments();
+
   /// Cancel a task that is in the dispatch queue. Returns false if the task
   /// was not present.
   bool _cancel_task_from_dispatch_queue(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -118,7 +118,11 @@ public:
   void set_queue(const std::vector<Assignment>& assignments);
 
   /// Get the non-charging requests among pending tasks
-  const std::vector<rmf_task::ConstRequestPtr> requests() const;
+  std::vector<rmf_task::ConstRequestPtr> dispatched_requests() const;
+
+  /// Send all dispatched requests that are still in the queue back to the fleet
+  /// handle for reassignment.
+  void reassign_dispatched_requests();
 
   std::optional<std::string> current_task_id() const;
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -333,10 +333,18 @@ public:
       expect.states.size(),
       expect.pending_requests.size());
 
+    std::unordered_map<std::size_t, RobotContextPtr> robot_indexes;
+    std::vector<rmf_task::State> states;
+    for (const auto& [context, state] : expect.states)
+    {
+      robot_indexes[states.size()] = context;
+      states.push_back(state);
+    }
+
     // Generate new task assignments
     const auto result = task_planner.plan(
       rmf_traffic_ros2::convert(node->now()),
-      expect.states,
+      states,
       expect.pending_requests);
 
     auto assignments_ptr = std::get_if<
@@ -387,7 +395,22 @@ public:
       return std::nullopt;
     }
 
-    const auto assignments = *assignments_ptr;
+    TaskAssignments assignments;
+    for (std::size_t i=0; i < assignments_ptr->size(); ++i)
+    {
+      const auto r_it = robot_indexes.find(i);
+      if (r_it == robot_indexes.end())
+      {
+        RCLCPP_ERROR(
+          node->get_logger(),
+          "[AllocateTasks] Unable to find a robot associated with index [%d]",
+          i);
+        continue;
+      }
+
+      const auto context = r_it->second;
+      assignments[context] = (*assignments_ptr)[i];
+    }
 
     if (assignments.empty())
     {
@@ -534,15 +557,15 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
 
       const auto& assignments = allocation_result.value();
 
-      const double cost = self->_pimpl->task_planner->compute_cost(assignments);
+      const double cost = self->_pimpl->compute_cost(assignments);
 
       // Display computed assignments for debugging
       std::stringstream debug_stream;
       debug_stream << "Cost: " << cost << std::endl;
-      for (std::size_t i = 0; i < assignments.size(); ++i)
+      for (const auto& [context, queue] : assignments)
       {
-        debug_stream << "--Agent: " << i << std::endl;
-        for (const auto& a : assignments[i])
+        debug_stream << "--Agent: " << context->requester_id() << std::endl;
+        for (const auto& a : queue)
         {
           const auto& s = a.finish_state();
           const double request_seconds =
@@ -569,31 +592,19 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
         "%s",
         debug_stream.str().c_str());
 
-      // Map robot index to name to populate robot_name in BidProposal
-      std::unordered_map<std::size_t, std::string> robot_name_map;
-      std::size_t index = 0;
-      for (const auto& t : self->_pimpl->task_managers)
-      {
-        robot_name_map.insert({index, t.first->name()});
-        ++index;
-      }
-
       std::optional<std::string> robot_name;
       std::optional<rmf_traffic::Time> finish_time;
-      index = 0;
-      for (const auto& agent : assignments)
+      for (const auto& [context, queue] : assignments)
       {
-        for (const auto& assignment : agent)
+        for (const auto& assignment : queue)
         {
           if (assignment.request()->booking()->id() == task_id)
           {
             finish_time = assignment.finish_state().time().value();
-            if (robot_name_map.find(index) != robot_name_map.end())
-              robot_name = robot_name_map[index];
+            robot_name = context->name();
             break;
           }
         }
-        ++index;
       }
 
       if (!robot_name.has_value() || !finish_time.has_value())
@@ -653,6 +664,7 @@ void FleetUpdateHandle::Implementation::dispatch_command_cb(
   dispatch_ack.dispatch_id = msg->dispatch_id;
   if (msg->type == DispatchCmdMsg::TYPE_AWARD)
   {
+    last_bid_assignment = task_id;
     const auto task_it = bid_notice_assignments.find(task_id);
     if (task_it == bid_notice_assignments.end())
     {
@@ -708,23 +720,6 @@ void FleetUpdateHandle::Implementation::dispatch_command_cb(
     auto assignments = std::move(task_it->second);
     bid_notice_assignments.erase(task_it);
 
-    if (assignments.size() != task_managers.size())
-    {
-      // FIXME(MXG): This error mode seems like a problem with our
-      // implementation. If a robot is added during a bid process, we could
-      // trigger this error even though it shouldn't actually be a problem.
-
-      std::string error_str =
-        "The number of available robots does not match that in the assignments "
-        "for task_id [" + task_id + "]. This request will be ignored.";
-      RCLCPP_ERROR(node->get_logger(), "%s", error_str.c_str());
-      dispatch_ack.errors.push_back(
-        make_error_str(13, "Internal bug", std::move(error_str)));
-
-      dispatch_ack_pub->publish(dispatch_ack);
-      return;
-    }
-
     // Here we make sure none of the tasks in the assignments has already begun
     // execution. If so, we replan assignments until a valid set is obtained
     // and only then update the task manager queues
@@ -732,9 +727,9 @@ void FleetUpdateHandle::Implementation::dispatch_command_cb(
     if (!valid_assignments)
     {
       rmf_task::ConstRequestPtr request;
-      for (const auto& a : assignments)
+      for (const auto& [_, queue] : assignments)
       {
-        for (const auto& r : a)
+        for (const auto& r : queue)
         {
           if (r.request()->booking()->id() == task_id)
           {
@@ -761,42 +756,71 @@ void FleetUpdateHandle::Implementation::dispatch_command_cb(
         return;
       }
 
-      // TODO: This replanning is blocking the main thread. Instead, the
-      // replanning should run on a separate worker and then deliver the
-      // result back to the main worker.
-      const auto replan_results = AllocateTasks(
-        nullptr, aggregate_expectations(), *task_planner, node)
-        .run(dispatch_ack.errors);
+      unassigned_requests.push_back(request);
+      reassign_dispatched_tasks(
+        // On success
+        [dispatch_ack, dispatch_ack_pub = dispatch_ack_pub]()
+        {
+          auto msg = dispatch_ack;
+          msg.success = true;
+          dispatch_ack_pub->publish(dispatch_ack);
+        },
+        // On failure
+        [dispatch_ack, w = weak_self, request](
+          std::vector<std::string> errors)
+        {
+          const auto self = w.lock();
+          if (!self)
+            return;
 
-      if (!replan_results)
-      {
-        std::string error_str =
-          "Unable to replan assignments when accommodating task_id [" + task_id
-          + "]. This request will be ignored.";
+          auto r_it = std::remove(
+            self->_pimpl->unassigned_requests.begin(),
+            self->_pimpl->unassigned_requests.end(),
+            request);
 
-        RCLCPP_ERROR(node->get_logger(), "%s", error_str.c_str());
-        dispatch_ack.errors.push_back(
-          make_error_str(9, "Not feasible", std::move(error_str)));
-        dispatch_ack_pub->publish(dispatch_ack);
-        return;
-      }
+          self->_pimpl->unassigned_requests.erase(
+            r_it, self->_pimpl->unassigned_requests.end());
 
-      assignments = replan_results.value();
-      // We do not need to re-check if assignments are valid as this function
-      // is being called by the ROS2 executor and is running on the main
-      // rxcpp worker. Hence, no new tasks would have started during this
-      // replanning.
+          std::string error_str =
+            "Unable to replan assignments when accommodating task_id ["
+            + request->booking()->id() + "]. Reasons:";
+          if (errors.empty())
+          {
+            error_str += " No reason given by planner.";
+          }
+          else
+          {
+            for (const auto& e : errors)
+            {
+              error_str += "\n -- " + e;
+            }
+          }
+
+          RCLCPP_ERROR(
+            self->_pimpl->node->get_logger(),
+            "%s",
+            error_str.c_str());
+          auto msg = dispatch_ack;
+          msg.success = false;
+          msg.errors.push_back(
+            make_error_str(9, "Not feasible", std::move(error_str)));
+          self->_pimpl->dispatch_ack_pub->publish(msg);
+        });
     }
     else
     {
-      std::size_t index = 0;
-      for (auto& t : task_managers)
+      for (const auto& [context, queue] : assignments)
       {
-        t.second->set_queue(assignments[index]);
-        ++index;
+        context->task_manager()->set_queue(queue);
       }
 
-      current_assignment_cost = task_planner->compute_cost(assignments);
+      // Any unassigned requests would have been collected by the aggregator and
+      // given an assignment while calculating this bid. As long as
+      // is_valid_assignments was able to pass, then all tasks have been
+      // assigned to properly commissioned robots.
+      unassigned_requests.clear();
+
+      current_assignment_cost = compute_cost(assignments);
       dispatch_ack.success = true;
       dispatch_ack_pub->publish(dispatch_ack);
 
@@ -829,52 +853,39 @@ void FleetUpdateHandle::Implementation::dispatch_command_cb(
 
       if (task_was_found)
       {
-        // Re-plan assignments while ignoring request for task to be cancelled
-        std::vector<std::string> errors;
-        const auto replan_results = AllocateTasks(
-          nullptr, aggregate_expectations(), *task_planner, node)
-          .run(errors);
-
-        if (!replan_results.has_value())
-        {
-          std::stringstream ss;
-          ss << "Unabled to replan assignments when cancelling task ["
-             << task_id << "]. ";
-          if (errors.empty())
+        reassign_dispatched_tasks(
+          // On success
+          [task_id, name = name, node = node]()
           {
-            ss << "No planner error messages were provided.";
-          }
-          else
+            RCLCPP_INFO(
+              node->get_logger(),
+              "Task with task_id [%s] has successfully been cancelled. "
+              "TaskAssignments updated for robots in fleet [%s].",
+              task_id.c_str(), name.c_str());
+          },
+          // On failure
+          [task_id, name = name, node = node](std::vector<std::string> errors)
           {
-            ss << "The following planner errors occurred:";
-            for (const auto& e : errors)
+            std::stringstream ss;
+            ss << "Unabled to replan assignments when cancelling task ["
+              << task_id << "] for fleet [" << name << "]. ";
+            if (errors.empty())
             {
-              const auto err = nlohmann::json::parse(e);
-              ss << "\n -- " << err["detail"].get<std::string>();
+              ss << "No planner error messages were provided.";
             }
-          }
-          ss << "\n";
+            else
+            {
+              ss << "The following planner errors occurred:";
+              for (const auto& e : errors)
+              {
+                const auto err = nlohmann::json::parse(e);
+                ss << "\n -- " << err["detail"].get<std::string>();
+              }
+            }
+            ss << "\n";
 
-          RCLCPP_WARN(node->get_logger(), "%s", ss.str().c_str());
-        }
-        else
-        {
-          const auto& assignments = replan_results.value();
-          std::size_t index = 0;
-          for (auto& t : task_managers)
-          {
-            t.second->set_queue(assignments[index]);
-            ++index;
-          }
-
-          current_assignment_cost = task_planner->compute_cost(assignments);
-
-          RCLCPP_INFO(
-            node->get_logger(),
-            "Task with task_id [%s] has successfully been cancelled. TaskAssignments "
-            "updated for robots in fleet [%s].",
-            task_id.c_str(), name.c_str());
-        }
+            RCLCPP_WARN(node->get_logger(), "%s", ss.str().c_str());
+          });
       }
     }
 
@@ -893,8 +904,23 @@ void FleetUpdateHandle::Implementation::dispatch_command_cb(
 }
 
 //==============================================================================
+double FleetUpdateHandle::Implementation::compute_cost(
+  const TaskAssignments& assignments) const
+{
+  rmf_task::TaskPlanner::Assignments raw_assignments;
+  raw_assignments.reserve(assignments.size());
+  for (const auto [_, queue] : assignments)
+  {
+    raw_assignments.push_back(queue);
+  }
+
+  return task_planner->compute_cost(raw_assignments);
+}
+
+//==============================================================================
 auto FleetUpdateHandle::Implementation::is_valid_assignments(
-  TaskAssignments& assignments) const -> bool
+  TaskAssignments& assignments,
+  std::string* report_error) const -> bool
 {
   std::unordered_set<std::string> executed_tasks;
   for (const auto& [context, mgr] : task_managers)
@@ -903,17 +929,169 @@ auto FleetUpdateHandle::Implementation::is_valid_assignments(
     executed_tasks.insert(tasks.begin(), tasks.end());
   }
 
-  for (const auto& agent : assignments)
+  for (const auto& [context, queue] : assignments)
   {
-    for (const auto& a : agent)
+    for (const auto& a : queue)
     {
       if (executed_tasks.find(a.request()->booking()->id()) !=
         executed_tasks.end())
+      {
+        if (report_error)
+        {
+          *report_error = "task [" + a.request()->booking()->id()
+            + "] already began executing";
+        }
         return false;
+      }
+    }
+
+    if (!queue.empty())
+    {
+      if (!context->commission().is_accepting_dispatched_tasks())
+      {
+        if (report_error)
+        {
+          *report_error = "robot [" + context->name()
+            + "] has been decommissioned";
+        }
+        // If any tasks were assigned to this robot after it has been
+        // decommissioned, then those were invalid assignments.
+        return false;
+      }
+
+      if (task_managers.find(context) == task_managers.end())
+      {
+        if (report_error)
+        {
+          *report_error = "robot [" + context->name()
+            + "] has been removed from the fleet";
+        }
+        // This robot is no longer part of the fleet, so we cannot assign
+        // tasks to it.
+        return false;
+      }
     }
   }
 
   return true;
+}
+
+//==============================================================================
+void FleetUpdateHandle::Implementation::reassign_dispatched_tasks(
+  std::function<void()> on_success,
+  std::function<void(std::vector<std::string>)> on_failure)
+{
+  auto expectations = aggregate_expectations();
+  if (expectations.states.empty() && !expectations.pending_requests.empty())
+  {
+    // If there are no robots that can perform any tasks but there are pending
+    // requests, then we should immediately assume failure.
+    worker.schedule(
+      [on_failure](const auto&)
+      {
+        on_failure({"no more robots available"});
+      });
+    return;
+  }
+
+  auto on_plan_received = [
+      on_success,
+      on_failure,
+      w = weak_self,
+      initial_last_bid_assignment = last_bid_assignment
+    ](TaskAssignments assignments)
+    {
+      const auto self = w.lock();
+      if (!self)
+        return;
+
+      const bool new_task_came_in =
+        initial_last_bid_assignment != self->_pimpl->last_bid_assignment;
+
+      std::string error;
+      const bool valid_assignments =
+        !new_task_came_in
+        && self->_pimpl->is_valid_assignments(assignments, &error);
+
+      if (!valid_assignments)
+      {
+        // We need to replan because some important aspect of the planning
+        // problem has changed since we originally tried to reassign.
+        if (new_task_came_in)
+        {
+          RCLCPP_WARN(
+            self->_pimpl->node->get_logger(),
+            "Redoing task reassignment for fleet [%s] because a new task was "
+            "dispatched while the reassignment was being calculated.",
+            self->_pimpl->name.c_str());
+        }
+        else
+        {
+          RCLCPP_WARN(
+            self->_pimpl->node->get_logger(),
+            "Redoing task reassignment for fleet [%s] because %s.",
+            self->_pimpl->name.c_str(),
+            error.c_str());
+        }
+
+        self->_pimpl->reassign_dispatched_tasks(on_success, on_failure);
+        return;
+      }
+
+      for (const auto& [context, queue] : assignments)
+      {
+        context->task_manager()->set_queue(queue);
+      }
+
+      // All requests should be assigned now, no matter which robot they were
+      // originally assigned to, so we can clear this buffer.
+      //
+      // As long as no new tasks were dispatched to this fleet (verified by the
+      // new_task_came_in check), any tasks that might have been previously
+      // unassigned will be accounted for in the current set of assignments.
+      self->_pimpl->unassigned_requests.clear();
+
+      self->_pimpl->current_assignment_cost =
+        self->_pimpl->compute_cost(assignments);
+
+      on_success();
+    };
+
+  reassignment_worker.schedule(
+    [
+      on_plan_received,
+      on_failure,
+      expectations = std::move(expectations),
+      task_planner = *task_planner,
+      node = node,
+      worker = worker
+    ](const auto&)
+    {
+      std::vector<std::string> errors;
+      const auto replan_results = AllocateTasks(
+        nullptr, expectations, task_planner, node)
+        .run(errors);
+
+      if (replan_results.has_value())
+      {
+        worker.schedule(
+          [
+            assignments = std::move(*replan_results),
+            on_plan_received
+          ](const auto&)
+          {
+            on_plan_received(assignments);
+          });
+      }
+      else
+      {
+        worker.schedule(
+          [errors = std::move(errors), on_failure](const auto&)
+          {
+            on_failure(errors);
+          });
+      }
+    });
 }
 
 //==============================================================================
@@ -1495,11 +1673,20 @@ auto FleetUpdateHandle::Implementation::aggregate_expectations() const
     if (!t.first->commission().is_accepting_dispatched_tasks())
       continue;
 
-    expect.states.push_back(t.second->expected_finish_state());
+    expect.states.push_back(
+      ExpectedState {
+        t.first,
+        t.second->expected_finish_state()
+      });
     const auto requests = t.second->requests();
     expect.pending_requests.insert(
       expect.pending_requests.end(), requests.begin(), requests.end());
   }
+
+  expect.pending_requests.insert(
+    expect.pending_requests.end(),
+    unassigned_requests.begin(),
+    unassigned_requests.end());
 
   return expect;
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1268,6 +1268,16 @@ void FleetUpdateHandle::Implementation::update_fleet_state() const
         issue_msg["detail"] = issue->detail;
         issues_msg.push_back(std::move(issue_msg));
       }
+
+      const auto& commission = context->commission();
+      nlohmann::json commission_json;
+      commission_json["dispatch_tasks"] =
+        commission.is_accepting_dispatched_tasks();
+      commission_json["direct_tasks"] = commission.is_accepting_direct_tasks();
+      commission_json["idle_behavior"] =
+        commission.is_performing_idle_behavior();
+
+      json["commission"] = commission_json;
     }
 
     try

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1492,7 +1492,7 @@ auto FleetUpdateHandle::Implementation::aggregate_expectations() const
   for (const auto& t : task_managers)
   {
     // Ignore any robots that are not currently commissioned.
-    if (!t.first->is_commissioned())
+    if (!t.first->commission().is_accepting_dispatched_tasks())
       continue;
 
     expect.states.push_back(t.second->expected_finish_state());

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -403,7 +403,7 @@ public:
     }
 
     TaskAssignments assignments;
-    for (std::size_t i=0; i < assignments_ptr->size(); ++i)
+    for (std::size_t i = 0; i < assignments_ptr->size(); ++i)
     {
       const auto r_it = robot_indexes.find(i);
       if (r_it == robot_indexes.end())
@@ -789,8 +789,8 @@ void FleetUpdateHandle::Implementation::dispatch_command_cb(
             r_it, self->_pimpl->unassigned_requests.end());
 
           std::string error_str =
-            "Unable to replan assignments when accommodating task_id ["
-            + request->booking()->id() + "]. Reasons:";
+          "Unable to replan assignments when accommodating task_id ["
+          + request->booking()->id() + "]. Reasons:";
           if (errors.empty())
           {
             error_str += " No reason given by planner.";
@@ -875,7 +875,7 @@ void FleetUpdateHandle::Implementation::dispatch_command_cb(
           {
             std::stringstream ss;
             ss << "Unabled to replan assignments when cancelling task ["
-              << task_id << "] for fleet [" << name << "]. ";
+               << task_id << "] for fleet [" << name << "]. ";
             if (errors.empty())
             {
               ss << "No planner error messages were provided.";
@@ -1002,10 +1002,10 @@ void FleetUpdateHandle::Implementation::reassign_dispatched_tasks(
   }
 
   auto on_plan_received = [
-      on_success,
-      on_failure,
-      w = weak_self,
-      initial_last_bid_assignment = last_bid_assignment
+    on_success,
+    on_failure,
+    w = weak_self,
+    initial_last_bid_assignment = last_bid_assignment
     ](TaskAssignments assignments)
     {
       const auto self = w.lock();
@@ -1077,7 +1077,7 @@ void FleetUpdateHandle::Implementation::reassign_dispatched_tasks(
       std::vector<std::string> errors;
       const auto replan_results = AllocateTasks(
         nullptr, expectations, task_planner, node)
-        .run(errors);
+      .run(errors);
 
       if (replan_results.has_value())
       {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1678,7 +1678,7 @@ auto FleetUpdateHandle::Implementation::aggregate_expectations() const
         t.first,
         t.second->expected_finish_state()
       });
-    const auto requests = t.second->requests();
+    const auto requests = t.second->dispatched_requests();
     expect.pending_requests.insert(
       expect.pending_requests.end(), requests.begin(), requests.end());
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -961,21 +961,24 @@ std::shared_ptr<TaskManager> RobotContext::task_manager()
 }
 
 //==============================================================================
-bool RobotContext::is_commissioned() const
+void RobotContext::set_commission(RobotUpdateHandle::Commission value)
 {
-  return _commissioned;
+  std::lock_guard<std::mutex> lock(*_commission_mutex);
+  _commission = std::move(value);
 }
 
 //==============================================================================
-void RobotContext::decommission()
+const RobotUpdateHandle::Commission& RobotContext::commission() const
 {
-  _commissioned = false;
+  return _commission;
 }
 
 //==============================================================================
-void RobotContext::recommission()
+RobotUpdateHandle::Commission RobotContext::copy_commission() const
 {
-  _commissioned = true;
+  std::lock_guard<std::mutex> lock(*_commission_mutex);
+  RobotUpdateHandle::Commission copy = _commission;
+  return copy;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -53,6 +53,7 @@ class TaskManager;
 
 namespace agv {
 
+class FleetUpdateHandle;
 class RobotContext;
 using TransformDictionary = std::unordered_map<std::string, Transformation>;
 using SharedPlanner = std::shared_ptr<
@@ -641,6 +642,9 @@ public:
   /// Lock the commission_mutex and return a copy of the robot's current
   /// commission.
   RobotUpdateHandle::Commission copy_commission() const;
+
+  /// Reassign the tasks that have been dispatched for this robot
+  void reassign_dispatched_tasks();
 
   Reporting& reporting();
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -632,13 +632,15 @@ public:
   /// Get the task manager for this robot, if it exists.
   std::shared_ptr<TaskManager> task_manager();
 
-  /// Return true if this robot is currently commissioned (available to accept
-  /// new tasks).
-  bool is_commissioned() const;
+  /// Set the commission for this robot
+  void set_commission(RobotUpdateHandle::Commission value);
 
-  void decommission();
+  /// Get a reference to the robot's commission.
+  const RobotUpdateHandle::Commission& commission() const;
 
-  void recommission();
+  /// Lock the commission_mutex and return a copy of the robot's current
+  /// commission.
+  RobotUpdateHandle::Commission copy_commission() const;
 
   Reporting& reporting();
 
@@ -831,7 +833,9 @@ private:
 
   RobotUpdateHandle::Unstable::Watchdog _lift_watchdog;
   rmf_traffic::Duration _lift_rewait_duration = std::chrono::seconds(0);
-  bool _commissioned = true;
+  std::unique_ptr<std::mutex> _commission_mutex =
+    std::make_unique<std::mutex>();
+  RobotUpdateHandle::Commission _commission;
   bool _emergency = false;
   EasyFullControl::LocalizationRequest _localize;
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -809,7 +809,7 @@ void RobotUpdateHandle::reassign_dispatched_tasks()
       {
         const auto mgr = context->task_manager();
         if (mgr)
-          mgr->reassign_dispatched_requests();
+          mgr->reassign_dispatched_requests([](){}, [](auto){});
       });
   }
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -731,7 +731,7 @@ public:
 
 //==============================================================================
 RobotUpdateHandle::Commission::Commission()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
@@ -809,7 +809,7 @@ void RobotUpdateHandle::reassign_dispatched_tasks()
       {
         const auto mgr = context->task_manager();
         if (mgr)
-          mgr->reassign_dispatched_requests([](){}, [](auto){});
+          mgr->reassign_dispatched_requests([]() {}, [](auto) {});
       });
   }
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -800,6 +800,21 @@ auto RobotUpdateHandle::commission() const -> Commission
 }
 
 //==============================================================================
+void RobotUpdateHandle::reassign_dispatched_tasks()
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->worker().schedule(
+      [context](const auto&)
+      {
+        const auto mgr = context->task_manager();
+        if (mgr)
+          mgr->reassign_dispatched_requests();
+      });
+  }
+}
+
+//==============================================================================
 RobotUpdateHandle::RobotUpdateHandle()
 {
   // Do nothing

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -721,6 +721,69 @@ void RobotUpdateHandle::release_lift()
 }
 
 //==============================================================================
+class RobotUpdateHandle::Commission::Implementation
+{
+public:
+  bool is_accepting_dispatched_tasks = true;
+  bool is_accepting_direct_tasks = true;
+};
+
+//==============================================================================
+RobotUpdateHandle::Commission::Commission()
+  : _pimpl(rmf_utils::make_impl<Implementation>())
+{
+  // Do nothing
+}
+
+//==============================================================================
+auto RobotUpdateHandle::Commission::decommission() -> Commission
+{
+  return Commission()
+    .accept_dispatched_tasks(false)
+    .accept_direct_tasks(false);
+}
+
+//==============================================================================
+auto RobotUpdateHandle::Commission::accept_dispatched_tasks(bool decision)
+-> Commission&
+{
+  _pimpl->is_accepting_dispatched_tasks = decision;
+  return *this;
+}
+
+//==============================================================================
+bool RobotUpdateHandle::Commission::is_accepting_dispatched_tasks() const
+{
+  return _pimpl->is_accepting_dispatched_tasks;
+}
+
+//==============================================================================
+auto RobotUpdateHandle::Commission::accept_direct_tasks(bool decision)
+-> Commission&
+{
+  _pimpl->is_accepting_direct_tasks = decision;
+  return *this;
+}
+
+//==============================================================================
+bool RobotUpdateHandle::Commission::is_accepting_direct_tasks() const
+{
+  return _pimpl->is_accepting_direct_tasks;
+}
+
+//==============================================================================
+void RobotUpdateHandle::set_commission(Commission commission)
+{
+  _pimpl->set_commission(std::move(commission));
+}
+
+//==============================================================================
+auto RobotUpdateHandle::commission() const -> Commission
+{
+  return _pimpl->commission();
+}
+
+//==============================================================================
 RobotUpdateHandle::RobotUpdateHandle()
 {
   // Do nothing
@@ -742,7 +805,7 @@ const RobotUpdateHandle::Unstable& RobotUpdateHandle::unstable() const
 bool RobotUpdateHandle::Unstable::is_commissioned() const
 {
   if (const auto context = _pimpl->get_context())
-    return context->is_commissioned();
+    return context->copy_commission().is_accepting_dispatched_tasks();
 
   return false;
 }
@@ -750,29 +813,17 @@ bool RobotUpdateHandle::Unstable::is_commissioned() const
 //==============================================================================
 void RobotUpdateHandle::Unstable::decommission()
 {
-  if (const auto context = _pimpl->get_context())
-  {
-    context->worker().schedule(
-      [w = context->weak_from_this()](const auto&)
-      {
-        if (const auto context = w.lock())
-          context->decommission();
-      });
-  }
+  _pimpl->set_commission(
+    _pimpl->commission()
+    .accept_dispatched_tasks(false));
 }
 
 //==============================================================================
 void RobotUpdateHandle::Unstable::recommission()
 {
-  if (const auto context = _pimpl->get_context())
-  {
-    context->worker().schedule(
-      [w = context->weak_from_this()](const auto&)
-      {
-        if (const auto context = w.lock())
-          context->recommission();
-      });
-  }
+  _pimpl->set_commission(
+    _pimpl->commission()
+    .accept_dispatched_tasks(true));
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -726,6 +726,7 @@ class RobotUpdateHandle::Commission::Implementation
 public:
   bool is_accepting_dispatched_tasks = true;
   bool is_accepting_direct_tasks = true;
+  bool is_performing_idle_behavior = true;
 };
 
 //==============================================================================
@@ -740,7 +741,8 @@ auto RobotUpdateHandle::Commission::decommission() -> Commission
 {
   return Commission()
     .accept_dispatched_tasks(false)
-    .accept_direct_tasks(false);
+    .accept_direct_tasks(false)
+    .perform_idle_behavior(false);
 }
 
 //==============================================================================
@@ -769,6 +771,19 @@ auto RobotUpdateHandle::Commission::accept_direct_tasks(bool decision)
 bool RobotUpdateHandle::Commission::is_accepting_direct_tasks() const
 {
   return _pimpl->is_accepting_direct_tasks;
+}
+
+//==============================================================================
+auto RobotUpdateHandle::Commission::perform_idle_behavior(bool decision)
+{
+  _pimpl->is_performing_idle_behavior = decision;
+  return *this;
+}
+
+//==============================================================================
+bool RobotUpdateHandle::Commission::is_performing_idle_behavior() const
+{
+  return _pimpl->is_performing_idle_behavior;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -775,6 +775,7 @@ bool RobotUpdateHandle::Commission::is_accepting_direct_tasks() const
 
 //==============================================================================
 auto RobotUpdateHandle::Commission::perform_idle_behavior(bool decision)
+-> Commission&
 {
   _pimpl->is_performing_idle_behavior = decision;
   return *this;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -383,6 +383,9 @@ public:
     handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
       Implementation{handle, std::forward<Args>(args)...});
 
+    handle->_pimpl->reassignment_worker =
+      rxcpp::schedulers::make_event_loop().create_worker();
+
     handle->_pimpl->add_standard_tasks();
 
     handle->_pimpl->emergency_obs =

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -68,6 +68,7 @@
 #include <rmf_api_msgs/schemas/fleet_log_update.hpp>
 #include <rmf_api_msgs/schemas/fleet_log.hpp>
 #include <rmf_api_msgs/schemas/log_entry.hpp>
+#include <rmf_api_msgs/schemas/commission.hpp>
 
 #include <rmf_fleet_adapter/schemas/event_description__perform_action.hpp>
 
@@ -497,7 +498,8 @@ public:
       rmf_api_msgs::schemas::robot_state,
       rmf_api_msgs::schemas::location_2D,
       rmf_api_msgs::schemas::fleet_log,
-      rmf_api_msgs::schemas::log_entry
+      rmf_api_msgs::schemas::log_entry,
+      rmf_api_msgs::schemas::commission,
     };
 
     for (const auto& schema : schemas)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -299,6 +299,30 @@ public:
     return *handle._pimpl;
   }
 
+  void set_commission(Commission commission)
+  {
+    if (const auto context = get_context())
+    {
+      context->worker().schedule(
+        [w = context->weak_from_this(), commission = std::move(commission)](
+          const auto&)
+        {
+          if (const auto context = w.lock())
+            context->set_commission(commission);
+        });
+    }
+  }
+
+  Commission commission() const
+  {
+    if (const auto context = get_context())
+    {
+      return context->copy_commission();
+    }
+
+    return Commission::decommission();
+  }
+
   std::shared_ptr<RobotContext> get_context();
 
   std::shared_ptr<const RobotContext> get_context() const;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -308,7 +308,9 @@ public:
           const auto&)
         {
           if (const auto context = w.lock())
+          {
             context->set_commission(commission);
+          }
         });
     }
   }

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -61,6 +61,7 @@ using ActivityIdentifier = agv::RobotUpdateHandle::ActivityIdentifier;
 using ActionExecution = agv::RobotUpdateHandle::ActionExecution;
 using RobotInterruption = agv::RobotUpdateHandle::Interruption;
 using IssueTicket = agv::RobotUpdateHandle::IssueTicket;
+using Commission = agv::RobotUpdateHandle::Commission;
 using Stubbornness = agv::RobotUpdateHandle::Unstable::Stubbornness;
 
 void bind_types(py::module&);
@@ -291,7 +292,14 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("text"))
   .def("enable_responsive_wait",
     &agv::RobotUpdateHandle::enable_responsive_wait,
-    py::arg("value"));
+    py::arg("value"))
+  .def("set_commission",
+    &agv::RobotUpdateHandle::set_commission,
+    py::arg("commission"))
+  .def("commission",
+    &agv::RobotUpdateHandle::commission)
+  .def("reassign_dispatched_tasks",
+    &agv::RobotUpdateHandle::reassign_dispatched_tasks);
 
   // ACTION EXECUTOR   =======================================================
   auto m_robot_update_handle = m.def_submodule("robot_update_handle");
@@ -353,6 +361,22 @@ PYBIND11_MODULE(rmf_adapter, m) {
     .value("Info", agv::RobotUpdateHandle::Tier::Info)
     .value("Warning", agv::RobotUpdateHandle::Tier::Warning)
     .value("Error", agv::RobotUpdateHandle::Tier::Error);
+
+  // Commission ======================================================
+  py::class_<Commission>(
+    m_robot_update_handle, "Commission")
+  .def_property(
+    "accept_dispatched_tasks",
+    &Commission::is_accepting_dispatched_tasks,
+    &Commission::accept_dispatched_tasks)
+  .def_property(
+    "accept_direct_tasks",
+    &Commission::is_accepting_direct_tasks,
+    &Commission::accept_direct_tasks)
+  .def_property(
+    "perform_idle_behavior",
+    &Commission::is_performing_idle_behavior,
+    &Commission::perform_idle_behavior);
 
   // Stubbornness ============================================================
   py::class_<Stubbornness>(


### PR DESCRIPTION
We have had a decommission feature in the unstable API for a while now, but it left some loose ends, e.g. what should be done with pending tasks that were already assigned to the decommissioned robot?

This PR adds a stable API for changing the commissioning of a robot. It provides a number of settings that allow the commission to be customized based on the needs of the deployment. Acceptance of dispatched tasks, direct tasks, and performing idle behavior can all be toggled separately. Any of these three can be toggled on or off at any time.

When requesting a change in commission it is also possible to specify what should happen with pending tasks for the robot. For dispatched tasks, there are three options, with `reassign` being the default:
* `reassign`: The robot's tasks will be reassigned to other robots within the fleet. If the robot is being decommissioned for dispatched tasks then its pending tasks will be distributed across all the remaining robots in the fleet that are currently commissioned for dispatch requests. If there are no more robots in the fleet that are commissioned for dispatch requests, then the pending tasks will be canceled. If `reassign` is used while **re**commissioning a robot (toggling its `dispatch_tasks` commission to `true`) then the recommissioned robot may immediately draw in pending tasks from other robots in the fleet.
* `complete`: There will be no change to the pending dispatched tasks of the robot. Even if the `dispatch_tasks` commission is being toggled off, the robot will continue to complete its pending task queue but will not accept any new dispatched tasks.
* `cancel`: All pending dispatched tasks for the robot will be canceled. If set, this will take effect whether the robot's `dispatch_tasks` commission is being toggled on or off or remaining unchanged, so avoid using this setting recklessly. 

The only options provided for handling the pending direct tasks are `complete` and `cancel` with `complete` being the default. We currently do not provide a way to reassign pending direct tasks from one robot to another.

Any changes to commissioning do not impact any tasks that are currently running. RMF does not currently provide a reliable way to hand off an ongoing task from one robot to another. If a robot that is currently running a task has been decommissioned, then the operator or system integrator must decide whether to allow the ongoing task to finish or to additionally issue a request to cancel the ongoing task. This choice will likely depend on operational and situational details, which is why this API does not take any automatic action on it.

This PR also fixes some previously existing issues:
* If a robot in the fleet happens to begin one of its pending tasks in the very brief window between when a new task bid began and when that bid gets awarded, then that new task would never actually be run. This was a bug that has been overlooked because this race condition has such an extremely rare window that we have never noticed it happen before.
* In some rare cases a newly awarded task bid would require the fleet adapter to replan all the tasks for its fleet, and that replanning was taking place on the main event loop worker, which would potentially delay all other main event loop callbacks that need to be processed. This has been fixed so that all task planning happens on a separate worker.