### PR TITLE
Fix the criteria for replanning

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -1085,7 +1085,7 @@ void EasyCommandHandle::follow_new_path(
             {
               const double dist =
                 (*l.location() - wp.position().block<2, 1>(0, 0)).norm();
-              if (dist <= nav_params->max_merge_waypoint_distance)
+              if (dist <= nav_params->max_merge_lane_distance)
               {
                 found_connection = true;
                 i0 = 0;


### PR DESCRIPTION
Issue #404 reported an unnecessarily long wait when passing through a door. This PR fixes that problem.

Essentially we were using `max_merge_waypoint_distance` to judge whether a robot is close enough to where it was supposed to be when we should've been using `max_merge_lane_distance`. The "merge waypoint" distance is supposed to be much stricter than the "merge lane" distance because merging waypoints implies that the waypoints are essentially the same whereas merging lanes means the robot can move along the path as though it's somewhere on the lane.

Using the less strict parameter is now allowing the scenario to work as expected.