### PR TITLE
Dispatcher only use websockets when dispatch fails

### DIFF
--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -795,10 +795,14 @@ public:
       }
 
       /// Publish failed bid
-      const auto task_state_update =
+      const auto task_state =
         create_task_state_json(dispatch_state, "failed");
       if (broadcast_client)
+      {
+        auto task_state_update = _task_state_update_json;
+        task_state_update["data"] = task_state;
         broadcast_client->publish(task_state_update);
+      }
 
       auctioneer->ready_for_next_bid();
       return;
@@ -870,9 +874,6 @@ public:
     dispatch_json["status"] = status_to_string(state->status);
     dispatch_json["errors"] = state->errors;
     task_state["dispatch"] = dispatch_json;
-
-    auto task_state_update = _task_state_update_json;
-    task_state_update["data"] = task_state;
 
     /// TODO: (YL) json validator for taskstateupdate
     return task_state;

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -795,10 +795,10 @@ public:
       }
 
       /// Publish failed bid
-      const auto task_state =
-        create_task_state_json(dispatch_state, "failed");
       if (broadcast_client)
       {
+        const auto task_state =
+          create_task_state_json(dispatch_state, "failed");
         auto task_state_update = _task_state_update_json;
         task_state_update["data"] = task_state;
         broadcast_client->publish(task_state_update);


### PR DESCRIPTION
## Bug fix

### Fixed bug

This is not technically a bug, but rather a bit of a workaround due to https://github.com/tortoise/tortoise-orm/issues/792

Due to this issue upstream (a fix for a newer version is on the way), there are occasions where the API server receives responses from the dispatcher via ROS 2 api response and websocket responses in quick succession where the DB still has no entry to the task ID yet.

Even with a mutex for this state save, it still doesn't resolve it.

This workaround only sends out a state update via websocket (if server URI is provided), when the task dispatch fails

This way, when a task dispatch succeeds, the API server will only hear from a single source, the ROS 2 API responses.