### PR TITLE
Update _last_active_task_time if robot is executing task

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1496,15 +1496,17 @@ void RobotContext::_check_door_supervisor(
 {
   const auto now = std::chrono::steady_clock::now();
   const auto dt = std::chrono::seconds(10);
-
   if (_current_task_id.has_value())
   {
     _last_active_task_time = now;
   }
-  else if (_last_active_task_time + dt < now)
+  else
   {
-    // Do not hold a door if a robot is idle for more than 10 seconds
-    _holding_door = std::nullopt;
+    if (_last_active_task_time + dt < now)
+    {
+      // Do not hold a door if a robot is idle for more than 10 seconds
+      _holding_door = std::nullopt;
+    }
   }
 
   for (const auto& door : state.all_sessions)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1496,7 +1496,12 @@ void RobotContext::_check_door_supervisor(
 {
   const auto now = std::chrono::steady_clock::now();
   const auto dt = std::chrono::seconds(10);
-  if (_last_active_task_time + dt < now)
+
+  if (_current_task_id.has_value())
+  {
+    _last_active_task_time = now;
+  }
+  else if (_last_active_task_time + dt < now)
   {
     // Do not hold a door if a robot is idle for more than 10 seconds
     _holding_door = std::nullopt;


### PR DESCRIPTION
## Bug fix

### Fixed bug
Reference: open-rmf/rmf#516


### Fix applied
Set `_last_active_task_time` to `now` if the robot is currently doing task.
