### PR TITLE
Add reassign task allocation API

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -401,6 +401,9 @@ public:
   FleetUpdateHandle& set_retreat_to_charger_interval(
     std::optional<rmf_traffic::Duration> duration);
 
+  /// Trigger a replan for task allocation for robots in this fleet.
+  FleetUpdateHandle& reassign_dispatched_tasks();
+
   /// Get the rclcpp::Node that this fleet update handle will be using for
   /// communication.
   std::shared_ptr<rclcpp::Node> node();

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -2539,6 +2539,13 @@ FleetUpdateHandle& FleetUpdateHandle::set_retreat_to_charger_interval(
 }
 
 //==============================================================================
+FleetUpdateHandle& FleetUpdateHandle::reassign_dispatched_tasks()
+{
+  _pimpl->reassign_dispatched_tasks([]() {}, [](auto) {});
+  return *this;
+}
+
+//==============================================================================
 std::shared_ptr<rclcpp::Node> FleetUpdateHandle::node()
 {
   return _pimpl->node;

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -596,7 +596,9 @@ PYBIND11_MODULE(rmf_adapter, m) {
         );
     },
     py::arg("category"),
-    py::arg("consider"));
+    py::arg("consider"))
+  .def("reassign_dispatched_tasks",
+    &agv::FleetUpdateHandle::reassign_dispatched_tasks);
 
   // TASK REQUEST CONFIRMATION ===============================================
   auto m_fleet_update_handle = m.def_submodule("fleet_update_handle");


### PR DESCRIPTION
This PR exposes the `reassign_dispatched_tasks` API to be usable from fleet adapter implementations. This allows users to request for a replan of task allocation at runtime in scenarios, especially in scenarios where a robot may be stuck on a task longer than expected with a queued task. 