### PR TITLE
Fix serialization of exit events

### DIFF
--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Graph.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Graph.cpp
@@ -906,7 +906,7 @@ std::unique_ptr<rmf_building_map_msgs::msg::Graph> convert(
     if (exit_event != nullptr)
     {
       EventPhaseFactory factory("exit", params);
-      entry_event->execute(factory);
+      exit_event->execute(factory);
     }
     const auto* exit_orientation = lane.entry().orientation_constraint();
     if (exit_orientation != nullptr)


### PR DESCRIPTION
As reported in #363 we were not serializing exit events correctly when converting a nav graph into a ROS message. Entry events were accidentally being serialized in place of exit events. In situations where an exit event was present but not an entry event on the same lane, this would lead to a segmentation fault.

This PR fixes the mistake.