### PR TITLE
Fix schema loading

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -64,6 +64,7 @@
 #include <rmf_api_msgs/schemas/undo_skip_phase_request.hpp>
 #include <rmf_api_msgs/schemas/undo_skip_phase_response.hpp>
 #include <rmf_api_msgs/schemas/error.hpp>
+#include <rmf_api_msgs/schemas/commission.hpp>
 
 namespace rmf_fleet_adapter {
 
@@ -243,7 +244,8 @@ TaskManagerPtr TaskManager::make(
     rmf_api_msgs::schemas::task_request,
     rmf_api_msgs::schemas::undo_skip_phase_request,
     rmf_api_msgs::schemas::undo_skip_phase_response,
-    rmf_api_msgs::schemas::error
+    rmf_api_msgs::schemas::error,
+    rmf_api_msgs::schemas::commission
   };
 
   for (const auto& schema : schemas)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -67,6 +67,7 @@
 #include <rmf_api_msgs/schemas/fleet_log_update.hpp>
 #include <rmf_api_msgs/schemas/fleet_log.hpp>
 #include <rmf_api_msgs/schemas/log_entry.hpp>
+#include <rmf_api_msgs/schemas/commission.hpp>
 
 #include <rmf_fleet_adapter/schemas/event_description__perform_action.hpp>
 
@@ -432,7 +433,8 @@ public:
       rmf_api_msgs::schemas::robot_state,
       rmf_api_msgs::schemas::location_2D,
       rmf_api_msgs::schemas::fleet_log,
-      rmf_api_msgs::schemas::log_entry
+      rmf_api_msgs::schemas::log_entry,
+      rmf_api_msgs::schemas::commission
     };
 
     for (const auto& schema : schemas)


### PR DESCRIPTION
After https://github.com/open-rmf/rmf_api_msgs/pull/50 was merged, the schema dictionary of `rmf_fleet_adapter` became out of date because a new schema file was added to the collection. This PR updates the dictionary.