### PR TITLE
Publish fleet and task updates over ROS 2 if websocket is not provided

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -28,6 +28,8 @@ const std::string DestinationRequestTopicName = "destination_requests";
 const std::string ModeRequestTopicName = "robot_mode_requests";
 const std::string PathRequestTopicName = "robot_path_requests";
 const std::string PauseRequestTopicName = "robot_pause_requests";
+const std::string FleetStateUpdateTopicName = "fleet_state_update";
+const std::string FleetLogUpdateTopicName = "fleet_log_update";
 
 const std::string FinalDoorRequestTopicName = "door_requests";
 const std::string AdapterDoorRequestTopicName = "adapter_door_requests";
@@ -68,6 +70,8 @@ const std::string InterruptRequestTopicName = "robot_interrupt_request";
 
 const std::string TaskApiRequests = "task_api_requests";
 const std::string TaskApiResponses = "task_api_responses";
+const std::string TaskStateUpdateTopicName = "task_state_update";
+const std::string TaskLogUpdateTopicName = "task_log_update";
 
 const std::string ChargingAssignmentsTopicName = "charging_assignments";
 

--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -43,6 +43,7 @@
   <!-- The uri is set to the TrajectoryServer uri for debugging purposes. The default port needs to be updated before merging -->
   <arg name="server_uri" default="" description="The URI of the api server to trasnmit state and task infromation. If empty, information will not be transmitted"/>
 
+
   <node pkg="rmf_fleet_adapter"
         exec="$(var control_type)"
         name="$(var fleet_name)_fleet_adapter"

--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -41,8 +41,7 @@
   <arg name="experimental_lift_watchdog_service" default="" description="(Experimental) The name of a service to check whether a robot can enter a lift"/>
   <arg name="enable_responsive_wait" default="true" description="Should the robot wait responsively"/>
   <!-- The uri is set to the TrajectoryServer uri for debugging purposes. The default port needs to be updated before merging -->
-  <arg name="server_uri" default="" description="The URI of the api server to trasnmit state and task infromation. If empty, information will be sent over ROS 2"/>
-
+  <arg name="server_uri" default="" description="The URI of the api server to trasnmit state and task infromation. If empty, information will not be transmitted"/>
 
   <node pkg="rmf_fleet_adapter"
         exec="$(var control_type)"

--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -41,7 +41,7 @@
   <arg name="experimental_lift_watchdog_service" default="" description="(Experimental) The name of a service to check whether a robot can enter a lift"/>
   <arg name="enable_responsive_wait" default="true" description="Should the robot wait responsively"/>
   <!-- The uri is set to the TrajectoryServer uri for debugging purposes. The default port needs to be updated before merging -->
-  <arg name="server_uri" default="" description="The URI of the api server to trasnmit state and task infromation. If empty, information will not be transmitted"/>
+  <arg name="server_uri" default="" description="The URI of the api server to trasnmit state and task infromation. If empty, information will be sent over ROS 2"/>
 
 
   <node pkg="rmf_fleet_adapter"

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -193,7 +193,7 @@ TaskManagerPtr TaskManager::make(
     });
 
   auto reliable_transient_qos =
-    rclcpp::ServicesQoS().keep_last(20).transient_local();
+    rclcpp::ServicesQoS().keep_last(10).reliable().transient_local();
   mgr->_task_state_update_pub =
     mgr->_context->node()->create_publisher<TaskStateUpdateMsg>(
       TaskStateUpdateTopicName, reliable_transient_qos);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -199,7 +199,7 @@ TaskManagerPtr TaskManager::make(
       TaskStateUpdateTopicName, reliable_transient_qos);
   mgr->_task_log_update_pub =
     mgr->_context->node()->create_publisher<TaskLogUpdateMsg>(
-      TaskLogUpdateTopicName, reliable_transient_qos);
+      TaskLogUpdateTopicName, reliable_transient_qos.keep_last(100));
 
   const std::vector<nlohmann::json> schemas = {
     rmf_api_msgs::schemas::task_state,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -192,17 +192,14 @@ TaskManagerPtr TaskManager::make(
         self->_handle_request(request->json_msg, request->request_id);
     });
 
-  if (!mgr->_broadcast_client.has_value())
-  {
-    auto reliable_transient_qos =
-      rclcpp::ServicesQoS().keep_last(20).transient_local();
-    mgr->_task_state_update_pub =
-      mgr->_context->node()->create_publisher<TaskStateUpdateMsg>(
-        TaskStateUpdateTopicName, reliable_transient_qos);
-    mgr->_task_log_update_pub =
-      mgr->_context->node()->create_publisher<TaskLogUpdateMsg>(
-        TaskLogUpdateTopicName, reliable_transient_qos);
-  }
+  auto reliable_transient_qos =
+    rclcpp::ServicesQoS().keep_last(20).transient_local();
+  mgr->_task_state_update_pub =
+    mgr->_context->node()->create_publisher<TaskStateUpdateMsg>(
+      TaskStateUpdateTopicName, reliable_transient_qos);
+  mgr->_task_log_update_pub =
+    mgr->_context->node()->create_publisher<TaskLogUpdateMsg>(
+      TaskLogUpdateTopicName, reliable_transient_qos);
 
   const std::vector<nlohmann::json> schemas = {
     rmf_api_msgs::schemas::task_state,
@@ -2065,20 +2062,18 @@ void TaskManager::_validate_and_publish_json(
     }
     client->publish(msg);
   }
-  else
+
+  if (msg["type"] == "task_state_update")
   {
-    if (msg["type"] == "task_state_update" && _task_state_update_pub)
-    {
-      TaskStateUpdateMsg update_msg;
-      update_msg.data = msg.dump();
-      _task_state_update_pub->publish(update_msg);
-    }
-    else if (msg["type"] == "task_log_update" && _task_log_update_pub)
-    {
-      TaskLogUpdateMsg update_msg;
-      update_msg.data = msg.dump();
-      _task_log_update_pub->publish(update_msg);
-    }
+    TaskStateUpdateMsg update_msg;
+    update_msg.data = msg.dump();
+    _task_state_update_pub->publish(update_msg);
+  }
+  else if (msg["type"] == "task_log_update")
+  {
+    TaskLogUpdateMsg update_msg;
+    update_msg.data = msg.dump();
+    _task_log_update_pub->publish(update_msg);
   }
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -32,6 +32,8 @@
 #include <rmf_fleet_msgs/msg/robot_mode.hpp>
 #include <rmf_task_msgs/msg/task_summary.hpp>
 
+#include <std_msgs/msg/string.hpp>
+
 #include <nlohmann/json.hpp>
 #include <nlohmann/json-schema.hpp>
 
@@ -395,6 +397,13 @@ private:
   bool _task_state_update_available = true;
   std::chrono::steady_clock::time_point _last_update_time;
 
+  using TaskStateUpdateMsg = std_msgs::msg::String;
+  rclcpp::Publisher<TaskStateUpdateMsg>::SharedPtr _task_state_update_pub =
+    nullptr;
+
+  using TaskLogUpdateMsg = std_msgs::msg::String;
+  rclcpp::Publisher<TaskLogUpdateMsg>::SharedPtr _task_log_update_pub = nullptr;
+
   // Container to keep track of tasks that have been started by this TaskManager
   // Use the _register_executed_task() to populate this container.
   std::vector<std::string> _executed_task_registry;
@@ -552,7 +561,7 @@ private:
 
   /// Validate and publish a json. This can be used for task
   /// state and log updates
-  void _validate_and_publish_websocket(
+  void _validate_and_publish_json(
     const nlohmann::json& msg,
     const nlohmann::json_schema::json_validator& validator) const;
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1233,151 +1233,175 @@ void FleetUpdateHandle::Implementation::update_fleet() const
 //==============================================================================
 void FleetUpdateHandle::Implementation::update_fleet_state() const
 {
-  // Publish to API server
-  if (broadcast_client)
+  if (!broadcast_client && !fleet_state_update_pub)
   {
-    nlohmann::json fleet_state_update_msg;
-    fleet_state_update_msg["type"] = "fleet_state_update";
-    auto& fleet_state_msg = fleet_state_update_msg["data"];
-    fleet_state_msg["name"] = name;
-    auto& robots = fleet_state_msg["robots"];
-    robots = std::unordered_map<std::string, nlohmann::json>();
-    for (const auto& [context, mgr] : task_managers)
+    return;
+  }
+
+  nlohmann::json fleet_state_update_msg;
+  fleet_state_update_msg["type"] = "fleet_state_update";
+  auto& fleet_state_msg = fleet_state_update_msg["data"];
+  fleet_state_msg["name"] = name;
+  auto& robots = fleet_state_msg["robots"];
+  robots = std::unordered_map<std::string, nlohmann::json>();
+  for (const auto& [context, mgr] : task_managers)
+  {
+    const auto& name = context->name();
+    nlohmann::json& json = robots[name];
+    json["name"] = name;
+    json["status"] = mgr->robot_status();
+    json["task_id"] = mgr->current_task_id().value_or("");
+    json["unix_millis_time"] =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+      context->now().time_since_epoch()).count();
+    json["battery"] = context->current_battery_soc();
+
+    const auto location_msg = convert_location(*context);
+    if (location_msg.has_value())
     {
-      const auto& name = context->name();
-      nlohmann::json& json = robots[name];
-      json["name"] = name;
-      json["status"] = mgr->robot_status();
-      json["task_id"] = mgr->current_task_id().value_or("");
-      json["unix_millis_time"] =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-        context->now().time_since_epoch()).count();
-      json["battery"] = context->current_battery_soc();
-
-      const auto location_msg = convert_location(*context);
-      if (location_msg.has_value())
-      {
-        nlohmann::json& location = json["location"];
-        location["map"] = location_msg->level_name;
-        location["x"] = location_msg->x;
-        location["y"] = location_msg->y;
-        location["yaw"] = location_msg->yaw;
-      }
-
-      std::lock_guard<std::mutex> lock(context->reporting().mutex());
-      const auto& issues = context->reporting().open_issues();
-      auto& issues_msg = json["issues"];
-      issues_msg = std::vector<nlohmann::json>();
-      for (const auto& issue : issues)
-      {
-        nlohmann::json issue_msg;
-        issue_msg["category"] = issue->category;
-        issue_msg["detail"] = issue->detail;
-        issues_msg.push_back(std::move(issue_msg));
-      }
-
-      const auto& commission = context->commission();
-      nlohmann::json commission_json;
-      commission_json["dispatch_tasks"] =
-        commission.is_accepting_dispatched_tasks();
-      commission_json["direct_tasks"] = commission.is_accepting_direct_tasks();
-      commission_json["idle_behavior"] =
-        commission.is_performing_idle_behavior();
-
-      json["commission"] = commission_json;
-
-      nlohmann::json mutex_groups_json;
-      std::vector<std::string> locked_mutex_groups;
-      for (const auto& g : context->locked_mutex_groups())
-      {
-        locked_mutex_groups.push_back(g.first);
-      }
-      mutex_groups_json["locked"] = std::move(locked_mutex_groups);
-
-      std::vector<std::string> requesting_mutex_groups;
-      for (const auto& g : context->requesting_mutex_groups())
-      {
-        requesting_mutex_groups.push_back(g.first);
-      }
-      mutex_groups_json["requesting"] = std::move(requesting_mutex_groups);
-
-      json["mutex_groups"] = std::move(mutex_groups_json);
+      nlohmann::json& location = json["location"];
+      location["map"] = location_msg->level_name;
+      location["x"] = location_msg->x;
+      location["y"] = location_msg->y;
+      location["yaw"] = location_msg->yaw;
     }
 
-    try
+    std::lock_guard<std::mutex> lock(context->reporting().mutex());
+    const auto& issues = context->reporting().open_issues();
+    auto& issues_msg = json["issues"];
+    issues_msg = std::vector<nlohmann::json>();
+    for (const auto& issue : issues)
     {
-      static const auto validator =
-        make_validator(rmf_api_msgs::schemas::fleet_state_update);
+      nlohmann::json issue_msg;
+      issue_msg["category"] = issue->category;
+      issue_msg["detail"] = issue->detail;
+      issues_msg.push_back(std::move(issue_msg));
+    }
 
-      validator.validate(fleet_state_update_msg);
+    const auto& commission = context->commission();
+    nlohmann::json commission_json;
+    commission_json["dispatch_tasks"] =
+      commission.is_accepting_dispatched_tasks();
+    commission_json["direct_tasks"] = commission.is_accepting_direct_tasks();
+    commission_json["idle_behavior"] =
+      commission.is_performing_idle_behavior();
 
-      std::unique_lock<std::mutex> lock(*update_callback_mutex);
-      if (update_callback)
-        update_callback(fleet_state_update_msg);
+    json["commission"] = commission_json;
+
+    nlohmann::json mutex_groups_json;
+    std::vector<std::string> locked_mutex_groups;
+    for (const auto& g : context->locked_mutex_groups())
+    {
+      locked_mutex_groups.push_back(g.first);
+    }
+    mutex_groups_json["locked"] = std::move(locked_mutex_groups);
+
+    std::vector<std::string> requesting_mutex_groups;
+    for (const auto& g : context->requesting_mutex_groups())
+    {
+      requesting_mutex_groups.push_back(g.first);
+    }
+    mutex_groups_json["requesting"] = std::move(requesting_mutex_groups);
+
+    json["mutex_groups"] = std::move(mutex_groups_json);
+  }
+
+  try
+  {
+    static const auto validator =
+      make_validator(rmf_api_msgs::schemas::fleet_state_update);
+
+    validator.validate(fleet_state_update_msg);
+
+    std::unique_lock<std::mutex> lock(*update_callback_mutex);
+    if (update_callback)
+      update_callback(fleet_state_update_msg);
+
+    // Publish to API server
+    if (broadcast_client)
+    {
       broadcast_client->publish(fleet_state_update_msg);
     }
-    catch (const std::exception& e)
+    else
     {
-      RCLCPP_ERROR(
-        node->get_logger(),
-        "Malformed outgoing fleet state json message: %s\nMessage:\n%s",
-        e.what(),
-        fleet_state_update_msg.dump(2).c_str());
+      FleetStateUpdateMsg update_msg;
+      update_msg.data = fleet_state_update_msg.dump();
+      fleet_state_update_pub->publish(update_msg);
     }
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Malformed outgoing fleet state json message: %s\nMessage:\n%s",
+      e.what(),
+      fleet_state_update_msg.dump(2).c_str());
   }
 }
 
 //==============================================================================
 void FleetUpdateHandle::Implementation::update_fleet_logs() const
 {
-  if (broadcast_client)
+  if (!broadcast_client && !fleet_log_update_pub)
   {
-    nlohmann::json fleet_log_update_msg;
-    fleet_log_update_msg["type"] = "fleet_log_update";
-    auto& fleet_log_msg = fleet_log_update_msg["data"];
-    fleet_log_msg["name"] = name;
-    // TODO(MXG): fleet_log_msg["log"]
-    auto& robots_msg = fleet_log_msg["robots"];
-    robots_msg = std::unordered_map<std::string, nlohmann::json>();
-    for (const auto& [context, _] : task_managers)
+    return;
+  }
+
+  nlohmann::json fleet_log_update_msg;
+  fleet_log_update_msg["type"] = "fleet_log_update";
+  auto& fleet_log_msg = fleet_log_update_msg["data"];
+  fleet_log_msg["name"] = name;
+  // TODO(MXG): fleet_log_msg["log"]
+  auto& robots_msg = fleet_log_msg["robots"];
+  robots_msg = std::unordered_map<std::string, nlohmann::json>();
+  for (const auto& [context, _] : task_managers)
+  {
+    auto robot_log_msg_array = std::vector<nlohmann::json>();
+
+    std::lock_guard<std::mutex> lock(context->reporting().mutex());
+    const auto& log = context->reporting().log();
+    for (const auto& entry : log_reader.read(log.view()))
+      robot_log_msg_array.push_back(log_to_json(entry));
+
+    if (!robot_log_msg_array.empty())
+      robots_msg[context->name()] = std::move(robot_log_msg_array);
+  }
+
+  if (robots_msg.empty())
+  {
+    // No new logs to report
+    return;
+  }
+
+  try
+  {
+    static const auto validator =
+      make_validator(rmf_api_msgs::schemas::fleet_log_update);
+
+    validator.validate(fleet_log_update_msg);
+
+    std::unique_lock<std::mutex> lock(*update_callback_mutex);
+    if (update_callback)
+      update_callback(fleet_log_update_msg);
+
+    if (broadcast_client)
     {
-      auto robot_log_msg_array = std::vector<nlohmann::json>();
-
-      std::lock_guard<std::mutex> lock(context->reporting().mutex());
-      const auto& log = context->reporting().log();
-      for (const auto& entry : log_reader.read(log.view()))
-        robot_log_msg_array.push_back(log_to_json(entry));
-
-      if (!robot_log_msg_array.empty())
-        robots_msg[context->name()] = std::move(robot_log_msg_array);
-    }
-
-    if (robots_msg.empty())
-    {
-      // No new logs to report
-      return;
-    }
-
-    try
-    {
-      static const auto validator =
-        make_validator(rmf_api_msgs::schemas::fleet_log_update);
-
-      validator.validate(fleet_log_update_msg);
-
-      std::unique_lock<std::mutex> lock(*update_callback_mutex);
-      if (update_callback)
-        update_callback(fleet_log_update_msg);
       broadcast_client->publish(fleet_log_update_msg);
     }
-    catch (const std::exception& e)
+    else
     {
-      RCLCPP_ERROR(
-        node->get_logger(),
-        "Malformed outgoing fleet log json message: %s\nMessage:\n%s",
-        e.what(),
-        fleet_log_update_msg.dump(2).c_str());
+      FleetLogUpdateMsg update_msg;
+      update_msg.data = fleet_log_update_msg.dump();
+      fleet_log_update_pub->publish(update_msg);
     }
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Malformed outgoing fleet log json message: %s\nMessage:\n%s",
+      e.what(),
+      fleet_log_update_msg.dump(2).c_str());
   }
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1296,11 +1296,6 @@ void FleetUpdateHandle::Implementation::update_fleet_state() const
 
   try
   {
-    static const auto validator =
-      make_validator(rmf_api_msgs::schemas::fleet_state_update);
-
-    validator.validate(fleet_state_update_msg);
-
     std::unique_lock<std::mutex> lock(*update_callback_mutex);
     if (update_callback)
       update_callback(fleet_state_update_msg);
@@ -1308,6 +1303,10 @@ void FleetUpdateHandle::Implementation::update_fleet_state() const
     // Publish to API server
     if (broadcast_client)
     {
+      static const auto validator =
+        make_validator(rmf_api_msgs::schemas::fleet_state_update);
+      validator.validate(fleet_state_update_msg);
+
       broadcast_client->publish(fleet_state_update_msg);
     }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1233,11 +1233,6 @@ void FleetUpdateHandle::Implementation::update_fleet() const
 //==============================================================================
 void FleetUpdateHandle::Implementation::update_fleet_state() const
 {
-  if (!broadcast_client && !fleet_state_update_pub)
-  {
-    return;
-  }
-
   nlohmann::json fleet_state_update_msg;
   fleet_state_update_msg["type"] = "fleet_state_update";
   auto& fleet_state_msg = fleet_state_update_msg["data"];
@@ -1322,12 +1317,10 @@ void FleetUpdateHandle::Implementation::update_fleet_state() const
     {
       broadcast_client->publish(fleet_state_update_msg);
     }
-    else
-    {
-      FleetStateUpdateMsg update_msg;
-      update_msg.data = fleet_state_update_msg.dump();
-      fleet_state_update_pub->publish(update_msg);
-    }
+
+    FleetStateUpdateMsg update_msg;
+    update_msg.data = fleet_state_update_msg.dump();
+    fleet_state_update_pub->publish(update_msg);
   }
   catch (const std::exception& e)
   {
@@ -1342,11 +1335,6 @@ void FleetUpdateHandle::Implementation::update_fleet_state() const
 //==============================================================================
 void FleetUpdateHandle::Implementation::update_fleet_logs() const
 {
-  if (!broadcast_client && !fleet_log_update_pub)
-  {
-    return;
-  }
-
   nlohmann::json fleet_log_update_msg;
   fleet_log_update_msg["type"] = "fleet_log_update";
   auto& fleet_log_msg = fleet_log_update_msg["data"];
@@ -1388,12 +1376,10 @@ void FleetUpdateHandle::Implementation::update_fleet_logs() const
     {
       broadcast_client->publish(fleet_log_update_msg);
     }
-    else
-    {
-      FleetLogUpdateMsg update_msg;
-      update_msg.data = fleet_log_update_msg.dump();
-      fleet_log_update_pub->publish(update_msg);
-    }
+
+    FleetLogUpdateMsg update_msg;
+    update_msg.data = fleet_log_update_msg.dump();
+    fleet_log_update_pub->publish(update_msg);
   }
   catch (const std::exception& e)
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -544,10 +544,10 @@ public:
 
     handle->_pimpl->fleet_state_update_pub =
       handle->_pimpl->node->create_publisher<FleetStateUpdateMsg>(
-        FleetStateUpdateTopicName, reliable_transient_qos);
+        FleetStateUpdateTopicName, reliable_transient_qos.keep_last(10));
     handle->_pimpl->fleet_log_update_pub =
       handle->_pimpl->node->create_publisher<FleetLogUpdateMsg>(
-        FleetLogUpdateTopicName, reliable_transient_qos);
+        FleetLogUpdateTopicName, reliable_transient_qos.keep_last(100));
 
     // Add PerformAction event to deserialization
     auto validator = handle->_pimpl->deserialization.make_validator_shared(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -541,15 +541,13 @@ public:
           return task_logs;
         });
     }
-    else
-    {
-      handle->_pimpl->fleet_state_update_pub =
-        handle->_pimpl->node->create_publisher<FleetStateUpdateMsg>(
-          FleetStateUpdateTopicName, reliable_transient_qos);
-      handle->_pimpl->fleet_log_update_pub =
-        handle->_pimpl->node->create_publisher<FleetLogUpdateMsg>(
-          FleetLogUpdateTopicName, reliable_transient_qos);
-    }
+
+    handle->_pimpl->fleet_state_update_pub =
+      handle->_pimpl->node->create_publisher<FleetStateUpdateMsg>(
+        FleetStateUpdateTopicName, reliable_transient_qos);
+    handle->_pimpl->fleet_log_update_pub =
+      handle->_pimpl->node->create_publisher<FleetLogUpdateMsg>(
+        FleetLogUpdateTopicName, reliable_transient_qos);
 
     // Add PerformAction event to deserialization
     auto validator = handle->_pimpl->deserialization.make_validator_shared(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -18,6 +18,8 @@
 #ifndef SRC__RMF_FLEET_ADAPTER__AGV__INTERNAL_FLEETUPDATEHANDLE_HPP
 #define SRC__RMF_FLEET_ADAPTER__AGV__INTERNAL_FLEETUPDATEHANDLE_HPP
 
+#include <std_msgs/msg/string.hpp>
+
 #include <rmf_task_msgs/msg/loop.hpp>
 
 #include <rmf_task_ros2/bidding/AsyncBidder.hpp>
@@ -296,6 +298,15 @@ public:
     std::shared_ptr<TaskManager>> task_managers = {};
 
   std::shared_ptr<rmf_websocket::BroadcastClient> broadcast_client = nullptr;
+
+  using FleetStateUpdateMsg = std_msgs::msg::String;
+  rclcpp::Publisher<FleetStateUpdateMsg>::SharedPtr fleet_state_update_pub =
+    nullptr;
+
+  using FleetLogUpdateMsg = std_msgs::msg::String;
+  rclcpp::Publisher<FleetLogUpdateMsg>::SharedPtr fleet_log_update_pub =
+    nullptr;
+
   // Map uri to schema for validator loader function
   std::unordered_map<std::string, nlohmann::json> schema_dictionary = {};
 
@@ -529,6 +540,15 @@ public:
           }
           return task_logs;
         });
+    }
+    else
+    {
+      handle->_pimpl->fleet_state_update_pub =
+        handle->_pimpl->node->create_publisher<FleetStateUpdateMsg>(
+          FleetStateUpdateTopicName, reliable_transient_qos);
+      handle->_pimpl->fleet_log_update_pub =
+        handle->_pimpl->node->create_publisher<FleetLogUpdateMsg>(
+          FleetLogUpdateTopicName, reliable_transient_qos);
     }
 
     // Add PerformAction event to deserialization

--- a/rmf_task_ros2/include/rmf_task_ros2/StandardNames.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/StandardNames.hpp
@@ -34,6 +34,7 @@ const std::string DispatchCommandTopicName = Prefix + "dispatch_request";
 const std::string DispatchAckTopicName = Prefix + "dispatch_ack";
 const std::string DispatchStatesTopicName = "dispatch_states";
 const std::string TaskStatusTopicName = "task_summaries";
+const std::string TaskStateUpdateTopicName = "task_state_update";
 
 } // namespace rmf_task_ros2
 

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -46,6 +46,8 @@
 #include <rmf_api_msgs/schemas/task_state.hpp>
 #include <rmf_api_msgs/schemas/error.hpp>
 
+#include <std_msgs/msg/string.hpp>
+
 #include <random>
 #include <unordered_set>
 
@@ -140,6 +142,10 @@ public:
   using ApiResponseMsg = rmf_task_msgs::msg::ApiResponse;
   rclcpp::Subscription<ApiRequestMsg>::SharedPtr api_request;
   rclcpp::Publisher<ApiResponseMsg>::SharedPtr api_response;
+
+  using TaskStateUpdateMsg = std_msgs::msg::String;
+  rclcpp::Publisher<TaskStateUpdateMsg>::SharedPtr task_state_update_pub =
+    nullptr;
 
   class ApiMemory
   {
@@ -295,8 +301,16 @@ public:
       });
 
     if (server_uri)
+    {
       broadcast_client = rmf_websocket::BroadcastClient::make(
         *server_uri, node);
+    }
+    else
+    {
+      task_state_update_pub = node->create_publisher<TaskStateUpdateMsg>(
+        rmf_task_ros2::TaskStateUpdateTopicName,
+        rclcpp::ServicesQoS().keep_last(10).reliable().transient_local());
+    }
 
     auctioneer = bidding::Auctioneer::make(
       node,
@@ -794,13 +808,19 @@ public:
       }
 
       /// Publish failed bid
+      const auto task_state =
+        create_task_state_json(dispatch_state, "failed");
+      auto task_state_update = _task_state_update_json;
+      task_state_update["data"] = task_state;
       if (broadcast_client)
       {
-        const auto task_state =
-          create_task_state_json(dispatch_state, "failed");
-        auto task_state_update = _task_state_update_json;
-        task_state_update["data"] = task_state;
         broadcast_client->publish(task_state_update);
+      }
+      else if (task_state_update_pub)
+      {
+        TaskStateUpdateMsg update_msg;
+        update_msg.data = task_state_update.dump();
+        task_state_update_pub->publish(update_msg);
       }
 
       auctioneer->ready_for_next_bid();

--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -300,16 +300,14 @@ public:
         this->handle_dispatch_ack(*msg);
       });
 
+    task_state_update_pub = node->create_publisher<TaskStateUpdateMsg>(
+      rmf_task_ros2::TaskStateUpdateTopicName,
+      rclcpp::ServicesQoS().keep_last(10).reliable().transient_local());
+
     if (server_uri)
     {
       broadcast_client = rmf_websocket::BroadcastClient::make(
         *server_uri, node);
-    }
-    else
-    {
-      task_state_update_pub = node->create_publisher<TaskStateUpdateMsg>(
-        rmf_task_ros2::TaskStateUpdateTopicName,
-        rclcpp::ServicesQoS().keep_last(10).reliable().transient_local());
     }
 
     auctioneer = bidding::Auctioneer::make(
@@ -816,12 +814,10 @@ public:
       {
         broadcast_client->publish(task_state_update);
       }
-      else if (task_state_update_pub)
-      {
-        TaskStateUpdateMsg update_msg;
-        update_msg.data = task_state_update.dump();
-        task_state_update_pub->publish(update_msg);
-      }
+
+      TaskStateUpdateMsg update_msg;
+      update_msg.data = task_state_update.dump();
+      task_state_update_pub->publish(update_msg);
 
       auctioneer->ready_for_next_bid();
       return;


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Allows `fleet_state_update`, `fleet_log_update`, `task_state_update`, and `task_log_update` to be published over ROS 2 when websocket server URL is not provided.

Works with https://github.com/open-rmf/rmf-web/pull/1003

### Implementation description

The motivation is related to https://github.com/open-rmf/rmf-web/pull/899, where non-reproducible issues with websockets occur unpredictably in production environments, causing various systems to fail.

This allows the option to mitigate issues with the upstream `websocketpp` library, and just rely on ROS 2 to publish updates instead.

This will also allow the use of ROS 2 introspection tools in production if network instability occurs, which hopefully is a much better experience than debugging websocket connections.

## Testing

Instead of running demos with the `server_uri`, just run

```bash
ros2 run rmf_demos_gz office.launch.xml #headless:=1
```