### PR TITLE
Fix potential issues around tasks starting

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/WaitForTraffic.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/WaitForTraffic.cpp
@@ -282,7 +282,9 @@ void WaitForTraffic::Active::_consider_going()
   for (const auto& dep : _dependencies)
   {
     if (!dep.reached() && !dep.deprecated())
+    {
       all_dependencies_reached = false;
+    }
   }
 
   if (all_dependencies_reached)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -150,7 +150,7 @@ std::shared_ptr<LegacyTask::ActivePhase> WaitForCharge::Pending::begin()
     "Robot [%s] has begun waiting for its battery to charge to %.1f%%. "
     "Please ensure that the robot is charging.",
     _context->name().c_str(),
-    _charge_to_soc.value_or(1.0) * 100.0);
+    _charge_to_soc.value_or(0.98) * 100.0);
 
   active->_battery_soc_subscription = _context->observe_battery_soc()
     .observe_on(rxcpp::identity_same_worker(_context->worker()))


### PR DESCRIPTION
This PR fixes two potential issues that can come up around tasks starting:
* Make the default threshold for charging the battery more reasonable. An exact 100.0% charge might never get reported by some batteries.
* Direct tasks weren't triggering the `_begin_next_task` function of the `TaskManager`; instead they relied on the ROS timer to trigger it. Sometimes the ROS timer that periodically triggers `_begin_next_task` doesn't fire off for long periods of time, causing direct tasks to take inordinately long before they begin. With this PR, we always trigger `_begin_next_task` after a direct task request has been received.