### PR TITLE
Filter DoorOpen insertion by map name

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ExecutePlan.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ExecutePlan.cpp
@@ -739,13 +739,18 @@ std::optional<ExecutePlan> ExecutePlan::make(
 
     if (first_graph_wp.has_value())
     {
-      const Eigen::Vector2d p1 =
-        graph.get_waypoint(*first_graph_wp).get_location();
+      const auto& wp = graph.get_waypoint(*first_graph_wp);
+      const Eigen::Vector2d p1 = wp.get_location();
+      const auto& map = wp.get_map_name();
 
       // Check if the line from the start of the plan to this waypoint crosses
       // through a door, and add a DoorOpen phase if it does
       for (const auto& door : graph.all_known_doors())
       {
+        if (door->map() != map)
+        {
+          continue;
+        }
 
         if (door->intersects(p0, p1, envelope))
         {
@@ -762,7 +767,6 @@ std::optional<ExecutePlan> ExecutePlan::make(
         }
       }
 
-      const auto& map = graph.get_waypoint(*first_graph_wp).get_map_name();
       // Check if the robot is going into a lift and summon the lift
       for (const auto& lift : graph.all_known_lifts())
       {


### PR DESCRIPTION
It [was reported](https://github.com/open-rmf/rmf/discussions/454#discussioncomment-9378856) by @cwrx777 that when a replan happens while a robot is passing through door, the code that ensures the door is held open may accidentally open doors on other maps that are vertically aligned with the one that needs to be held open. This PR fixes the issue.

I tested this by running the hotel world and sending the robot through a door on L2 that has a matching door above it on L3. I force a replan to happen just before the robot attempts to go through the door. Before this PR, both doors would open after the replan. After this PR only the door on L2 is opened.