### PR TITLE
Feature/lkw303/task estimation

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -2860,12 +2860,12 @@ void TaskManager::_handle_estimate_robot_task_request(
   if (fleet.empty() || fleet != _context->group())
     return;
 
-  const nlohmann::json& request = request_json["request"];
-  const nlohmann::json& state = (request.find("state") == request.end()) ?
+  const nlohmann::json& task_request = request_json["request"];
+  const nlohmann::json& state = (request_json.find("state") == request_json.end()) ?
     nlohmann::json({}) : request_json["state"];
 
   const auto response = estimate_robot_task_request(
-    request,
+    task_request,
     state,
     request_id);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1194,8 +1194,7 @@ nlohmann::json TaskManager::estimate_robot_task_request(
   const auto& impl =
     agv::FleetUpdateHandle::Implementation::get(*fleet_handle);
   std::vector<std::string> errors;
-  const auto new_request = impl.convert(request_id, request["task_request"],
-      errors);
+  const auto new_request = impl.convert(request_id, request, errors);
 
   if (!new_request)
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1295,41 +1295,18 @@ nlohmann::json TaskManager::estimate_robot_task_request(
   // calculate estimated duration of task
   nlohmann::json result_json;
 
-  RCLCPP_INFO(
-    _context->node()->get_logger(),
-    "Estimated results: \n"
-  );
-
   result_json["deployment_time"] =
     to_millis(deployment_time.time_since_epoch()).count();
-
-  RCLCPP_INFO(
-    _context->node()->get_logger(),
-    "   estimated deployment time: [%f]\n",
-    result_json["deployment_time"].get<double>()
-  );
 
   if (finish_state.time().has_value())
   {
     result_json["finish_time"] =
       to_millis(finish_state.time().value().time_since_epoch()).count();
 
-    RCLCPP_INFO(
-      _context->node()->get_logger(),
-      "   estimated finish time: [%f]\n",
-      result_json["finish_time"].get<double>()
-    );
-
     auto estimate_duration_rmf =
       std::chrono::duration_cast<std::chrono::milliseconds>(
       finish_state.time().value() - deployment_time);
     result_json["duration"] = estimate_duration_rmf.count();
-
-    RCLCPP_INFO(
-      _context->node()->get_logger(),
-      "   estimated duration: [%f] seconds\n",
-      result_json["duration"].get<double>()
-    );
   }
 
   // Convert rmf_task::State into a JSON
@@ -1342,25 +1319,8 @@ nlohmann::json TaskManager::estimate_robot_task_request(
   }
 
   state["waypoint"] = int(finish_state.waypoint().value());
-  RCLCPP_INFO(
-    _context->node()->get_logger(),
-    "   waypoint: [%i]\n",
-    state["waypoint"].get<int>()
-  );
-
   state["orientation"] = finish_state.orientation().value();
-  RCLCPP_INFO(
-    _context->node()->get_logger(),
-    "   orientation: [%f]\n",
-    state["orientation"].get<double>()
-  );
-
   state["battery_soc"] = finish_state.battery_soc().value();
-  RCLCPP_INFO(
-    _context->node()->get_logger(),
-    "   battery soc: [%f]\n",
-    state["battery_soc"].get<double>()
-  );
 
   result_json["state"] = state;
   nlohmann::json response_json;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -67,6 +67,7 @@
 #include <rmf_api_msgs/schemas/commission.hpp>
 #include <rmf_api_msgs/schemas/robot_commission_request.hpp>
 #include <rmf_api_msgs/schemas/robot_commission_response.hpp>
+#include <rmf_api_msgs/schemas/task_estimate_result.hpp>
 #include <rmf_api_msgs/schemas/task_estimate_request.hpp>
 #include <rmf_api_msgs/schemas/task_estimate_response.hpp>
 
@@ -234,6 +235,7 @@ TaskManagerPtr TaskManager::make(
     rmf_api_msgs::schemas::robot_commission_request,
     rmf_api_msgs::schemas::robot_commission_response,
     rmf_api_msgs::schemas::error,
+    rmf_api_msgs::schemas::task_estimate_result,
     rmf_api_msgs::schemas::task_estimate_request,
     rmf_api_msgs::schemas::task_estimate_response
   };
@@ -1362,7 +1364,7 @@ nlohmann::json TaskManager::estimate_task_request(
 
   result_json["state"] = state;
   nlohmann::json response_json;
-  response_json["success"] = false;
+  response_json["success"] = true;
   response_json["result"] = result_json;
   return response_json;
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -191,6 +191,22 @@ public:
     const nlohmann::json& task_request,
     const std::string& request_id);
 
+  /// Submit an estimate task request to this manager
+  ///
+  /// \param[in] task_request
+  ///   A JSON description of the task request. It should match the
+  ///   task_request.json schema of rmf_api_msgs, in particular it must contain
+  ///   `category` and `description` properties.
+  ///
+  /// \param[in] request_id
+  ///   The unique ID for this task request.
+  ///
+  /// \return A robot_task_response.json message from rmf_api_msgs (note: this
+  /// message is not validated before being returned).
+  nlohmann::json estimate_task_request(
+    const nlohmann::json& task_request,
+    const std::string& request_id);
+
   class Interruption
   {
   public:
@@ -632,6 +648,10 @@ private:
     const std::string& request_id);
 
   void _handle_undo_skip_phase_request(
+    const nlohmann::json& request_json,
+    const std::string& request_id);
+
+  void _handle_estimate_request(
     const nlohmann::json& request_json,
     const std::string& request_id);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -203,8 +203,9 @@ public:
   ///
   /// \return A robot_task_response.json message from rmf_api_msgs (note: this
   /// message is not validated before being returned).
-  nlohmann::json estimate_task_request(
+  nlohmann::json estimate_robot_task_request(
     const nlohmann::json& task_request,
+    const nlohmann::json& initial_state,
     const std::string& request_id);
 
   class Interruption
@@ -651,7 +652,7 @@ private:
     const nlohmann::json& request_json,
     const std::string& request_id);
 
-  void _handle_estimate_request(
+  void _handle_estimate_robot_task_request(
     const nlohmann::json& request_json,
     const std::string& request_id);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -215,6 +215,10 @@ std::shared_ptr<rmf_task::Request> FleetUpdateHandle::Implementation::convert(
   if (!deserialized_task.description)
   {
     errors = deserialized_task.errors;
+    for (auto& e : errors)
+    {
+      e = make_error_str(6, "Unable to deserialize", e);
+    }
     return nullptr;
   }
 


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This pull request provides users a way to get estimated end states of the robot after carrying out a task. This can be useful for users who are making plans for tasks across multiple robots and would need to get an estimate for the duration of a task as well as the robot's remaining battery percentage after the task is completed.

This pull request depends on [this pull request](https://github.com/open-rmf/rmf_api_msgs/pull/57) from `rmf_api_msgs`

### Implementation description
The task estimation feature is implemented in the `TaskManager` and makes use of the `TaskPlanner` to estimate the end state of the robot after completing a task and returns this information to the user or the program which made the query.

### How it works
1. The user provides a **task** and **start state** of the robot in the task estimate request.
    * If no start state is provided, the `TaskManager` uses the expected finish state of the robot's last task by calling `TaskManager::expected_finish_state()`.
2. `TaskManager` uses the the `TaskPlanner` to get the end state of the robot after completing the task
3. `FleetAdapter` returns the estimated result to the user.


#### Other notes
I would need some help on the return of the correct error codes response for the `TaskManager` as I am not sure where I can find the documentation on it. Currently I have just used the error code `21` [here](https://github.com/lkw303/rmf_ros2/blob/feature/lkw303/task-estimation/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp#L1278-L1287) as it was one after the highest number I could find. Some help on this would be appreciated.
