### PR TITLE
Dynamic Event Action Server

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -25,6 +25,7 @@ include(GNUInstallDirs)
 
 set(dep_pkgs
   rclcpp
+  rclcpp_action
   rclcpp_components
   rmf_utils
   rmf_dispenser_msgs
@@ -91,6 +92,7 @@ ament_target_dependencies(rmf_fleet_adapter
     rmf_building_map_msgs
     rmf_reservation_msgs
     rclcpp
+    rclcpp_action
 )
 
 target_link_libraries(rmf_fleet_adapter

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -88,6 +88,10 @@ const std::string ReservationAllocationTopicName =
 const std::string ReservationReleaseTopicName = "rmf/reservations/release";
 const std::string ReservationCancelTopicName = "rmf/reservations/cancel";
 
+const std::string DynamicEventBeginTopicBase = "rmf/dynamic_event/begin";
+const std::string DynamicEventStatusTopicBase = "rmf/dynamic_event/status";
+const std::string DynamicEventActionName = "rmf/dynamic_event/command";
+
 const uint64_t Unclaimed = (uint64_t)(-1);
 
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/schemas/event_description__dynamic_event.json
+++ b/rmf_fleet_adapter/schemas/event_description__dynamic_event.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/open-rmf/rmf_ros2/main/rmf_fleet_adapter/schemas/event_description__dynamic_event.json",
+  "title": "Event Description for executing events dynamically",
+  "description": "Have a robot go to a place",
+  "type": "object",
+  "properties": {
+    "estimate": {
+      "description": "An event that estimates the expected behavior of the dynamic event, used by the task planner for optimal dispatch",
+      "$ref": "#/$defs/event"
+    },
+    "required": {
+      "description": "An array of events that the fleet must be able to execute to ensure that the dynamic event will execute successfully. This is used during task dispatch to ensure the RMF system choose an appropriate fleet for the task.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/event" }
+    }
+  },
+  "$defs": {
+    "event": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "description": "The category name of the event being used to estimate the dynamic event",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the event. This must match a schema supported by the fleet for the event category."
+        }
+      }
+    }
+  }
+}

--- a/rmf_fleet_adapter/schemas/event_description__dynamic_event.json
+++ b/rmf_fleet_adapter/schemas/event_description__dynamic_event.json
@@ -6,13 +6,23 @@
   "type": "object",
   "properties": {
     "estimate": {
-      "description": "An event that estimates the expected behavior of the dynamic event, used by the task planner for optimal dispatch",
+      "description": "Optional. An event that estimates the expected behavior of the dynamic event, used by the task planner for optimal dispatch. If this is left out, the model for the event will be a no-op.",
       "$ref": "#/$defs/event"
     },
     "required": {
       "description": "An array of events that the fleet must be able to execute to ensure that the dynamic event will execute successfully. This is used during task dispatch to ensure the RMF system choose an appropriate fleet for the task.",
       "type": "array",
       "items": { "$ref": "#/$defs/event" }
+    },
+    "category": {
+      "description": "Optional. Override the category that will be displayed in the event header. If this is left out, the catgegory field in the header will be dynamic_event."
+    },
+    "detail": {
+      "description": "Optional. Details about this event which will go into the event header. If this is left out, the detail field in the header will be left blank.",
+      "type": "string"
+    },
+    "parameters": {
+      "description": "Optional. This field is reserved for custom user-defined parameters that can inform the dynamic event client what its behavior should be."
     }
   },
   "$defs": {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/DeserializeJSON.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/DeserializeJSON.hpp
@@ -22,7 +22,44 @@
 #include <nlohmann/json.hpp>
 #include <nlohmann/json-schema.hpp>
 
+#include <rmf_task_sequence/Task.hpp>
+#include <rmf_task_sequence/Phase.hpp>
+#include <rmf_task_sequence/Event.hpp>
+#include <rmf_task_sequence/events/PerformAction.hpp>
+
 namespace rmf_fleet_adapter {
+
+//==============================================================================
+template<typename T>
+struct DeserializedDescription
+{
+  T description;
+  std::vector<std::string> errors;
+};
+
+//==============================================================================
+using DeserializedTask =
+  DeserializedDescription<std::shared_ptr<const rmf_task::Task::Description>>;
+
+//==============================================================================
+using TaskDescriptionDeserializer =
+  std::function<DeserializedTask(const nlohmann::json&)>;
+
+//==============================================================================
+using DeserializedPhase =
+  DeserializedDescription<
+  std::shared_ptr<const rmf_task_sequence::Phase::Description>
+  >;
+
+//==============================================================================
+using PhaseDescriptionDeserializer =
+  std::function<DeserializedPhase(const nlohmann::json&)>;
+
+//==============================================================================
+using DeserializedEvent =
+  DeserializedDescription<
+  std::shared_ptr<const rmf_task_sequence::Event::Description>
+  >;
 
 //==============================================================================
 template<typename Deserialized>

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -284,39 +284,6 @@ const std::string& TaskManager::ActiveTask::id() const
 namespace {
 
 //==============================================================================
-std::string status_to_string(rmf_task::Event::Status status)
-{
-  using Status = rmf_task::Event::Status;
-  switch (status)
-  {
-    case Status::Uninitialized:
-      return "uninitialized";
-    case Status::Blocked:
-      return "blocked";
-    case Status::Error:
-      return "error";
-    case Status::Failed:
-      return "failed";
-    case Status::Standby:
-      return "standby";
-    case Status::Underway:
-      return "underway";
-    case Status::Delayed:
-      return "delayed";
-    case Status::Skipped:
-      return "skipped";
-    case Status::Canceled:
-      return "canceled";
-    case Status::Killed:
-      return "killed";
-    case Status::Completed:
-      return "completed";
-    default:
-      return "uninitialized";
-  }
-}
-
-//==============================================================================
 nlohmann::json& copy_phase_data(
   nlohmann::json& phases,
   const rmf_task::Phase::Active& snapshot,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -36,6 +36,7 @@
 #include "../events/GoToPlace.hpp"
 #include "../events/ResponsiveWait.hpp"
 #include "../events/PerformAction.hpp"
+#include "../events/DynamicEvent.hpp"
 
 #include <rmf_task/Constraints.hpp>
 #include <rmf_task/Parameters.hpp>
@@ -1683,6 +1684,8 @@ void FleetUpdateHandle::Implementation::add_standard_tasks()
     deserialization,
     activation,
     node->clock());
+
+  events::DynamicEvent::add(deserialization, activation.event);
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1575,7 +1575,7 @@ PlaceDeserializer make_place_deserializer(
   planner)
 {
   return [planner = std::move(planner)](const nlohmann::json& msg)
-    -> agv::DeserializedPlace
+    -> DeserializedPlace
     {
       std::optional<rmf_traffic::agv::Plan::Goal> place;
       const auto& graph = (*planner)->get_configuration().graph();

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -143,6 +143,10 @@ std::shared_ptr<Node> Node::make(
     node->create_publisher<ReservationCancel>(
     ReservationCancelTopicName, transient_local_qos);
 
+  node->_general_dynamic_event_description_pub =
+    node->create_publisher<DynamicEventDescription>(
+      DynamicEventBeginTopicBase, transient_local_qos);
+
   return node;
 }
 
@@ -319,5 +323,12 @@ auto Node::cancel_reservation() const -> const ReservationCancelPub&
 {
   return _reservation_cancel_pub;
 }
+
+//==============================================================================
+const DynamicEventDescriptionPub& Node::all_dynamic_event_descriptions() const
+{
+  return _general_dynamic_event_description_pub;
+}
+
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
@@ -48,10 +48,17 @@
 
 #include <rmf_task_msgs/msg/api_request.hpp>
 #include <rmf_task_msgs/msg/api_response.hpp>
+#include <rmf_task_msgs/msg/dynamic_event_description.hpp>
 
 #include <rmf_traffic/Time.hpp>
 
 namespace rmf_fleet_adapter {
+
+using DynamicEventDescription = rmf_task_msgs::msg::DynamicEventDescription;
+using DynamicEventDescriptionPub =
+  rclcpp::Publisher<DynamicEventDescription>::SharedPtr;
+
+
 namespace agv {
 
 //==============================================================================
@@ -171,6 +178,8 @@ public:
     rclcpp::Publisher<ReservationCancel>::SharedPtr;
   const ReservationCancelPub& cancel_reservation() const;
 
+  const DynamicEventDescriptionPub& all_dynamic_event_descriptions() const;
+
 
   template<typename DurationRepT, typename DurationT, typename CallbackT>
   rclcpp::TimerBase::SharedPtr try_create_wall_timer(
@@ -238,6 +247,7 @@ private:
   Bridge<ReservationAllocation> _reservation_alloc_obs;
   ReservationReleasePub _reservation_release_pub;
   ReservationCancelPub _reservation_cancel_pub;
+  DynamicEventDescriptionPub _general_dynamic_event_description_pub;
 };
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -2162,9 +2162,12 @@ void RobotContext::_initialize_dynamic_event_server()
       return rclcpp_action::GoalResponse::REJECT;
     }
 
-    if (!callbacks->validator(goal->category, goal->description))
+    if (goal->event_type == DynamicEventAction::Goal::EVENT_TYPE_NEXT)
     {
-      return rclcpp_action::GoalResponse::REJECT;
+      if (!callbacks->validator(goal->category, goal->description))
+      {
+        return rclcpp_action::GoalResponse::REJECT;
+      }
     }
 
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -2185,7 +2185,10 @@ void RobotContext::_initialize_dynamic_event_server()
     }
 
     const auto callbacks = me->_dynamic_event_callbacks.lock();
-    if (!callbacks || !me->_dynamic_event_goal.expired())
+    const auto event_conflict = !me->_dynamic_event_goal.expired()
+      && handle->get_goal()->event_type != DynamicEventAction::Goal::EVENT_TYPE_CANCEL;
+
+    if (!callbacks || event_conflict)
     {
       handle->execute();
       handle->abort(dynamic_event_execution_failure("race condition"));

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -32,11 +32,6 @@
 #include <rmf_task/requests/Clean.hpp>
 #include <rmf_task/BinaryPriorityScheme.hpp>
 
-#include <rmf_task_sequence/Task.hpp>
-#include <rmf_task_sequence/Phase.hpp>
-#include <rmf_task_sequence/Event.hpp>
-#include <rmf_task_sequence/events/PerformAction.hpp>
-
 #include <rmf_building_map_msgs/msg/graph.hpp>
 
 #include <rmf_fleet_msgs/msg/dock_summary.hpp>
@@ -49,7 +44,6 @@
 #include "Node.hpp"
 #include "RobotContext.hpp"
 #include "../TaskManager.hpp"
-#include "../DeserializeJSON.hpp"
 #include <rmf_websocket/BroadcastClient.hpp>
 
 #include <rmf_traffic/schedule/Mirror.hpp>
@@ -89,38 +83,6 @@ struct TaskActivation
   rmf_task_sequence::Phase::ActivatorPtr phase;
   rmf_task_sequence::Event::InitializerPtr event;
 };
-
-//==============================================================================
-template<typename T>
-struct DeserializedDescription
-{
-  T description;
-  std::vector<std::string> errors;
-};
-
-//==============================================================================
-using DeserializedTask =
-  DeserializedDescription<std::shared_ptr<const rmf_task::Task::Description>>;
-
-//==============================================================================
-using TaskDescriptionDeserializer =
-  std::function<DeserializedTask(const nlohmann::json&)>;
-
-//==============================================================================
-using DeserializedPhase =
-  DeserializedDescription<
-  std::shared_ptr<const rmf_task_sequence::Phase::Description>
-  >;
-
-//==============================================================================
-using PhaseDescriptionDeserializer =
-  std::function<DeserializedPhase(const nlohmann::json&)>;
-
-//==============================================================================
-using DeserializedEvent =
-  DeserializedDescription<
-  std::shared_ptr<const rmf_task_sequence::Event::Description>
-  >;
 
 //==============================================================================
 using EventDescriptionDeserializer =

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.cpp
@@ -317,6 +317,15 @@ auto DynamicEvent::Active::make(
       me->_state->update_status(rmf_task::Event::State::Status::Completed);
       me->_publish_update();
       me->_finished();
+
+      const auto state = me->_current_event->state();
+      const auto result = std::make_shared<DynamicEventAction::Result>(
+        rmf_task_msgs::build<DynamicEventAction::Result>()
+          .execution_failure("")
+          .status(status_to_string(state->status()))
+          .id(state->id())
+      );
+      handle->succeed(result);
       return;
     }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.cpp
@@ -318,12 +318,11 @@ auto DynamicEvent::Active::make(
       me->_publish_update();
       me->_finished();
 
-      const auto state = me->_current_event->state();
       const auto result = std::make_shared<DynamicEventAction::Result>(
         rmf_task_msgs::build<DynamicEventAction::Result>()
           .execution_failure("")
-          .status(status_to_string(state->status()))
-          .id(state->id())
+          .status(status_to_string(me->_state->status()))
+          .id(me->_state->id())
       );
       handle->succeed(result);
       return;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.cpp
@@ -1,0 +1,654 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "DynamicEvent.hpp"
+#include "../log_to_json.hpp"
+
+#include <rmf_task_sequence/events/Placeholder.hpp>
+#include <rmf_task_msgs/msg/log_entry.hpp>
+
+#include <rmf_fleet_adapter/schemas/event_description__dynamic_event.hpp>
+
+namespace rmf_fleet_adapter {
+namespace events {
+
+//==============================================================================
+void DynamicEvent::add(
+  agv::TaskDeserialization& deserialization,
+  rmf_task_sequence::Event::InitializerPtr event_initializer)
+{
+  const auto event_deserializer = deserialization.event;
+  auto validate_dynamic_event = deserialization.make_validator_shared(
+    schemas::event_description__dynamic_event);
+
+  auto deserialize_dynamic_event =
+    [event_deserializer, event_initializer](
+      const nlohmann::json& msg) -> DeserializedEvent
+    {
+      std::vector<std::string> errors;
+      const auto estimate_it = msg.find("estimate");
+      rmf_task_sequence::Event::ConstDescriptionPtr estimate;
+      if (estimate_it != msg.end())
+      {
+        const auto& estimate_category =
+          estimate_it->at("category").get<std::string>();
+        const auto& estimate_description = estimate_it->at("description");
+        const auto e_it = event_deserializer->handlers.find(estimate_category);
+        if (e_it == event_deserializer->handlers.end())
+        {
+          errors.push_back(
+            "No support for [" + estimate_category + "] activities");
+          return {nullptr, std::move(errors)};
+        }
+
+        auto event = e_it->second.deserializer(estimate_description);
+        errors.insert(errors.end(), event.errors.begin(), event.errors.end());
+        if (!event.description)
+        {
+          return {nullptr, std::move(errors)};
+        }
+
+        estimate = event.description;
+      }
+
+      if (!estimate)
+      {
+        // If the estimate was left blank, just use a placeholder estimate.
+        estimate = std::make_shared<rmf_task_sequence::events::Placeholder::Description>("", "");
+      }
+
+      const auto required_it = msg.find("required");
+      if (required_it != msg.end())
+      {
+        bool any_error = false;
+        for (const auto& event : *required_it)
+        {
+          const auto& req_category = event.at("category").get<std::string>();
+          const auto& req_description = event.at("description");
+          const auto r_it = event_deserializer->handlers.find(req_category);
+          if (r_it == event_deserializer->handlers.end())
+          {
+            errors.push_back("No support for [" + req_category + "] activities");
+            any_error = true;
+          }
+          else
+          {
+            auto event = r_it->second.deserializer(req_description);
+            errors.insert(errors.end(), event.errors.begin(), event.errors.end());
+            if (!event.description)
+            {
+              any_error = true;
+            }
+          }
+        }
+
+        if (any_error)
+        {
+          return {nullptr, std::move(errors)};
+        }
+      }
+
+      std::string category = "dynamic_event";
+      const auto category_it = msg.find("category");
+      if (category_it != msg.end())
+      {
+        category = category_it->get<std::string>();
+      }
+
+      std::string detail;
+      const auto detail_it = msg.find("detail");
+      if (detail_it != msg.end())
+      {
+        detail = detail_it->get<std::string>();
+      }
+
+      const auto description = DynamicEvent::Description::make(
+        category, detail, msg, std::move(estimate), event_deserializer, event_initializer);
+      return {description, std::move(errors)};
+    };
+
+  deserialization.event->add(
+    "dynamic_event",
+    validate_dynamic_event,
+    deserialize_dynamic_event);
+
+  event_initializer->add<Description>(
+    [event_deserializer, event_initializer](
+      const AssignIDPtr& id,
+      const std::function<rmf_task::State()>& get_state,
+      const rmf_task::ConstParametersPtr& parameters,
+      const Description& description,
+      std::function<void()> update) -> StandbyPtr
+    {
+      return Standby::make(
+        id, get_state, parameters, description, std::move(update));
+    },
+    [=](
+      const AssignIDPtr& id,
+      const std::function<rmf_task::State()>& get_state,
+      const rmf_task::ConstParametersPtr& parameters,
+      const Description& description,
+      const nlohmann::json&,
+      std::function<void()> update,
+      std::function<void()> checkpoint,
+      std::function<void()> finished) -> ActivePtr
+    {
+      return Standby::make(
+        id, get_state, parameters, description, std::move(update))
+      ->begin(std::move(checkpoint), std::move(finished));
+    });
+}
+
+//==============================================================================
+const std::string& DynamicEvent::Description::json_text() const
+{
+  return _json_text;
+}
+
+//==============================================================================
+const nlohmann::json& DynamicEvent::Description::json() const
+{
+  return _json;
+}
+
+//==============================================================================
+rmf_task_sequence::Activity::ConstModelPtr
+DynamicEvent::Description::make_model(
+  rmf_task::State initial_state,
+  const rmf_task::Parameters& parameters) const
+{
+  return _estimate->make_model(initial_state, parameters);
+}
+
+//==============================================================================
+rmf_task::Header DynamicEvent::Description::generate_header(
+  const rmf_task::State& initial_state,
+  const rmf_task::Parameters& parameters) const
+{
+  const auto estimate = _estimate->generate_header(initial_state, parameters);
+  return rmf_task::Header(
+    _category, _detail, estimate.original_duration_estimate());
+}
+
+//==============================================================================
+const DeserializeJSONPtr<DeserializedEvent>&
+DynamicEvent::Description::event_deserializer() const
+{
+  return _event_deserializer;
+}
+
+//==============================================================================
+const rmf_task_sequence::Event::ConstInitializerPtr&
+DynamicEvent::Description::event_initializer() const
+{
+  return _event_initializer;
+}
+
+//==============================================================================
+DynamicEvent::Description::Description(
+  std::string category,
+  std::string detail,
+  nlohmann::json description_json,
+  rmf_task_sequence::Event::ConstDescriptionPtr estimate,
+  DeserializeJSONPtr<DeserializedEvent> event_deserializer,
+  rmf_task_sequence::Event::ConstInitializerPtr event_initializer)
+: _json_text(description_json.dump()),
+  _json(std::move(description_json)),
+  _category(std::move(category)),
+  _detail(std::move(detail)),
+  _estimate(std::move(estimate)),
+  _event_deserializer(std::move(event_deserializer)),
+  _event_initializer(std::move(event_initializer))
+{
+  // Do nothing
+}
+
+//==============================================================================
+auto DynamicEvent::Standby::make(
+  const AssignIDPtr& id,
+  const std::function<rmf_task::State()>& get_state,
+  const rmf_task::ConstParametersPtr& parameters,
+  const Description& description,
+  std::function<void()> update) -> std::shared_ptr<Standby>
+{
+  const auto state = get_state();
+  const auto context = state.get<agv::GetContext>()->value;
+  const auto header = description.generate_header(state, *parameters);
+
+  auto standby = std::make_shared<Standby>(Standby{description});
+  standby->_assign_id = id;
+  standby->_context = context;
+  standby->_time_estimate = header.original_duration_estimate();
+  standby->_update = std::move(update);
+  standby->_state = rmf_task::events::SimpleEventState::make(
+    id->assign(),
+    header.category(),
+    header.detail(),
+    rmf_task::Event::Status::Standby,
+    {},
+    context->clock());
+
+  return standby;
+}
+
+//==============================================================================
+auto DynamicEvent::Standby::state() const -> ConstStatePtr
+{
+  return _state;
+}
+
+//==============================================================================
+rmf_traffic::Duration DynamicEvent::Standby::duration_estimate() const
+{
+  return _time_estimate;
+}
+
+//==============================================================================
+auto DynamicEvent::Standby::begin(
+  std::function<void()> /*checkpoint*/,
+  std::function<void()> finished) -> ActivePtr
+{
+  if (!_active)
+  {
+    _active = DynamicEvent::Active::make(
+      _assign_id,
+      _context,
+      _description,
+      _state,
+      _update,
+      finished);
+  }
+
+  return _active;
+}
+
+//==============================================================================
+DynamicEvent::Standby::Standby(Description description)
+: _description(std::move(description))
+{
+  // Do nothing
+}
+
+//==============================================================================
+auto DynamicEvent::Active::make(
+  const AssignIDPtr& id,
+  agv::RobotContextPtr context,
+  Description description,
+  rmf_task::events::SimpleEventStatePtr state,
+  std::function<void()> update,
+  std::function<void()> finished) -> std::shared_ptr<Active>
+{
+  auto active = std::make_shared<Active>(Active{description});
+
+  active->_assign_ids = id;
+  active->_context = context;
+  active->_state = state;
+  active->_update = update;
+  active->_finished = finished;
+
+  auto executor = [w = active->weak_from_this()](
+    std::shared_ptr<DynamicEventHandle> handle,
+    std::shared_ptr<void> event_raii)
+  {
+    handle->execute();
+    const auto me = w.lock();
+    if (!me)
+    {
+      handle->abort(dynamic_event_execution_failure("shutting down"));
+      return;
+    }
+
+    if (DynamicEventAction::Goal::EVENT_TYPE_FINISHED == handle->get_goal()->event_type)
+    {
+      // The dynamic event is completely finished now
+      me->_state->update_status(rmf_task::Event::State::Status::Completed);
+      me->_publish_update();
+      me->_finished();
+      return;
+    }
+
+    if (DynamicEventAction::Goal::EVENT_TYPE_CANCEL == handle->get_goal()->event_type)
+    {
+      if (!me->_current_event)
+      {
+        handle->abort(dynamic_event_execution_failure(
+          "an idle dynamic event cannot be cancelled"));
+        return;
+      }
+
+      const auto id = me->_current_event->state()->id();
+      if (id != handle->get_goal()->id)
+      {
+        handle->abort(dynamic_event_execution_failure(
+          "ID for cancel request does not match current event"));
+        return;
+      }
+
+      me->_current_event->cancel();
+      return;
+    }
+
+    if (DynamicEventAction::Goal::EVENT_TYPE_NEXT != handle->get_goal()->event_type)
+    {
+      handle->abort(dynamic_event_execution_failure("invalid event_type"));
+      return;
+    }
+
+    const std::string& child_category = handle->get_goal()->category;
+
+    const auto child_description_json =
+      nlohmann::json::parse(handle->get_goal()->description);
+
+    // We can use .at here because we already validated that we can run the
+    // description. Unfortunately because of the way the rclcpp_action API is
+    // designed, we need to parse this twice.
+    const auto deserializer = me->_description.event_deserializer()->handlers
+      .at(child_category);
+
+    const auto deser = deserializer.deserializer(child_description_json);
+    const auto child_description = deser.description;
+
+    if (!child_description)
+    {
+      std::string failure_msg = "Description parsing failure";
+      for (const auto& error : deser.errors)
+      {
+        failure_msg += "\n -- " + error;
+      }
+
+      handle->abort(dynamic_event_execution_failure(failure_msg));
+      return;
+    }
+
+    me->_deferred_event_start = nullptr;
+    me->_current_event_raii = std::move(event_raii);
+    me->_current_handle = std::move(handle);
+    if (me->_interrupted)
+    {
+      me->_deferred_event_start = [w = me->weak_from_this(), child_description]()
+        {
+          const auto me = w.lock();
+          if (!me)
+            return;
+
+          me->_begin_next_event(child_description);
+        };
+
+      return;
+    }
+
+    me->_begin_next_event(child_description);
+  };
+
+  auto cancel = [w = active->weak_from_this()](
+    std::shared_ptr<DynamicEventHandle>)
+  {
+    const auto me = w.lock();
+    if (!me || !me->_current_event)
+      return;
+
+    me->_current_event->cancel();
+  };
+
+  auto validator = [w = active->weak_from_this()](
+    const std::string& category,
+    const std::string& description)
+  {
+    const auto me = w.lock();
+    if (!me)
+      return false;
+
+    const auto& handlers = me->_description.event_deserializer()->handlers;
+
+    const auto deserialize_it = handlers.find(category);
+    if (deserialize_it == handlers.end())
+      return false;
+
+    nlohmann::json description_json;
+    try
+    {
+      description_json = nlohmann::json::parse(description);
+    }
+    catch (const std::exception&)
+    {
+      return false;
+    }
+
+    try
+    {
+      deserialize_it->second.validator->validate(description_json);
+    }
+    catch (const std::exception&)
+    {
+      return false;
+    }
+
+    const auto deser = deserialize_it->second.deserializer(description_json);
+    return deser.description != nullptr;
+  };
+
+  active->_callbacks = std::make_shared<DynamicEventCallbacks>(
+    DynamicEventCallbacks {
+      executor,
+      cancel,
+      validator,
+      active->_context
+    });
+
+  active->_seq = active->_context->_begin_dynamic_event(
+    active->_description.json_text(),
+    active->_callbacks);
+
+  active->_state->update_status(rmf_task::Event::State::Status::Standby);
+
+  active->_publish_update();
+  active->_update();
+
+  active->_context->_publish_dynamic_event_status(
+    rmf_task::Event::State::Status::Standby,
+    active->_state->id()
+  );
+
+  return active;
+}
+
+//==============================================================================
+auto DynamicEvent::Active::state() const -> ConstStatePtr
+{
+  return _state;
+}
+
+//==============================================================================
+rmf_traffic::Duration DynamicEvent::Active::remaining_time_estimate() const
+{
+  if (_current_event)
+    return _current_event->remaining_time_estimate();
+
+  return rmf_traffic::Duration(0);
+}
+
+//==============================================================================
+auto DynamicEvent::Active::backup() const -> Backup
+{
+  return Backup::make(0, nlohmann::json());
+}
+
+//==============================================================================
+auto DynamicEvent::Active::interrupt(
+  std::function<void()> task_is_interrupted) -> Resume
+{
+  _interrupted = true;
+  if (_current_event)
+    return _current_event->interrupt(task_is_interrupted);
+
+  return Resume::make(
+    [w = weak_from_this()]()
+    {
+      const auto me = w.lock();
+      if (!me)
+        return;
+
+      me->_interrupted = false;
+      if (me->_deferred_event_start)
+      {
+        me->_context->worker().schedule(
+          [job = me->_deferred_event_start](const auto&)
+          {
+            job();
+          });
+
+        me->_deferred_event_start = nullptr;
+      }
+    });
+}
+
+//==============================================================================
+void DynamicEvent::Active::cancel()
+{
+  _cancelled = true;
+  if (_current_event)
+  {
+    _current_event->cancel();
+    return;
+  }
+
+  _context->worker().schedule([finished = _finished](const auto&)
+    {
+      finished();
+    });
+}
+
+//==============================================================================
+void DynamicEvent::Active::kill()
+{
+  _cancelled = true;
+  if (_current_event)
+  {
+    _current_event->kill();
+    return;
+  }
+
+  _context->worker().schedule([finished = _finished](const auto&)
+    {
+      finished();
+    });
+}
+
+//==============================================================================
+DynamicEvent::Active::Active(Description description)
+: _description(std::move(description))
+{
+  // Do nothing
+}
+
+//==============================================================================
+void DynamicEvent::Active::_publish_update()
+{
+  _update();
+
+  if (!_current_event || !_current_handle)
+    return;
+
+  using LogEntry = rmf_task_msgs::msg::LogEntry;
+
+  const auto& state = _current_event->state();
+  std::vector<LogEntry> logs;
+  for (auto log : _log_reader.read(state->log()))
+  {
+    logs.push_back(
+      rmf_task_msgs::build<LogEntry>()
+        .seq(_seq)
+        .tier(tier_to_string(log.tier()))
+        .unix_millis_time(to_millis(log.time().time_since_epoch()).count())
+        .text(log.text()));
+  }
+
+  auto msg = rmf_task_msgs::build<DynamicEventAction::Feedback>()
+    .status(status_to_string(state->status()))
+    .id(state->id())
+    .logs(std::move(logs));
+
+  _current_handle->publish_feedback(
+    std::make_shared<DynamicEventAction::Feedback>(std::move(msg)));
+
+  _context->_publish_dynamic_event_status(state->status(), state->id());
+}
+
+//==============================================================================
+void DynamicEvent::Active::_begin_next_event(
+  std::shared_ptr<const rmf_task_sequence::Event::Description> child_description)
+{
+  auto on_update = [w = this->weak_from_this()]()
+  {
+    const auto me = w.lock();
+    if (!me)
+      return;
+
+    me->_publish_update();
+  };
+
+  auto on_finish = [w = this->weak_from_this(), handle = _current_handle]()
+  {
+    const auto me = w.lock();
+    if (!me || !me->_current_event)
+    {
+      if (handle)
+        handle->abort(dynamic_event_execution_failure("shutting down"));
+
+      return;
+    }
+
+    me->_state->update_status(rmf_task::Event::Status::Standby);
+    me->_publish_update();
+
+    const auto state = me->_current_event->state();
+    handle->succeed(std::make_shared<DynamicEventAction::Result>(
+      rmf_task_msgs::build<DynamicEventAction::Result>()
+        .execution_failure("")
+        .status(status_to_string(state->status()))
+        .id(state->id())
+    ));
+
+    me->_current_event = nullptr;
+    me->_current_event_raii = nullptr;
+    me->_current_handle = nullptr;
+    me->_deferred_event_start = nullptr;
+
+    if (me->_cancelled)
+    {
+      me->_finished();
+    }
+  };
+
+  // We don't use checkpoints for dynamic events
+  auto on_checkpoint = []() {};
+
+  _current_event = _description.event_initializer()->initialize(
+    _assign_ids,
+    _context->make_get_state(),
+    _context->task_parameters(),
+    *child_description,
+    std::move(on_update))
+    ->begin(std::move(on_checkpoint), std::move(on_finish));
+
+  _state->add_dependency(_current_event->state());
+  _state->update_status(rmf_task::Event::Status::Underway);
+  _publish_update();
+}
+
+} // namespace events
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.cpp
@@ -304,7 +304,6 @@ auto DynamicEvent::Active::make(
     std::shared_ptr<DynamicEventHandle> handle,
     std::shared_ptr<void> event_raii)
   {
-    handle->execute();
     const auto me = w.lock();
     if (!me)
     {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.hpp
@@ -160,7 +160,8 @@ private:
   void _publish_update();
 
   void _begin_next_event(
-    std::shared_ptr<const rmf_task_sequence::Event::Description> child_description);
+    std::shared_ptr<const rmf_task_sequence::Event::Description> child_description,
+    float stubborn_period);
 
   Description _description;
   std::shared_ptr<DynamicEventCallbacks> _callbacks;
@@ -178,6 +179,7 @@ private:
   bool _interrupted = false;
   bool _cancelled = false;
   std::function<void()> _deferred_event_start;
+  rclcpp::TimerBase::SharedPtr _stubborn_timer;
 };
 
 } // namespace events

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.hpp
@@ -174,6 +174,7 @@ private:
   std::shared_ptr<void> _current_event_raii;
   rmf_task_sequence::Event::ActivePtr _current_event;
   std::shared_ptr<DynamicEventHandle> _current_handle;
+  std::vector<std::shared_ptr<DynamicEventHandle>> _event_cancellation_handles;
   rmf_task::VersionedString::Reader _string_reader;
   rmf_task::Log::Reader _log_reader;
   bool _interrupted = false;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/DynamicEvent.hpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__EVENTS__DYNAMICEVENT_HPP
+#define SRC__RMF_FLEET_ADAPTER__EVENTS__DYNAMICEVENT_HPP
+
+#include "../agv/RobotContext.hpp"
+#include "../agv/internal_FleetUpdateHandle.hpp"
+
+#include <rmf_task_sequence/Event.hpp>
+#include <rmf_task/events/SimpleEventState.hpp>
+
+namespace rmf_fleet_adapter {
+namespace events {
+
+//==============================================================================
+class DynamicEvent : public rmf_task_sequence::Event
+{
+public:
+  class Description;
+  using DescriptionPtr = std::shared_ptr<Description>;
+
+  static void add(
+    agv::TaskDeserialization& deserialization,
+    rmf_task_sequence::Event::InitializerPtr event_initializer);
+
+  class Standby;
+  class Active;
+
+};
+
+//==============================================================================
+class DynamicEvent::Description : public Event::Description
+{
+public:
+
+  template<typename... Args>
+  static DescriptionPtr make(Args&&... args)
+  {
+    return std::shared_ptr<Description>(
+      new Description(std::forward<Args>(args)...));
+  }
+
+  /// Get the original json text of the description. This may contain additional
+  /// unparsed parameters set by the user.
+  const std::string& json_text() const;
+
+  /// Get the parsed json of the description.
+  const nlohmann::json& json() const;
+
+  rmf_task_sequence::Activity::ConstModelPtr make_model(
+    rmf_task::State initial_state,
+    const rmf_task::Parameters& parameters) const final;
+
+  rmf_task::Header generate_header(
+    const rmf_task::State& initial_state,
+    const rmf_task::Parameters& parameters) const final;
+
+  const DeserializeJSONPtr<DeserializedEvent>& event_deserializer() const;
+
+  const rmf_task_sequence::Event::ConstInitializerPtr& event_initializer() const;
+
+private:
+
+  Description(
+    std::string category,
+    std::string detail,
+    nlohmann::json description_json,
+    rmf_task_sequence::Event::ConstDescriptionPtr estimate,
+    DeserializeJSONPtr<DeserializedEvent> event_deserializer,
+    rmf_task_sequence::Event::ConstInitializerPtr event_initializer);
+
+  std::string _json_text;
+  nlohmann::json _json;
+  std::string _category;
+  std::string _detail;
+  rmf_task_sequence::Event::ConstDescriptionPtr _estimate;
+  DeserializeJSONPtr<DeserializedEvent> _event_deserializer;
+  rmf_task_sequence::Event::ConstInitializerPtr _event_initializer;
+};
+
+//==============================================================================
+class DynamicEvent::Standby : public rmf_task_sequence::Event::Standby
+{
+public:
+
+  static std::shared_ptr<Standby> make(
+    const AssignIDPtr& id,
+    const std::function<rmf_task::State()>& get_state,
+    const rmf_task::ConstParametersPtr& parameters,
+    const Description& description,
+    std::function<void()> update);
+
+  ConstStatePtr state() const final;
+
+  rmf_traffic::Duration duration_estimate() const final;
+
+  ActivePtr begin(
+    std::function<void()> checkpoint,
+    std::function<void()> finished) final;
+
+private:
+
+  Standby(Description description);
+
+  Description _description;
+  AssignIDPtr _assign_id;
+  agv::RobotContextPtr _context;
+  rmf_traffic::Duration _time_estimate;
+  std::function<void()> _update;
+  rmf_task::events::SimpleEventStatePtr _state;
+  ActivePtr _active = nullptr;
+};
+
+//==============================================================================
+class DynamicEvent::Active
+  : public rmf_task_sequence::Event::Active,
+  public std::enable_shared_from_this<Active>
+{
+public:
+
+  static std::shared_ptr<Active> make(
+    const AssignIDPtr& id,
+    agv::RobotContextPtr context,
+    Description description,
+    rmf_task::events::SimpleEventStatePtr state,
+    std::function<void()> update,
+    std::function<void()> finished);
+
+  ConstStatePtr state() const final;
+
+  rmf_traffic::Duration remaining_time_estimate() const final;
+
+  Backup backup() const final;
+
+  Resume interrupt(std::function<void()> task_is_interrupted) final;
+
+  void cancel() final;
+
+  void kill() final;
+
+private:
+
+  Active(Description description);
+
+  void _publish_update();
+
+  void _begin_next_event(
+    std::shared_ptr<const rmf_task_sequence::Event::Description> child_description);
+
+  Description _description;
+  std::shared_ptr<DynamicEventCallbacks> _callbacks;
+  AssignIDPtr _assign_ids;
+  agv::RobotContextPtr _context;
+  rmf_task::events::SimpleEventStatePtr _state;
+  std::function<void()> _update;
+  std::function<void()> _finished;
+  uint32_t _seq;
+  std::shared_ptr<void> _current_event_raii;
+  rmf_task_sequence::Event::ActivePtr _current_event;
+  std::shared_ptr<DynamicEventHandle> _current_handle;
+  rmf_task::VersionedString::Reader _string_reader;
+  rmf_task::Log::Reader _log_reader;
+  bool _interrupted = false;
+  bool _cancelled = false;
+  std::function<void()> _deferred_event_start;
+};
+
+} // namespace events
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__EVENTS__DYNAMICEVENT_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Clean.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Clean.cpp
@@ -229,7 +229,7 @@ void add_clean(
     traits,
     place_deser = deserialization.place,
     consider = deserialization.consider_clean
-    ](const nlohmann::json& msg) -> agv::DeserializedTask
+    ](const nlohmann::json& msg) -> DeserializedTask
     {
       if (!consider || !(*consider))
       {
@@ -308,7 +308,7 @@ void add_clean(
   deserialization.task->add("clean", validate_clean_task, deserialize_clean);
 
   auto deserialize_clean_event =
-    [deserialize_clean](const nlohmann::json& msg) -> agv::DeserializedEvent
+    [deserialize_clean](const nlohmann::json& msg) -> DeserializedEvent
     {
       auto clean_task = deserialize_clean(msg);
       if (!clean_task.description)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Compose.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Compose.cpp
@@ -46,7 +46,7 @@ void add_compose(
     [
     deser_phase = deserialization.phase,
     deser_event = deserialization.event
-    ](const nlohmann::json& msg) -> agv::DeserializedPhase
+    ](const nlohmann::json& msg) -> DeserializedPhase
     {
       const auto& category = msg.at("category").get<std::string>();
       const auto& description_json = msg.at("description");
@@ -104,7 +104,7 @@ void add_compose(
     deser_activity = deserialize_activity,
     consider = deserialization.consider_composed
     ](const nlohmann::json& msg)
-    -> agv::DeserializedTask
+    -> DeserializedTask
     {
       if (!(*consider))
       {
@@ -188,7 +188,7 @@ void add_compose(
 
   using rmf_task_sequence::events::Bundle;
   using DeserializedDependencies =
-    agv::DeserializedDescription<
+    DeserializedDescription<
     std::optional<Bundle::Description::Dependencies>>;
 
   // Deserialize composed tasks
@@ -234,7 +234,7 @@ void add_compose(
 
   auto deserialize_event_sequence =
     [deserialize_event_dependencies](const nlohmann::json& msg)
-    -> agv::DeserializedEvent
+    -> DeserializedEvent
     {
       DeserializedDependencies dependencies;
       std::optional<std::string> category;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.cpp
@@ -199,7 +199,7 @@ struct TransferItems
 };
 
 //==============================================================================
-using DeserializedItemTransfer = agv::DeserializedEvent;
+using DeserializedItemTransfer = DeserializedEvent;
 template<typename T>
 std::function<DeserializedItemTransfer(const nlohmann::json& msg)>
 make_deserializer(
@@ -226,7 +226,7 @@ make_deserializer(
     place_deser,
     consider,
     parse_payload_component = std::move(parse_payload_component)
-    ](const nlohmann::json& msg) -> agv::DeserializedEvent
+    ](const nlohmann::json& msg) -> DeserializedEvent
     {
       if (!consider || !(*consider))
       {
@@ -332,7 +332,7 @@ void add_delivery(
 
   auto deserialize_delivery =
     [deserialize_pickup, deserialize_dropoff](
-    const nlohmann::json& msg) -> agv::DeserializedTask
+    const nlohmann::json& msg) -> DeserializedTask
     {
       const auto pickup = deserialize_pickup(msg.at("pickup"));
       const auto dropoff = deserialize_dropoff(msg.at("dropoff"));

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Patrol.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Patrol.cpp
@@ -47,7 +47,7 @@ void add_patrol(
 
   auto deserialize_go_to_place =
     [place_deser = deserialization.place](const nlohmann::json& msg)
-    -> agv::DeserializedEvent
+    -> DeserializedEvent
     {
       nlohmann::json place_msg;
       const auto one_of = msg.find("one_of");
@@ -147,7 +147,7 @@ void add_patrol(
     [
     place_deser = deserialization.place,
     consider = deserialization.consider_patrol
-    ](const nlohmann::json& msg) -> agv::DeserializedTask
+    ](const nlohmann::json& msg) -> DeserializedTask
     {
       if (!(*consider))
       {


### PR DESCRIPTION
This implements the dynamic event action server proposed in [this discussion](https://github.com/open-rmf/rmf/discussions/632).

This PR depends on [another PR for `rmf_internal_msgs`](https://github.com/open-rmf/rmf_internal_msgs/pull/81).

To use the new feature in this PR:
* Create a composed task that contains a [`dynamic_event`](https://github.com/open-rmf/rmf_ros2/blob/dynamic_event/rmf_fleet_adapter/schemas/event_description__dynamic_event.json) and dispatch it
* Implement a [dynamic event action](https://github.com/open-rmf/rmf_internal_msgs/blob/dynamic_event/rmf_task_msgs/action/DynamicEvent.action) **_client_** that issues goals for the dynamic action event server to follow

@TanJunKiat Maybe your team can help with testing by contributing a simple Python script to [`rmf_demos_tasks`](https://github.com/open-rmf/rmf_demos/tree/main/rmf_demos_tasks/rmf_demos_tasks) that does the following:
* Subscribe to `rmf/dynamic_event/begin` to watch for a dynamic event to begin
* When a new dynamic event begins, make an action client for `rmf/dynamic_event/command/<fleet>/<robot>`, wait for it to connect, and then issue a command based on CLI arguments given by `--category` and `--file` similar to [`dispatch_json.py`](https://github.com/open-rmf/rmf_demos/blob/main/rmf_demos_tasks/rmf_demos_tasks/dispatch_json.py)
* Wait for the event to finish and then quit

Let me know what you think and feel free to reach out for more guidance.