### PR TITLE
Add reached API to read-only fleet adapter

### DIFF
--- a/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
@@ -20,6 +20,8 @@
 #include <rmf_traffic/DetectConflict.hpp>
 
 #include <rmf_traffic/agv/Interpolate.hpp>
+#include <rmf_traffic/agv/Planner.hpp>
+#include <rmf_traffic/Time.hpp>
 
 #include <rmf_traffic_ros2/StandardNames.hpp>
 #include <rmf_traffic_ros2/Time.hpp>
@@ -214,6 +216,15 @@ void FleetAdapterNode::push_route(
 
   it->second->cumulative_delay = std::chrono::seconds(0);
   it->second->route = make_route(state, _traits, it->second->sitting);
+  // Set checkpoints for this route
+  std::set<uint64_t> checkpoints;
+  uint64_t checkpoint_id = 0;
+  for (const auto& wp : it->second->route->trajectory())
+  {
+    checkpoints.insert(checkpoint_id);
+    checkpoint_id++;
+  }
+  it->second->route->checkpoints(checkpoints);
   it->second->schedule->push_routes({*it->second->route});
 }
 
@@ -234,6 +245,40 @@ void FleetAdapterNode::update_robot(
   const RobotState& state,
   const ScheduleEntries::iterator& it)
 {
+  if (it->second->route.has_value())
+  {
+    auto& participant = it->second->schedule->participant();
+    uint64_t route_id = participant.itinerary().size() - 1;
+    uint64_t last_checkpoint_reached = participant.reached()[route_id];
+
+    uint64_t checkpoint_id = 0;
+    for (const auto& wp : it->second->route.value().trajectory())
+    {
+      if (checkpoint_id <= last_checkpoint_reached)
+      {
+        checkpoint_id++;
+        continue;
+      }
+
+      Eigen::Vector2d current_location =
+        Eigen::Vector2d(state.location.x, state.location.y);
+      Eigen::Vector2d checkpoint_pose =
+        Eigen::Vector2d(wp.position()[0], wp.position()[1]);
+      Eigen::Vector2d diff = current_location - checkpoint_pose;
+      // TODO(@xiyuoh) Make this merge_waypoint_distance configurable
+      if (diff.norm() < 0.3)
+      {
+        // The robot is close enough to the checkpoint, mark as reached.
+        participant.reached(
+          participant.current_plan_id(), route_id, checkpoint_id);
+      }
+      else
+        break;
+
+      checkpoint_id++;
+    }
+  }
+
   if (handle_delay(state, it))
     return;
 

--- a/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
@@ -20,8 +20,6 @@
 #include <rmf_traffic/DetectConflict.hpp>
 
 #include <rmf_traffic/agv/Interpolate.hpp>
-#include <rmf_traffic/agv/Planner.hpp>
-#include <rmf_traffic/Time.hpp>
 
 #include <rmf_traffic_ros2/StandardNames.hpp>
 #include <rmf_traffic_ros2/Time.hpp>


### PR DESCRIPTION
This PR adds the `reached()` API to the read-only fleet adapter.

Currently when a read-only robot's path is populated in RobotState, a route is created and stored in the FleetAdapterNode. This PR further populates the route with checkpoints using all the waypoints in the RobotState path. When the read-only robot reaches a new checkpoint, the API is called and allows better tracking of the robot progress around the map, which would help the full-control robots in the same map to move out of the read-only robot's way.

This PR uses the shortest distance away from the next checkpoint to measure whether the robot has reached, and assumes that the robot is always using the newest route in the itinerary.