### PR TITLE
Fixes warning given by `colcon_ros` on Jazzy

### DIFF
--- a/rmf_charging_schedule/setup.py
+++ b/rmf_charging_schedule/setup.py
@@ -7,6 +7,7 @@ setup(
     version='2.8.0',
     packages=find_packages(),
     data_files=[
+        ('share/' + package_name, ['package.xml']),
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],


### PR DESCRIPTION
This is a small fix for when we build systems on jazzy we get the warning:

```
[5.452s] WARNING:colcon.colcon_ros.task.ament_python.build:Package 'rmf_charging_schedule' doesn't explicitly install the 'package.xml' file (colcon-ros currently does it implicitly but that fallback will be removed in the future)
```

This pr fixes this warning by installing the `package.xml`
