### PR TITLE
Allow go_to_place as long as one waypoint is valid

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Patrol.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Patrol.cpp
@@ -58,16 +58,20 @@ void add_patrol(
         for (const auto& place_msg : one_of.value())
         {
           auto place = place_deser(place_msg);
-          if (!place.description.has_value())
-          {
-            return {nullptr, std::move(place.errors)};
-          }
-
-          goals.push_back(*place.description);
           errors.insert(
             errors.end(),
             std::make_move_iterator(place.errors.begin()),
             std::make_move_iterator(place.errors.end()));
+          if (!place.description.has_value())
+          {
+            continue;
+          }
+
+          goals.push_back(*place.description);
+        }
+        if (goals.empty())
+        {
+          return {nullptr, errors};
         }
 
         auto desc = GoToPlace::Description::make_for_one_of(goals);


### PR DESCRIPTION
## New feature implementation

### Implemented feature

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

Currently a `go_to_place` with `one_of` will fail as long as any of the waypoints defined is invalid or not found in the navigation graph. This is useful when users are trying to send tasks to fleets that are able to navigate to said waypoints, however in the scenario where `go_to_place` is used for cancellation behaviours of a task that may be picked up by multiple fleets, users might not be able to determine which fleet will be performing the task before dispatching it (while constructing the task json description) hence it might make sense to insert all available cancellation lots of all fleets into the cancellation behaviour

This change hopes to make `go_to_place` with `one_of` work as long as any on of the waypoints are valid.

### Testing

This can be tested in `office` world, with this task json, before this PR the there would be no bidders for this task, while after this PR, it can be dispatched to `tinyRobot`, and cancelling the task will make the robot head to `lounge`

```
{
  "type": "dispatch_task_request",
  "request": {
    "category": "compose",
    "description": {
      "category": "go_to_place",
      "phases": [
        {
          "activity": {
            "category": "go_to_place",
            "description": {
              "waypoint": "pantry"
            }
          },
          "on_cancel": [
            {
              "category": "sequence",
              "description": [
                {
                  "category": "go_to_place",
                  "description": {
                    "one_of": [
                      {
                        "waypoint": "lounge"
                      },
                      {
                        "waypoint": "invalid1"
                      },
                      {
                        "waypoint": "invalid2"
                      }
                    ],
                    "constraints": [
                      {
                        "category": "prefer_same_map",
                        "description": ""
                      }
                    ]
                  }
                }
              ]
            }
          ]
        }
      ]
    },
    "unix_millis_earliest_start_time": 0
  }
}
```

