### PR TITLE
return if no ticket when cancel reservation

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/ReservationManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/ReservationManager.cpp
@@ -53,7 +53,7 @@ void ReservationManager::cancel()
   {
     return;
   }
-  if (has_ticket())
+  if (!has_ticket())
     return;
 
   RCLCPP_INFO(


### PR DESCRIPTION

## Bug fix

### Fixed bug

return if `!has_ticket()` when cancel reservation instead of `has_ticket()`

