### PR TITLE
Allow automatic action cancellation to be toggled

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -239,6 +239,19 @@ public:
     /// Returns false if the Action has been killed or cancelled
     bool okay() const;
 
+    /// Set whether automatic cancellation is turned on for this action.
+    ///
+    /// When automatic cancellation is on, the task system will believe that the
+    /// action is successfully cancelled immediately upon receiving a cancel
+    /// signal. By default, automatic cancellation is on (true).
+    ///
+    /// If your action needs to perform some kind of wind-down or cleanup after
+    /// being cancelled, then you should set this to false. At that point you
+    /// must ensure that your action implementation is watching okay() to know
+    /// if it has been cancelled, and you must trigger finished() when your
+    /// wind-down or cleanup is finished.
+    void set_automatic_cancel(bool on);
+
     /// Activity identifier for this action. Used by the EasyFullControl API.
     ConstActivityIdentifierPtr identifier() const;
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -1213,6 +1213,22 @@ bool RobotUpdateHandle::ActionExecution::okay() const
 }
 
 //==============================================================================
+void RobotUpdateHandle::ActionExecution::set_automatic_cancel(bool on)
+{
+  if (_pimpl->data)
+  {
+    if (const auto context = _pimpl->data->w_context.lock())
+    {
+      context->worker().schedule(
+        [on, self = _pimpl->data](const auto&)
+        {
+          self->automatic_cancel = on;
+        });
+    }
+  }
+}
+
+//==============================================================================
 auto RobotUpdateHandle::ActionExecution::identifier() const
 -> ConstActivityIdentifierPtr
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -156,6 +156,7 @@ public:
     std::optional<rmf_traffic::Duration> remaining_time;
     bool request_replan;
     bool okay;
+    bool automatic_cancel;
     std::optional<ScheduleOverride> schedule_override;
 
     void update_location(
@@ -213,7 +214,8 @@ public:
       state(std::move(state_)),
       remaining_time(remaining_time_),
       request_replan(false),
-      okay(true)
+      okay(true),
+      automatic_cancel(true)
     {
       // Do nothing
     }

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -359,6 +359,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("hold") = 0.0)
   .def("finished", &ActionExecution::finished)
   .def("okay", &ActionExecution::okay)
+  .def("set_automatic_cancel", &ActionExecution::set_automatic_cancel, py::arg("on"))
   .def_property_readonly("identifier", &ActionExecution::identifier);
 
   // ROBOT INTERRUPTION   ====================================================


### PR DESCRIPTION
Historically the way task cancellation worked for "perform action" events was to immediately declare that the action is cancelled and trust the action implementer to somehow gracefully wind down the action even though we might immediately start issuing new commands.

With this PR, the action implementer can use `execution.set_automatic_cancel(false)` to prevent the task system from immediately declaring that the cancellation is finished. Instead the task system will wait until the implementer calls `execution.finished()`, at which point the cancellation will be registered.

If the action implementer does not call `execution.set_automatic_cancel(false)` then the old behavior will remain as it has always been.