### PR TITLE
Use unique name for exported targets and avoid exporting binary targets

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -520,9 +520,19 @@ rmf_api_generate_schema_headers(
 ament_export_targets(export_rmf_fleet_adapter HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dep_pkgs})
 
+# Install the libraries
 install(
   TARGETS
     rmf_fleet_adapter
+  EXPORT export_rmf_fleet_adapter
+  RUNTIME DESTINATION lib/rmf_fleet_adapter
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+# Install the binaries
+install(
+  TARGETS
     read_only
     read_only_blockade
     mock_traffic_light
@@ -538,10 +548,7 @@ install(
     close_lanes
     interrupt_robot
     robot_state_aggregator_main
-  EXPORT export_rmf_fleet_adapter
-  RUNTIME DESTINATION lib/rmf_fleet_adapter
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  DESTINATION lib/rmf_fleet_adapter
 )
 
 # -----------------------------------------------------------------------------

--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -517,7 +517,7 @@ rmf_api_generate_schema_headers(
 
 # -----------------------------------------------------------------------------
 
-ament_export_targets(rmf_fleet_adapter HAS_LIBRARY_TARGET)
+ament_export_targets(export_rmf_fleet_adapter HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dep_pkgs})
 
 install(
@@ -538,7 +538,7 @@ install(
     close_lanes
     interrupt_robot
     robot_state_aggregator_main
-  EXPORT rmf_fleet_adapter
+  EXPORT export_rmf_fleet_adapter
   RUNTIME DESTINATION lib/rmf_fleet_adapter
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -51,7 +51,7 @@ target_include_directories(rmf_task_ros2
     ${rclcpp_INCLUDE_DIRS}
 )
 
-ament_export_targets(rmf_task_ros2 HAS_LIBRARY_TARGET)
+ament_export_targets(export_rmf_task_ros2 HAS_LIBRARY_TARGET)
 ament_export_dependencies(rmf_traffic rmf_task_msgs rclcpp nlohmann_json)
 
 #===============================================================================
@@ -114,7 +114,7 @@ install(
 
 install(
   TARGETS rmf_task_ros2
-  EXPORT rmf_task_ros2
+  EXPORT export_rmf_task_ros2
   RUNTIME DESTINATION lib/rmf_task_ros2
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -204,7 +204,7 @@ target_include_directories(rmf_traffic_ros2
     ${rclcpp_INCLUDE_DIRS}
 )
 
-ament_export_targets(rmf_traffic_ros2 HAS_LIBRARY_TARGET)
+ament_export_targets(export_rmf_traffic_ros2 HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   rclcpp
   rmf_traffic
@@ -278,7 +278,7 @@ install(
 install(
   TARGETS
     rmf_traffic_ros2
-  EXPORT rmf_traffic_ros2
+  EXPORT export_rmf_traffic_ros2
   RUNTIME DESTINATION lib/rmf_traffic_ros2
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/rmf_websocket/CMakeLists.txt
+++ b/rmf_websocket/CMakeLists.txt
@@ -71,7 +71,7 @@ target_include_directories(example_client
 )
 
 
-ament_export_targets(rmf_websocket HAS_LIBRARY_TARGET)
+ament_export_targets(export_rmf_websocket HAS_LIBRARY_TARGET)
 ament_export_dependencies(rmf_traffic rclcpp nlohmann_json websocketpp)
 
 #===============================================================================
@@ -82,7 +82,7 @@ install(
 
 install(
   TARGETS rmf_websocket
-  EXPORT rmf_websocket
+  EXPORT export_rmf_websocket
   RUNTIME DESTINATION lib/rmf_websocket
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
## Bug fix

### Fixed bug

The libraries in `rmf_ros2` cannot be linked to by using `ament_target_dependencies`, forcing downstream users to use `target_link_libraries` instead.

### Fix applied

Based on the guidelines in the [ament_cmake docs](https://docs.ros.org/en/jazzy/How-To-Guides/Ament-CMake-Documentation.html), specifically the sample library:

```
install(
  TARGETS my_library
  EXPORT export_${PROJECT_NAME}
  LIBRARY DESTINATION lib
  ARCHIVE DESTINATION lib
  RUNTIME DESTINATION bin
)

ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
ament_export_dependencies(some_dependency)
```

The exported target has a unique name rather than the library name, this is also explicitly suggested in a later paragraph that says the following:


The EXPORT notation of the install call requires additional attention: It installs the CMake files for the my_library target. It must be named exactly the same as the argument in ament_export_targets. To ensure that it can be used via ament_target_dependencies, it should not be named exactly the same as the library name, but instead should have a prefix like export_ (as shown above).


Furthermore, we were exporting binaries and targets and downstream users using `ament_target_dependencies` would get cryptic CMake failures such as:

```
CMake Error at /opt/ros/jazzy/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:146 (target_link_libraries):
  Target "[...]" links to:

    rmf_fleet_adapter::read_only

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  CMakeLists.txt:28 (ament_target_dependencies)


CMake Generate step failed.  Build files cannot be regenerated correctly.
```

So I split the installation step to make sure we only export targets for the library and not for the executable, again following the documentation.

These changes made it possible to compile downstream applications that link to `rmf_fleet_adapter` (I haven't tested the other packages but applied the same fix for consistency)