### PR TITLE
Use main branch for repos file in CI

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   asan_test:
     name: rmf_ros2 asan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@luca/configurable_repos_file
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       dist-matrix: |
           [{"ros_distribution": "humble",
@@ -22,3 +22,4 @@ jobs:
         rmf_task_ros2
         rmf_fleet_adapter
       mixin: asan
+      

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -10,15 +10,15 @@ on:
 jobs:
   asan_test:
     name: rmf_ros2 asan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@luca/configurable_repos_file
     with:
       dist-matrix: |
           [{"ros_distribution": "humble",
             "ubuntu_distribution": "jammy"}]
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
+      repos-branch-override: "main"
       packages: |
         rmf_traffic_ros2
         rmf_task_ros2
         rmf_fleet_adapter
       mixin: asan
-      

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,10 @@ on:
 jobs:
   build_and_test:
     name: rmf_ros2
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@luca/configurable_repos_file
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
+      repos-branch-override: "main"
       packages: |
             rmf_fleet_adapter
             rmf_fleet_adapter_python

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_and_test:
     name: rmf_ros2
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@luca/configurable_repos_file
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
       repos-branch-override: "main"

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tsan_test:
     name: rmf_ros2 tsan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@luca/configurable_repos_file
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       dist-matrix: |
           [{"ros_distribution": "humble",
@@ -22,3 +22,4 @@ jobs:
         rmf_task_ros2
         rmf_fleet_adapter
       mixin: tsan
+      

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -10,15 +10,15 @@ on:
 jobs:
   tsan_test:
     name: rmf_ros2 tsan
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@luca/configurable_repos_file
     with:
       dist-matrix: |
           [{"ros_distribution": "humble",
             "ubuntu_distribution": "jammy"}]
       # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
+      repos-branch-override: "main"
       packages: |
         rmf_traffic_ros2
         rmf_task_ros2
         rmf_fleet_adapter
       mixin: tsan
-      


### PR DESCRIPTION
Some deployments might need newer features but still rely on older ROS distros (i.e. Humble), this PR changes the CI to always use the latest `main` branches for CI and test it against a few different underlying ROS distros (i.e. Humble, Iron, Jazzy and Rolling).

Note to reviewer, the order of operations should be:

* Merge the upstream PR https://github.com/open-rmf/rmf_ci_templates/pull/15
* Revert the change on this PR that uses a custom branch on `rmf_ci_templates`.
* Do a CI run
* Merge this PR