### PR TITLE
Provide an API that says the robot's lift destination

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -469,6 +469,26 @@ public:
   /// could change in the future.
   void reassign_dispatched_tasks();
 
+  /// Information about where the lift will be asked to go for a robot.
+  class LiftDestination
+  {
+  public:
+    /// Name of the lift that is being used.
+    const std::string& lift() const;
+
+    /// Name of the level that the lift will be going to.
+    const std::string& level() const;
+
+    class Implementation;
+  private:
+    LiftDestination();
+    rmf_utils::impl_ptr<Implementation> _pimpl;
+  };
+
+  /// If this robot has begun a lift session, this will contain information
+  /// about where the robot will ask to go, and which lift it intends to use.
+  std::optional<LiftDestination> lift_destination() const;
+
   class Implementation;
 
   /// This API is experimental and will not be supported in the future. Users

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1084,6 +1084,30 @@ void RobotContext::release_lift()
   _initial_time_idle_outside_lift = std::nullopt;
   _lift_stubbornness = nullptr;
   _lift_arrived = false;
+  clear_final_lift_destination();
+}
+
+//==============================================================================
+std::optional<RobotUpdateHandle::LiftDestination>
+RobotContext::final_lift_destination() const
+{
+  std::unique_lock<std::mutex> lock(*_final_lift_destination_mutex);
+  return _final_lift_destination;
+}
+
+//==============================================================================
+void RobotContext::set_final_lift_destination(
+  RobotUpdateHandle::LiftDestination destination)
+{
+  std::unique_lock<std::mutex> lock(*_final_lift_destination_mutex);
+  _final_lift_destination = std::move(destination);
+}
+
+//==============================================================================
+void RobotContext::clear_final_lift_destination()
+{
+  std::unique_lock<std::mutex> lock(*_final_lift_destination_mutex);
+  _final_lift_destination = std::nullopt;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -680,6 +680,22 @@ public:
   /// Indicate that the lift is no longer needed
   void release_lift();
 
+  /// Get the final lift destination that the overall session intends to end at.
+  /// This is used to give robots advanced notice of what floor they will be
+  /// going to, in case they need this information in order to enter the lift
+  /// correctly.
+  std::optional<RobotUpdateHandle::LiftDestination>
+  final_lift_destination() const;
+
+  /// Change what the final lift destination is currently set to. Typically this
+  /// should only be called by RequestLift.
+  void set_final_lift_destination(
+    RobotUpdateHandle::LiftDestination destination);
+
+  /// Clear the information about the final lift destination. Typically this
+  /// should only be called by release_lift().
+  void clear_final_lift_destination();
+
   /// Check if a door is being held
   const std::optional<std::string>& holding_door() const;
 
@@ -913,6 +929,10 @@ private:
   rclcpp::Subscription<rmf_fleet_msgs::msg::MutexGroupManualRelease>::SharedPtr
     _mutex_group_manual_release_sub;
   std::chrono::steady_clock::time_point _last_active_task_time;
+
+  std::optional<RobotUpdateHandle::LiftDestination> _final_lift_destination;
+  std::unique_ptr<std::mutex> _final_lift_destination_mutex =
+    std::make_unique<std::mutex>();
 };
 
 using RobotContextPtr = std::shared_ptr<RobotContext>;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -855,6 +855,8 @@ RobotUpdateHandle::lift_destination() const
   {
     return context->final_lift_destination();
   }
+
+  return std::nullopt;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -829,6 +829,35 @@ void RobotUpdateHandle::reassign_dispatched_tasks()
 }
 
 //==============================================================================
+RobotUpdateHandle::LiftDestination::LiftDestination()
+  : _pimpl(rmf_utils::make_impl<Implementation>())
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::string& RobotUpdateHandle::LiftDestination::lift() const
+{
+  return _pimpl->lift;
+}
+
+//==============================================================================
+const std::string& RobotUpdateHandle::LiftDestination::level() const
+{
+  return _pimpl->level;
+}
+
+//==============================================================================
+std::optional<RobotUpdateHandle::LiftDestination>
+RobotUpdateHandle::lift_destination() const
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    return context->final_lift_destination();
+  }
+}
+
+//==============================================================================
 RobotUpdateHandle::RobotUpdateHandle()
 {
   // Do nothing

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -333,6 +333,23 @@ public:
   }
 };
 
+//==============================================================================
+class RobotUpdateHandle::LiftDestination::Implementation
+{
+public:
+  std::string lift;
+  std::string level;
+
+  static RobotUpdateHandle::LiftDestination make(
+    std::string lift, std::string level)
+  {
+    RobotUpdateHandle::LiftDestination result;
+    result._pimpl->lift = std::move(lift);
+    result._pimpl->level = std::move(level);
+    return result;
+  }
+};
+
 } // namespace agv
 } // namespace rmf_fleet_adapter
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.cpp
@@ -97,6 +97,11 @@ void RequestLift::ActivePhase::_init_obs()
 {
   using rmf_lift_msgs::msg::LiftState;
 
+  if (_data.final_lift_destination.has_value())
+  {
+    _context->set_final_lift_destination(*_data.final_lift_destination);
+  }
+
   if (_data.located == Located::Outside && _context->current_lift_destination())
   {
     // Check if the current destination is the one we want and also has arrived.

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.hpp
@@ -43,6 +43,9 @@ struct RequestLift
     std::shared_ptr<rmf_traffic::schedule::Itinerary> resume_itinerary =
       nullptr;
     std::optional<rmf_traffic::agv::Plan::Waypoint> hold_point = std::nullopt;
+
+    std::optional<agv::RobotUpdateHandle::LiftDestination>
+    final_lift_destination = std::nullopt;
   };
 
   class ActivePhase : public LegacyTask::ActivePhase,
@@ -126,6 +129,11 @@ struct RequestLift
     const std::string& lift_name() const
     {
       return _lift_name;
+    }
+
+    Data& data()
+    {
+      return _data;
     }
 
   private:

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -63,6 +63,7 @@ using RobotInterruption = agv::RobotUpdateHandle::Interruption;
 using IssueTicket = agv::RobotUpdateHandle::IssueTicket;
 using Commission = agv::RobotUpdateHandle::Commission;
 using Stubbornness = agv::RobotUpdateHandle::Unstable::Stubbornness;
+using LiftDestination = agv::RobotUpdateHandle::LiftDestination;
 
 void bind_types(py::module&);
 void bind_graph(py::module&);
@@ -314,7 +315,9 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def("commission",
     &agv::RobotUpdateHandle::commission)
   .def("reassign_dispatched_tasks",
-    &agv::RobotUpdateHandle::reassign_dispatched_tasks);
+    &agv::RobotUpdateHandle::reassign_dispatched_tasks)
+  .def("lift_destination",
+    &agv::RobotUpdateHandle::lift_destination);
 
   // ACTION EXECUTOR   =======================================================
   auto m_robot_update_handle = m.def_submodule("robot_update_handle");
@@ -398,6 +401,16 @@ PYBIND11_MODULE(rmf_adapter, m) {
     m_robot_update_handle, "Stubbornness")
   .def("release",
     &Stubbornness::release);
+
+  // LiftDestination ======================================================
+  py::class_<LiftDestination>(
+    m_robot_update_handle, "LiftDestination")
+  .def_property_readonly(
+    "lift",
+    &LiftDestination::lift)
+  .def_property_readonly(
+    "level",
+    &LiftDestination::level);
 
   // FLEETUPDATE HANDLE ======================================================
   py::class_<agv::FleetUpdateHandle,


### PR DESCRIPTION
This PR addresses https://github.com/open-rmf/rmf/discussions/496 by providing an API in `RobotUpdateHandle` that will contain the final destination of a lift that the robot is about to use.

By the time a robot receives a command to enter the lift, the `RobotUpdateHandle::lift_destination()` function will contain information about where the lift will be going. If the robot is not interacting with a lift, it will return a `std::nullopt`.