### PR TITLE
Fix incorrect std rounding function used when generating timestamp st…

### DIFF
--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -486,7 +486,7 @@ public:
       if (use_timestamp_for_task_id)
       {
         task_id += std::to_string(
-          static_cast<int>(node->get_clock()->now().nanoseconds()/1e6));
+          std::lround(node->get_clock()->now().seconds() * 1e3));
       }
       else
       {


### PR DESCRIPTION
…rings for task ID (#366)

(cherry picked from commit f3bf60e1730b1368ddfd17eafd6f65a70e74ef4b)

# Backport https://github.com/open-rmf/rmf_ros2/pull/366