### PR TITLE
Mutex group manual release

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -73,6 +73,8 @@ const std::string ChargingAssignmentsTopicName = "charging_assignments";
 
 const std::string MutexGroupRequestTopicName = "mutex_group_request";
 const std::string MutexGroupStatesTopicName = "mutex_group_states";
+const std::string MutexGroupManualReleaseTopicName =
+  "mutex_group_manual_release";
 
 const uint64_t Unclaimed = (uint64_t)(-1);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1285,6 +1285,23 @@ void FleetUpdateHandle::Implementation::update_fleet_state() const
         commission.is_performing_idle_behavior();
 
       json["commission"] = commission_json;
+
+      nlohmann::json mutex_groups_json;
+      std::vector<std::string> locked_mutex_groups;
+      for (const auto& g : context->locked_mutex_groups())
+      {
+        locked_mutex_groups.push_back(g.first);
+      }
+      mutex_groups_json["locked"] = std::move(locked_mutex_groups);
+
+      std::vector<std::string> requesting_mutex_groups;
+      for (const auto& g : context->requesting_mutex_groups())
+      {
+        requesting_mutex_groups.push_back(g.first);
+      }
+      mutex_groups_json["requesting"] = std::move(requesting_mutex_groups);
+
+      json["mutex_groups"] = std::move(mutex_groups_json);
     }
 
     try

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1070,6 +1070,13 @@ RobotContext::locked_mutex_groups() const
 }
 
 //==============================================================================
+const std::unordered_map<std::string, TimeMsg>&
+RobotContext::requesting_mutex_groups() const
+{
+  return _requesting_mutex_groups;
+}
+
+//==============================================================================
 const rxcpp::observable<std::string>& RobotContext::request_mutex_groups(
   std::unordered_set<std::string> groups,
   rmf_traffic::Time claim_time)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1495,6 +1495,7 @@ void RobotContext::_check_mutex_groups(
   }
 }
 
+//==============================================================================
 void RobotContext::_retain_mutex_groups(
   const std::unordered_set<std::string>& retain,
   std::unordered_map<std::string, TimeMsg>& groups)
@@ -1594,6 +1595,30 @@ void RobotContext::_publish_mutex_group_requests()
   {
     publish(MutexGroupData{name, time});
   }
+}
+
+//==============================================================================
+void RobotContext::_handle_mutex_group_manual_release(
+  const rmf_fleet_msgs::msg::MutexGroupManualRelease& msg)
+{
+  if (msg.fleet != group())
+    return;
+
+  if (msg.robot != name())
+    return;
+
+  std::unordered_set<std::string> retain;
+  for (const auto& g : _locked_mutex_groups)
+  {
+    retain.insert(g.first);
+  }
+
+  for (const auto& g : msg.release_mutex_groups)
+  {
+    retain.erase(g);
+  }
+
+  retain_mutex_groups(retain);
 }
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -676,8 +676,13 @@ public:
   /// Check if a door is being held
   const std::optional<std::string>& holding_door() const;
 
-  /// What mutex group is currently being locked.
+  /// What mutex groups are currently locked by this robot.
   const std::unordered_map<std::string, TimeMsg>& locked_mutex_groups() const;
+
+  /// What mutex groups are currently being requested (but have not yet been
+  /// locked) by this robot.
+  const std::unordered_map<std::string, TimeMsg>&
+  requesting_mutex_groups() const;
 
   /// Set the mutex group that this robot needs to lock.
   const rxcpp::observable<std::string>& request_mutex_groups(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -777,17 +777,17 @@ public:
 
     context->_mutex_group_manual_release_sub =
       context->_node->create_subscription<
-        rmf_fleet_msgs::msg::MutexGroupManualRelease>(
-        MutexGroupManualReleaseTopicName,
-        rclcpp::SystemDefaultsQoS()
-          .reliable()
-          .keep_last(10),
-        [w = context->weak_from_this()](
-          rmf_fleet_msgs::msg::MutexGroupManualRelease::SharedPtr msg)
-        {
-          if (const auto self = w.lock())
-            self->_handle_mutex_group_manual_release(*msg);
-        });
+      rmf_fleet_msgs::msg::MutexGroupManualRelease>(
+      MutexGroupManualReleaseTopicName,
+      rclcpp::SystemDefaultsQoS()
+      .reliable()
+      .keep_last(10),
+      [w = context->weak_from_this()](
+        rmf_fleet_msgs::msg::MutexGroupManualRelease::SharedPtr msg)
+      {
+        if (const auto self = w.lock())
+          self->_handle_mutex_group_manual_release(*msg);
+      });
 
     return context;
   }


### PR DESCRIPTION
This adds the ability to manually release a mutex group for a robot by publishing a `rmf_fleet_msgs::msg::MutexGroupManualRelease` message on the `mutex_group_manual_release` topic. It also publishes each robot's mutex group information in their `robot_state` updates.

This PR depends on:
* https://github.com/open-rmf/rmf_api_msgs/pull/49
* https://github.com/open-rmf/rmf_internal_msgs/pull/67