### PR TITLE
Add a timeout before automatically releasing lift

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1333,11 +1333,29 @@ void RobotContext::_check_lift_state(
   {
     if (_lift_destination && !_lift_destination->requested_from_inside)
     {
-      // The lift destination reference count dropping to one while the lift
-      // destination request is on the outside means the task that prompted the
-      // lift usage was cancelled while the robot was outside of the lift.
-      // Therefore we should release the usage of the lift.
-      release_lift();
+      const auto now = std::chrono::steady_clock::now();
+      if (_initial_time_idle_outside_lift.has_value())
+      {
+        const auto lapse = now - *_initial_time_idle_outside_lift;
+        if (lapse > std::chrono::seconds(30))
+        {
+          // The lift destination reference count dropping to one while the lift
+          // destination request is on the outside means the task that prompted
+          // the lift usage was cancelled while the robot was outside of the lift.
+          // Therefore we should release the usage of the lift.
+          RCLCPP_INFO(
+            _node->get_logger(),
+            "Requesting lift [%s] to be released for [%s] because it is outside "
+            "the lift and not holding a claim for an extended period of time.",
+            _lift_destination->lift_name.c_str(),
+            requester_id().c_str());
+          release_lift();
+        }
+      }
+      else
+      {
+        _initial_time_idle_outside_lift = now;
+      }
     }
     else if (_lift_destination && !_current_task_id.has_value())
     {
@@ -1362,7 +1380,7 @@ void RobotContext::_check_lift_state(
         if (_initial_time_idle_outside_lift.has_value())
         {
           const auto lapse = now - *_initial_time_idle_outside_lift;
-          if (lapse > std::chrono::seconds(2))
+          if (lapse > std::chrono::seconds(10))
           {
             RCLCPP_INFO(
               _node->get_logger(),
@@ -1370,8 +1388,8 @@ void RobotContext::_check_lift_state(
               "outside of the lift.",
               _lift_destination->lift_name.c_str(),
               requester_id().c_str());
+            release_lift();
           }
-          release_lift();
         }
         else
         {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -387,14 +387,6 @@ struct MutexGroupData
 };
 
 //==============================================================================
-struct MutexGroupSwitch
-{
-  std::string from;
-  std::string to;
-  std::function<bool()> accept;
-};
-
-//==============================================================================
 class RobotContext
   : public std::enable_shared_from_this<RobotContext>,
   public rmf_traffic::schedule::Negotiator

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.cpp
@@ -111,6 +111,16 @@ void RequestLift::ActivePhase::_init_obs()
           if (!self)
             return;
 
+          if (self->_data.located == Located::Outside)
+          {
+            // The robot is going to start moving into the lift now, so we
+            // should lock in the lift by saying that the request is coming from
+            // inside the lift. This will prevent the auto-detection system from
+            // releasing the lift prematurely.
+            self->_context->set_lift_destination(
+              self->_lift_name, self->_destination, true);
+          }
+
           if (self->_data.resume_itinerary)
           {
             self->_context->schedule_itinerary(
@@ -411,8 +421,10 @@ bool RequestLift::ActivePhase::_finish()
 
   if (_data.located == Located::Outside)
   {
-    // The robot is going to start moving into the lift now, so we should lock
-    // the destination in.
+    // The robot is going to start moving into the lift now, so we
+    // should lock in the lift by saying that the request is coming from
+    // inside the lift. This will prevent the auto-detection system from
+    // releasing the lift prematurely.
     _context->set_lift_destination(_lift_name, _destination, true);
 
     // We should replan to make sure there are no traffic issues that came up


### PR DESCRIPTION
It's been discovered that a race condition can cause a deadlock when lift session usage is combined with lane mutexes.

If a robot locks the lane mutexes for the lift and begins a lift session but then a replan occurs before the robot enters the lift, there is a narrow window where the robot might automatically drop the lift session. If another robot is also summoning the lift simultaneously then that other robot could manage to take over the lift session. However the first robot will still be holding the lane mutexes. At that point, one of the robots will be waiting to lock the lift session while the other will be waiting to lock the lane mutex.

The automatic dropping of the lift session happens because of a blunt force mechanism that tries to identify when a robot is holding onto a lift session without really needing it. When a replan occurs while the robot is outside of the lift, it creates a very narrow window where that blunt force mechanism will pick up a false positive and trigger the release. This PR attempts to soften that mechanism by requiring a 30 second window to pass before doing the release automatically. This ensures that a situation where a quick replan occurs will not trigger the mechanism.

Remaining Issues / Rationale:
* In theory if something else blocks up the fleet adapter for more than 30 seconds, then the issue can still happen. However, if the fleet adapter is blocked up for 30 seconds then something much worse than this is happening and the system will likely need intervention anyway.
* We do not generally rely on this automatic release mechanism to end lift sessions. There are two other finer tuned mechanisms for knowing when a lift should be released, and the mechanism affected by this PR is only meant to be a desperate last resort. Adding a 30 second delay to mitigate harmful unintended effects seems like a reasonable measure before resorting to this mechanism. 
* I've considered whether we can introduce a blunt force mechanism to catch and resolve this deadlock situation in general, but every approach I can think of carries a risk of introducing other deadlocks due to race conditions in other situations.

This case will be taken into serious consideration as we work on the next generation traffic + resource locking mechanisms.