### PR TITLE
Revert "Event based lift / door logic (#320)"

### DIFF
--- a/rmf_fleet_adapter/src/door_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/door_supervisor/Node.cpp
@@ -28,8 +28,7 @@ const std::string DoorSupervisorRequesterID = "door_supervisor";
 Node::Node()
 : rclcpp::Node("door_supervisor")
 {
-  const auto default_qos =
-    rclcpp::SystemDefaultsQoS().durability_volatile().keep_last(100).reliable();
+  const auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
 
   _door_request_pub = create_publisher<DoorRequest>(
     FinalDoorRequestTopicName, default_qos);

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -27,8 +27,7 @@ namespace lift_supervisor {
 Node::Node()
 : rclcpp::Node("rmf_lift_supervisor")
 {
-  const auto default_qos =
-    rclcpp::SystemDefaultsQoS().durability_volatile().keep_last(100).reliable();
+  const auto default_qos = rclcpp::SystemDefaultsQoS().keep_last(10);
   const auto transient_qos = rclcpp::SystemDefaultsQoS()
     .reliable().keep_last(100).transient_local();
 
@@ -69,14 +68,12 @@ void Node::_adapter_lift_request_update(LiftRequest::UniquePtr msg)
   {
     if (curr_request->session_id == msg->session_id)
     {
-      msg->request_time = this->now();
-      _lift_request_pub->publish(*msg);
       if (msg->request_type != LiftRequest::REQUEST_END_SESSION)
-      {
         curr_request = std::move(msg);
-      }
       else
       {
+        msg->request_time = this->now();
+        _lift_request_pub->publish(*msg);
         RCLCPP_INFO(
           this->get_logger(),
           "[%s] Published end lift session from lift supervisor",
@@ -88,7 +85,6 @@ void Node::_adapter_lift_request_update(LiftRequest::UniquePtr msg)
   }
   else
   {
-    _lift_request_pub->publish(*msg);
     if (msg->request_type != LiftRequest::REQUEST_END_SESSION)
     {
       curr_request = std::move(msg);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1079,12 +1079,6 @@ void RobotContext::release_lift()
       "Releasing lift [%s] for [%s]",
       _lift_destination->lift_name.c_str(),
       requester_id().c_str());
-    rmf_lift_msgs::msg::LiftRequest msg;
-    msg.lift_name = _lift_destination->lift_name;
-    msg.request_type = rmf_lift_msgs::msg::LiftRequest::REQUEST_END_SESSION;
-    msg.session_id = requester_id();
-    msg.destination_floor = _lift_destination->destination_floor;
-    _node->lift_request()->publish(msg);
   }
   _lift_destination = nullptr;
   _initial_time_idle_outside_lift = std::nullopt;


### PR DESCRIPTION
## Bug fix

### Fixed bug

In order to avoid logic changes, #320 only increased lift request publishes to happen on both lift state callbacks and lift request callbacks, which might cause some issues in downstream lift adapters if they take time to execute each callback. Especially now that the queue size for lift requests is large (100 messages) there is a risk of queues building up.

### Fix applied

Be conservative and just revert the change, there are some changes we could keep from that PR (i.e. clearing up the qos) that I'm happy to cherry pick, but for now this is just a clean revert commit.