### PR TITLE
Allow robot-specific finishing request and specify parking spots

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -264,8 +264,8 @@ public:
     std::optional<bool> responsive_wait = std::nullopt,
     std::optional<double> max_merge_waypoint_distance = 1e-3,
     std::optional<double> max_merge_lane_distance = 0.3,
-    std::optional<double> min_lane_length = 1e-8,
-    std::optional<rmf_task::ConstRequestFactoryPtr> finishing_request = std::nullopt);
+    std::optional<double> min_lane_length = 1e-8);
+    // std::optional<rmf_task::ConstRequestFactoryPtr> finishing_request = std::nullopt);
 
   /// List of chargers that this robot is compatible with
   const std::vector<std::string>& compatible_chargers() const;

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -265,7 +265,6 @@ public:
     std::optional<double> max_merge_waypoint_distance = 1e-3,
     std::optional<double> max_merge_lane_distance = 0.3,
     std::optional<double> min_lane_length = 1e-8);
-    // std::optional<rmf_task::ConstRequestFactoryPtr> finishing_request = std::nullopt);
 
   /// List of chargers that this robot is compatible with
   const std::vector<std::string>& compatible_chargers() const;

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -264,7 +264,8 @@ public:
     std::optional<bool> responsive_wait = std::nullopt,
     std::optional<double> max_merge_waypoint_distance = 1e-3,
     std::optional<double> max_merge_lane_distance = 0.3,
-    std::optional<double> min_lane_length = 1e-8);
+    std::optional<double> min_lane_length = 1e-8,
+    std::optional<rmf_task::ConstRequestFactoryPtr> finishing_request = std::nullopt);
 
   /// List of chargers that this robot is compatible with
   const std::vector<std::string>& compatible_chargers() const;
@@ -315,6 +316,15 @@ public:
 
   /// Set the minimum lane length.
   void set_min_lane_length(std::optional<double> distance);
+
+  /// Get the idle behavior.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default finishing request
+  /// will be used.
+  std::optional<rmf_task::ConstRequestFactoryPtr> finishing_request() const;
+
+  /// Set the finishing request.
+  void set_finishing_request(std::optional<rmf_task::ConstRequestFactoryPtr> request);
 
   class Implementation;
 private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -25,6 +25,8 @@
 
 #include <rmf_traffic/schedule/Participant.hpp>
 
+#include <rmf_task/RequestFactory.hpp>
+
 #include <Eigen/Geometry>
 #include <nlohmann/json.hpp>
 
@@ -101,6 +103,9 @@ public:
   /// If not specified, the nearest waypoint in the graph with the is_charger()
   /// property will be assumed as the charger for this robot.
   RobotUpdateHandle& set_charger_waypoint(const std::size_t charger_wp);
+
+  /// Set a finishing request for this robot.
+  RobotUpdateHandle& set_finishing_request(rmf_task::ConstRequestFactoryPtr finishing_request);
 
   /// Update the current battery level of the robot by specifying its state of
   /// charge as a fraction of its total charge capacity, i.e. a value from 0.0

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -104,11 +104,11 @@ public:
   /// property will be assumed as the charger for this robot.
   RobotUpdateHandle& set_charger_waypoint(const std::size_t charger_wp);
 
-  /// Set a finishing request for this robot to use the fleet-wide finishing
-  /// request.
+  /// Set a finishing request for this robot.
   RobotUpdateHandle& set_finishing_request(rmf_task::ConstRequestFactoryPtr finishing_request);
 
-  /// Set a finishing request for this robot.
+  /// Set a finishing request for this robot to use the fleet-wide finishing
+  /// request.
   RobotUpdateHandle& use_default_finishing_request();
 
   /// Update the current battery level of the robot by specifying its state of

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -104,8 +104,12 @@ public:
   /// property will be assumed as the charger for this robot.
   RobotUpdateHandle& set_charger_waypoint(const std::size_t charger_wp);
 
-  /// Set a finishing request for this robot.
+  /// Set a finishing request for this robot to use the fleet-wide finishing
+  /// request.
   RobotUpdateHandle& set_finishing_request(rmf_task::ConstRequestFactoryPtr finishing_request);
+
+  /// Set a finishing request for this robot.
+  RobotUpdateHandle& use_default_finishing_request();
 
   /// Update the current battery level of the robot by specifying its state of
   /// charge as a fraction of its total charge capacity, i.e. a value from 0.0

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1687,6 +1687,10 @@ void TaskManager::_begin_waiting()
   }
 
   if (!_responsive_wait_enabled)
+    if (_waiting)
+    {
+      _waiting.cancel({"Idle behavior updated"}, _context->now());
+    }
     return;
 
   if (_context->location().empty())

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1691,11 +1691,13 @@ void TaskManager::_begin_waiting()
   }
 
   if (!_responsive_wait_enabled)
+  {
     if (_waiting)
     {
       _waiting.cancel({"Idle behavior updated"}, _context->now());
     }
     return;
+  }
 
   if (_context->location().empty())
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -942,6 +942,24 @@ void TaskManager::set_idle_task(rmf_task::ConstRequestFactoryPtr task)
 }
 
 //==============================================================================
+void TaskManager::use_default_idle_task()
+{
+  auto fleet_handle = _fleet_handle.lock();
+  if (!fleet_handle)
+  {
+    RCLCPP_ERROR(
+      _context->node()->get_logger(),
+      "Attempting to use default idle task for [%s] but its fleet is shutting down",
+      _context->requester_id().c_str());
+    return;
+  }
+  const auto& impl =
+    agv::FleetUpdateHandle::Implementation::get(*fleet_handle);
+
+  set_idle_task(impl.idle_task);
+}
+
+//==============================================================================
 void TaskManager::set_queue(
   const std::vector<TaskManager::Assignment>& assignments)
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -125,6 +125,8 @@ public:
 
   void set_idle_task(rmf_task::ConstRequestFactoryPtr task);
 
+  void use_default_idle_task();
+
   /// Set the queue for this task manager with assignments generated from the
   /// task planner
   void set_queue(const std::vector<Assignment>& assignments);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -137,7 +137,8 @@ EasyFullControl::RobotConfiguration::RobotConfiguration(
       responsive_wait,
       max_merge_waypoint_distance,
       max_merge_lane_distance,
-      min_lane_length
+      min_lane_length,
+      std::nullopt
     }))
 {
   // Do nothing
@@ -1685,7 +1686,7 @@ std::optional<rmf_task::ConstRequestFactoryPtr> parse_finishing_request(
             const auto mark = parking_spot_yaml.Mark();
             std::cerr
               << "Cannot assign a specific parking spot waypoint to the "
-              "fleet-wide default finishing request (line " << mark.line
+              "fleet-wide default finishing request (line " << (mark.line + 1)
               << ", column " << mark.column << ") because then all robots "
               "would attempt to park at the same location." << std::endl;
             error = true;
@@ -1699,7 +1700,7 @@ std::optional<rmf_task::ConstRequestFactoryPtr> parse_finishing_request(
             const auto mark = parking_spot_yaml.Mark();
             std::cerr
               << "Provided parking spot [" << parking_spot_string
-              << "] (line " << mark.line << ", column " << mark.column
+              << "] (line " << (mark.line + 1) << ", column " << mark.column
               << ") is not found in the fleet navigation graph. Unable to "
               "configure the fleet." << std::endl;
             error = true;
@@ -1723,8 +1724,8 @@ std::optional<rmf_task::ConstRequestFactoryPtr> parse_finishing_request(
     {
       const auto mark = finishing_request_yaml.Mark();
       std::cerr
-        << "Missing [type] for finishing_request object (line " << mark.line
-        << ", column " << mark.column << ")" << std::endl;
+        << "Missing [type] for finishing_request object (line "
+        << (mark.line + 1) << ", column " << mark.column << ")" << std::endl;
       error = true;
       return nullptr;
     }
@@ -1756,7 +1757,7 @@ std::optional<rmf_task::ConstRequestFactoryPtr> parse_finishing_request(
     const auto mark = finishing_request_yaml.Mark();
     std::cerr
       << "The finishing request [" << finishing_request_string << "] (line "
-      << mark.line << ", column " << mark.column
+      << (mark.line + 1) << ", column " << mark.column
       << ") is unsupported. The valid finishing requests are "
       "[charge, park, nothing].";
 
@@ -2313,7 +2314,7 @@ EasyFullControl::FleetConfiguration::from_config_files(
   {
     const auto mark = retreat_to_charger_yaml.Mark();
     std::cout << "[retreat_to_charger_interval] Unsupported value type "
-              << "provided: line " << mark.line << ", column " << mark.column
+              << "provided: line " << (mark.line + 1) << ", column " << mark.column
               << std::endl;
     return std::nullopt;
   }
@@ -2644,7 +2645,7 @@ EasyFullControl::FleetConfiguration::from_config_files(
       {
         const auto mark = lane_yaml.Mark();
         std::cerr << "[strict_lanes] Unrecognized lane format at line "
-          << mark.line << ", column " << mark.column << std::endl;
+          << (mark.line + 1) << ", column " << mark.column << std::endl;
         return std::nullopt;
       }
 
@@ -2655,7 +2656,7 @@ EasyFullControl::FleetConfiguration::from_config_files(
       {
         const auto mark = lane_yaml[0].Mark();
         std::cerr << "[strict_lanes] Unrecognized waypoint name [" << wp0_name
-          << "] at line " << mark.line << ", column " << mark.column << std::endl;
+          << "] at line " << (mark.line + 1) << ", column " << mark.column << std::endl;
         return std::nullopt;
       }
 
@@ -2664,7 +2665,7 @@ EasyFullControl::FleetConfiguration::from_config_files(
       {
         const auto mark = lane_yaml[1].Mark();
         std::cerr << "[strict_lanes] Unrecognized waypoint name [" << wp1_name
-          << "] at line " << mark.line << ", column " << mark.column << std::endl;
+          << "] at line " << (mark.line + 1) << ", column " << mark.column << std::endl;
         return std::nullopt;
       }
 
@@ -2710,7 +2711,7 @@ EasyFullControl::FleetConfiguration::from_config_files(
       {
         const auto mark = lane_yaml.Mark();
         std::cerr << "[strict_lanes] Unable to find a lane from [" << wp0_name
-          << "] to [" << wp1_name << "] at line " << mark.line << ", column "
+          << "] to [" << wp1_name << "] at line " << (mark.line + 1) << ", column "
           << mark.column << std::endl;
       }
     }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -2364,6 +2364,15 @@ EasyFullControl::FleetConfiguration::from_config_files(
                         << std::endl;
                     }
                   }
+                  else
+                  {
+                    std::cout
+                      << "Robot " << robot_name
+                      << " is configured to perform ParkRobot as finishing "
+                      "request, but no parking spot was provided. The robot "
+                      "will default to the fleet-wide finishing request."
+                      << std::endl;
+                  }
                 }
                 else if (request_type_string == "charge")
                 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -2615,7 +2615,9 @@ bool FleetUpdateHandle::set_task_planner_params(
         for (const auto& t : self->_pimpl->task_managers)
         {
           t.first->task_planner(self->_pimpl->task_planner);
-          t.second->set_idle_task(idle_task);
+          // Skip setting idle task if there exists a robot-specific behavior
+          if (!t.first->robot_finishing_request())
+            t.second->set_idle_task(idle_task);
         }
       });
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -697,6 +697,18 @@ void RobotContext::set_nav_params(std::shared_ptr<NavParams> value)
 }
 
 //==============================================================================
+bool RobotContext::robot_finishing_request() const
+{
+  return _robot_finishing_request;
+}
+
+//==============================================================================
+void RobotContext::robot_finishing_request(bool robot_specific)
+{
+  _robot_finishing_request = robot_specific;
+}
+
+//==============================================================================
 class RobotContext::NegotiatorLicense
 {
 public:

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -500,6 +500,14 @@ public:
   /// robots.
   void set_nav_params(std::shared_ptr<NavParams> value);
 
+  /// Check whether this robot is using a robot-specific or fleet-wide finishing
+  /// request.
+  bool robot_finishing_request() const;
+
+  /// Toggle the robot_finishing_request flag to indicate whether this robot is
+  /// using a robot-specific or fleet-wide finishing request.
+  void robot_finishing_request(bool robot_specific);
+
   class NegotiatorLicense;
 
   /// Set the schedule negotiator that will take responsibility for this robot.
@@ -907,6 +915,7 @@ private:
     std::make_unique<std::mutex>();
   std::shared_ptr<const rmf_task::TaskPlanner> _task_planner;
   std::weak_ptr<TaskManager> _task_manager;
+  bool _robot_finishing_request = false;
 
   RobotUpdateHandle::Unstable::Watchdog _lift_watchdog;
   rmf_traffic::Duration _lift_rewait_duration = std::chrono::seconds(0);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -267,6 +267,19 @@ RobotUpdateHandle& RobotUpdateHandle::set_charger_waypoint(
 }
 
 //==============================================================================
+RobotUpdateHandle& RobotUpdateHandle::set_finishing_request(
+  rmf_task::ConstRequestFactoryPtr finishing_request)
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    const auto mgr = context->task_manager();
+    mgr->set_idle_task(finishing_request);
+  }
+
+  return *this;
+}
+
+//==============================================================================
 void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 {
   if (const auto context = _pimpl->get_context())

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -280,6 +280,20 @@ RobotUpdateHandle& RobotUpdateHandle::set_finishing_request(
 }
 
 //==============================================================================
+RobotUpdateHandle& RobotUpdateHandle::use_default_finishing_request()
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    const auto mgr = context->task_manager();
+    mgr->use_default_idle_task();
+    // Disable robot_finishing_request flag in RobotContext
+    context->robot_finishing_request(false);
+  }
+
+  return *this;
+}
+
+//==============================================================================
 void RobotUpdateHandle::update_battery_soc(const double battery_soc)
 {
   if (const auto context = _pimpl->get_context())

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -147,6 +147,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("start_set"))
   .def("set_charger_waypoint", &agv::RobotUpdateHandle::set_charger_waypoint,
     py::arg("charger_wp"))
+  .def("set_finishing_request", &agv::RobotUpdateHandle::set_finishing_request,
+    py::arg("finishing_request"))
   .def("update_battery_soc", &agv::RobotUpdateHandle::update_battery_soc,
     py::arg("battery_soc"))
   .def("override_status", &agv::RobotUpdateHandle::override_status,
@@ -878,7 +880,11 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property(
     "compatible_chargers",
     &agv::EasyFullControl::RobotConfiguration::compatible_chargers,
-    &agv::EasyFullControl::RobotConfiguration::set_compatible_chargers);
+    &agv::EasyFullControl::RobotConfiguration::set_compatible_chargers)
+  .def_property(
+    "finishing_request",
+    &agv::EasyFullControl::RobotConfiguration::finishing_request,
+    &agv::EasyFullControl::RobotConfiguration::set_finishing_request);
 
   py::class_<agv::EasyFullControl::RobotCallbacks>(m_easy_full_control, "RobotCallbacks")
   .def(py::init<


### PR DESCRIPTION
This PR provides a way for users to specify different finishing requests for individual robots. Currently all robots in a fleet follow the [fleet-wide finishing request configured](https://github.com/open-rmf/rmf_demos/blob/main/rmf_demos/config/office/tinyRobot_config.yaml#L33). If the finishing request is either `park` or `charge`, the robots will head to their [assigned charger waypoint](https://github.com/open-rmf/rmf_demos/blob/main/rmf_demos/config/office/tinyRobot_config.yaml#L38) to perform their respective ParkRobotIndefinitely or ChargeBattery tasks.

With this PR, users can:
- Configure different finishing requests for robots in the same fleet, and
- Configure parking spots that are different from the robot's designated charger.

Relevant issue ticket: https://github.com/open-rmf/rmf_task/issues/115