### PR TITLE
Fix race condition for ingesting/dispensing and disable uncrustify tests by default

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -49,7 +49,9 @@ foreach(pkg ${dep_pkgs})
   find_package(${pkg} REQUIRED)
 endforeach()
 
-if(BUILD_TESTING)
+# Disable uncrustify tests by default.
+set(TEST_UNCRUSTIFY "Off")
+if(BUILD_TESTING AND TEST_UNCRUSTIFY)
   find_package(ament_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file
     NAMES "rmf_code_style.cfg"

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DispenseItem.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DispenseItem.cpp
@@ -160,11 +160,13 @@ LegacyTask::StatusMsg DispenseItem::ActivePhase::_get_status(
   status.state = LegacyTask::StatusMsg::STATE_ACTIVE;
 
   using rmf_dispenser_msgs::msg::DispenserResult;
-  if (dispenser_result
-    && dispenser_result->request_guid == _request_guid
-    && is_newer(dispenser_result->time, _last_msg))
+  if (dispenser_result && dispenser_result->request_guid == _request_guid)
   {
-    _last_msg = dispenser_result->time;
+    if (is_newer(dispenser_result->time, _last_msg))
+    {
+      _last_msg = dispenser_result->time;
+    }
+
     switch (dispenser_result->status)
     {
       case DispenserResult::ACKNOWLEDGED:

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/IngestItem.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/IngestItem.cpp
@@ -159,11 +159,13 @@ LegacyTask::StatusMsg IngestItem::ActivePhase::_get_status(
   status.state = LegacyTask::StatusMsg::STATE_ACTIVE;
 
   using rmf_ingestor_msgs::msg::IngestorResult;
-  if (ingestor_result
-    && ingestor_result->request_guid == _request_guid
-    && is_newer(ingestor_result->time, _last_msg))
+  if (ingestor_result && ingestor_result->request_guid == _request_guid)
   {
-    _last_msg = ingestor_result->time;
+    if (is_newer(ingestor_result->time, _last_msg))
+    {
+      _last_msg = ingestor_result->time;
+    }
+
     switch (ingestor_result->status)
     {
       case IngestorResult::ACKNOWLEDGED:

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/Utils.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/Utils.cpp
@@ -23,7 +23,7 @@ namespace phases {
 bool is_newer(const builtin_interfaces::msg::Time& a,
   const builtin_interfaces::msg::Time& b)
 {
-  return a.sec > b.sec || (a.sec == b.sec && a.nanosec > b.nanosec);
+  return a.sec > b.sec || (a.sec == b.sec && a.nanosec >= b.nanosec);
 }
 
 } // namespace phases

--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -55,20 +55,22 @@ ament_export_targets(rmf_task_ros2 HAS_LIBRARY_TARGET)
 ament_export_dependencies(rmf_traffic rmf_task_msgs rclcpp nlohmann_json)
 
 #===============================================================================
-
+set(TEST_UNCRUSTIFY "Off")
 if(BUILD_TESTING)
   find_package(ament_cmake_catch2 QUIET)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  find_file(uncrustify_config_file
-    NAMES "rmf_code_style.cfg"
-    PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
+  if (TEST_UNCRUSTIFY)
+    find_package(ament_cmake_uncrustify REQUIRED)
+    find_file(uncrustify_config_file
+      NAMES "rmf_code_style.cfg"
+      PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  ament_uncrustify(
-    ARGN include src test
-    CONFIG_FILE ${uncrustify_config_file}
-    LANGUAGE C++
-    MAX_LINE_LENGTH 80
-  )
+    ament_uncrustify(
+      ARGN include src test
+      CONFIG_FILE ${uncrustify_config_file}
+      LANGUAGE C++
+      MAX_LINE_LENGTH 80
+    )
+  endif()
 
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
 

--- a/rmf_task_ros2/test/bidding/test_SelfBid.cpp
+++ b/rmf_task_ros2/test/bidding/test_SelfBid.cpp
@@ -142,7 +142,7 @@ SCENARIO("Auction with 2 Bids", "[TwoBids]")
     REQUIRE(!test_notice_bidder2.has_value()); // bidder2 doesn't support patrol
 
     executor.spin_until_future_complete(ready_future,
-      rmf_traffic::time::from_seconds(5.0));
+      rmf_traffic::time::from_seconds(2.5));
 
     // Check if Auctioneer received Bid from bidder1
     REQUIRE(r_result_winner == "bidder1");
@@ -164,7 +164,7 @@ SCENARIO("Auction with 2 Bids", "[TwoBids]")
     REQUIRE(*test_notice_bidder2 == bidding_task2.request);
 
     executor.spin_until_future_complete(ready_future,
-      rmf_traffic::time::from_seconds(5.0));
+      rmf_traffic::time::from_seconds(2.5));
 
     // Check if Auctioneer received Bid from bidder1
     REQUIRE(r_result_winner == "bidder2");

--- a/rmf_task_ros2/test/bidding/test_SelfBid.cpp
+++ b/rmf_task_ros2/test/bidding/test_SelfBid.cpp
@@ -142,7 +142,7 @@ SCENARIO("Auction with 2 Bids", "[TwoBids]")
     REQUIRE(!test_notice_bidder2.has_value()); // bidder2 doesn't support patrol
 
     executor.spin_until_future_complete(ready_future,
-      rmf_traffic::time::from_seconds(2.5));
+      rmf_traffic::time::from_seconds(5.0));
 
     // Check if Auctioneer received Bid from bidder1
     REQUIRE(r_result_winner == "bidder1");
@@ -164,7 +164,7 @@ SCENARIO("Auction with 2 Bids", "[TwoBids]")
     REQUIRE(*test_notice_bidder2 == bidding_task2.request);
 
     executor.spin_until_future_complete(ready_future,
-      rmf_traffic::time::from_seconds(2.5));
+      rmf_traffic::time::from_seconds(5.0));
 
     // Check if Auctioneer received Bid from bidder1
     REQUIRE(r_result_winner == "bidder2");

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -41,19 +41,24 @@ if (rmf_traffic_FOUND)
   message(STATUS "rmf_traffic_INCLUDE_DIRS: ${rmf_traffic_INCLUDE_DIRS}")
 endif()
 
+# Disable uncrustify tests by default.
+set(TEST_UNCRUSTIFY "Off")
 if(BUILD_TESTING)
   find_package(ament_cmake_catch2 QUIET)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  find_file(uncrustify_config_file
-    NAMES "rmf_code_style.cfg"
-    PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  ament_uncrustify(
-    ARGN include src examples
-    CONFIG_FILE ${uncrustify_config_file}
-    LANGUAGE C++
-    MAX_LINE_LENGTH 80
-  )
+  if(TEST_UNCRUSTIFY)
+    find_package(ament_cmake_uncrustify REQUIRED)
+    find_file(uncrustify_config_file
+      NAMES "rmf_code_style.cfg"
+      PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
+
+    ament_uncrustify(
+      ARGN include src examples
+      CONFIG_FILE ${uncrustify_config_file}
+      LANGUAGE C++
+      MAX_LINE_LENGTH 80
+    )
+  endif()
 
   file(GLOB_RECURSE unit_test_srcs "test/unit/*.cpp")
 

--- a/rmf_websocket/CMakeLists.txt
+++ b/rmf_websocket/CMakeLists.txt
@@ -88,18 +88,22 @@ install(
   ARCHIVE DESTINATION lib
 )
 
+# Disable uncrustify tests by default.
+set(TEST_UNCRUSTIFY "Off")
 if(BUILD_TESTING)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  find_file(uncrustify_config_file
-    NAMES "rmf_code_style.cfg"
-    PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
+  if(TEST_UNCRUSTIFY)
+    find_package(ament_cmake_uncrustify REQUIRED)
+    find_file(uncrustify_config_file
+      NAMES "rmf_code_style.cfg"
+      PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  ament_uncrustify(
-    include src
-    CONFIG_FILE ${uncrustify_config_file}
-    LANGUAGE C++
-    MAX_LINE_LENGTH 80
-  )
+    ament_uncrustify(
+      include src
+      CONFIG_FILE ${uncrustify_config_file}
+      LANGUAGE C++
+      MAX_LINE_LENGTH 80
+    )
+  endif()
 
   # unit test
   find_package(ament_cmake_catch2 REQUIRED)


### PR DESCRIPTION
#359 is blocked by uncrustify tests and #361 attempted to lint the code to fix the style checks however it became clear that having a single codebase pass uncrustify on Jammy and Noble is not feasible. Since we want to keep CI on `main` compatible with Humble and Rolling, the best option is to disable uncrustify checks in testing.