### PR TITLE
Load the parking waypoint into RobotContext; access it in adapter and FleetUpdateHandle

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -102,6 +102,11 @@ public:
   /// property will be assumed as the charger for this robot.
   RobotUpdateHandle& set_charger_waypoint(const std::size_t charger_wp);
 
+  /// Set the waypoint where the parking spot for this robot is located.
+  /// If not specified, the nearest waypoint in the graph with the is_parking_spot()
+  /// property will be assumed as the parking spot for this robot.
+  RobotUpdateHandle& set_parking_waypoint(const std::size_t parking_wp);
+
   /// Update the current battery level of the robot by specifying its state of
   /// charge as a fraction of its total charge capacity
   void update_battery_soc(const double battery_soc);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -275,7 +275,9 @@ std::function<rmf_task::State()> RobotContext::make_get_state()
         self->_location.front(),
         self->_charger_wp,
         self->_current_battery_soc);
-
+      state.load_parking_waypoint(
+        self->_parking_wp);
+        
       state.insert<GetContext>(GetContext{self->shared_from_this()});
       return state;
     };
@@ -316,6 +318,12 @@ RobotContext& RobotContext::current_battery_soc(const double battery_soc)
 std::size_t RobotContext::dedicated_charger_wp() const
 {
   return _charger_wp;
+}
+
+//==============================================================================
+std::size_t RobotContext::dedicated_parking_wp() const
+{
+  return _parking_wp;
 }
 
 //==============================================================================
@@ -491,6 +499,7 @@ RobotContext::RobotContext(
   _requester_id(
     _itinerary.description().owner() + "/" + _itinerary.description().name()),
   _charger_wp(state.dedicated_charging_waypoint().value()),
+  _parking_wp(state.dedicated_parking_waypoint().value()),
   _current_task_end_state(state),
   _current_task_id(std::nullopt),
   _task_planner(std::move(task_planner)),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -182,7 +182,11 @@ public:
   /// publishes the battery soc via _battery_soc_publisher.
   RobotContext& current_battery_soc(const double battery_soc);
 
+  /// Get the dedicated charging waypoint for the robot
   std::size_t dedicated_charger_wp() const;
+
+  /// Get the dedicated parking waypoint for the robot
+  std::size_t dedicated_parking_wp() const;
 
   // Get a reference to the battery soc observer of this robot.
   const rxcpp::observable<double>& observe_battery_soc() const;
@@ -289,6 +293,7 @@ private:
   /// Always call the current_battery_soc() setter to set a new value
   double _current_battery_soc = 1.0;
   std::size_t _charger_wp;
+  std::size_t _parking_wp;
   rxcpp::subjects::subject<double> _battery_soc_publisher;
   rxcpp::observable<double> _battery_soc_obs;
   rmf_task::State _current_task_end_state;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -208,6 +208,25 @@ RobotUpdateHandle& RobotUpdateHandle::set_charger_waypoint(
 }
 
 //==============================================================================
+RobotUpdateHandle& RobotUpdateHandle::set_parking_waypoint(
+  const std::size_t parking_wp)
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    auto end_state = context->current_task_end_state();
+    end_state.dedicated_parking_waypoint(parking_wp);
+    context->current_task_end_state(end_state);
+    RCLCPP_INFO(
+      context->node()->get_logger(),
+      "Parking waypoint for robot [%s] set to index [%ld]",
+      context->name().c_str(),
+      parking_wp);
+  }
+
+  return *this;
+}
+
+//==============================================================================
 void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 {
   if (battery_soc < 0.0 || battery_soc > 1.0)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -294,6 +294,7 @@ public:
 
   // TODO Support for various charging configurations
   std::unordered_set<std::size_t> charging_waypoints = {};
+  std::unordered_set<std::size_t> parking_waypoints = {};
 
   std::shared_ptr<rmf_task_ros2::bidding::AsyncBidder> bidder = nullptr;
 
@@ -425,6 +426,13 @@ public:
         handle->_pimpl->charging_waypoints.insert(i);
     }
 
+    // Populate parking waypoints
+    for (std::size_t i = 0; i < graph.num_waypoints(); ++i)
+    {
+      if (graph.get_waypoint(i).is_parking_spot())
+        handle->_pimpl->parking_waypoints.insert(i);
+    }
+
     // Initialize schema dictionary
     const std::vector<nlohmann::json> schemas = {
       rmf_api_msgs::schemas::fleet_state_update,
@@ -550,6 +558,9 @@ public:
   void dispatch_command_cb(const DispatchCmdMsg::SharedPtr msg);
 
   std::optional<std::size_t> get_nearest_charger(
+    const rmf_traffic::agv::Planner::Start& start);
+
+  std::optional<std::size_t> get_nearest_parking_wp(
     const rmf_traffic::agv::Planner::Start& start);
 
   struct Expectations

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -115,6 +115,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("start_set"))
   .def("set_charger_waypoint", &agv::RobotUpdateHandle::set_charger_waypoint,
     py::arg("charger_wp"))
+  .def("set_parking_waypoint", &agv::RobotUpdateHandle::set_parking_waypoint,
+    py::arg("parking_wp"))
   .def("update_battery_soc", &agv::RobotUpdateHandle::update_battery_soc,
     py::arg("battery_soc"))
   .def("override_status", &agv::RobotUpdateHandle::override_status,


### PR DESCRIPTION
## Bug fix

### Fixed bug
Currently if we set the parking waypoint of a robot to a waypoint that is not a charger, and configure the finishing request as "park", the robot will still go back to its charger, instead of its parking spot, after finishing a task. This bug is raised in issue https://github.com/open-rmf/rmf_demos/issues/219 and https://github.com/open-rmf/rmf_task/issues/115.


### Fix applied
This issue happens because when we generate a parking request for the robot, we did not pass in a parking spot waypoint, and therefore the robot will head to its charger as default. My approach is the similar as suggested by Yadunund in https://github.com/open-rmf/rmf_task/issues/115 (the only difference is because I am on the humble branch instead of the main branch).

Basically, the Fleet adapter will read the dedicated parking waypoint for each robot from the configuration file, pass that waypoint to RobotCommandHandle and RobotUpdateHandle so that this waypoint will be set as the dedicated parking waypoint for each robot. When sending requests to robots, fleet adapter needs to know each robot's State, which can be retrieved through RobotContext. The robots' current state with a dedicated parking waypoint will be sent back to the fleet adapter. When creating finishing request, if the finishing request is configured as "park", fleet adapter will call the ParkRobotFactory class to use that parking waypoint as a finishing waypoint.

To implement the fix, I need to make changes to three repos: rmf_demos, rmf_task, and rmf_ros2. And therefore I have three pull requests. Please review them together.
