### PR TITLE
Giving options to separate fire alarm by fleet names

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1392,6 +1392,26 @@ void FleetUpdateHandle::Implementation::update_fleet_logs() const
 
 //==============================================================================
 void FleetUpdateHandle::Implementation::handle_emergency(
+  const bool emergency_signal)
+{
+  if (emergency_signal == emergency_active)
+    return;
+
+  emergency_active = emergency_signal;
+  if (emergency_signal)
+  {
+    update_emergency_planner();
+  }
+
+  for (const auto& [context, _] : task_managers)
+  {
+    context->_set_emergency(emergency_signal);
+  }
+  emergency_publisher.get_subscriber().on_next(emergency_signal);
+}
+
+//==============================================================================
+void FleetUpdateHandle::Implementation::handle_target_emergency(
   std::shared_ptr<rmf_fleet_msgs::msg::EmergencySignal> emergency_signal)
 {
   bool execute = false;
@@ -1425,8 +1445,6 @@ void FleetUpdateHandle::Implementation::handle_emergency(
     }
     emergency_publisher.get_subscriber().on_next(emergency_signal->is_emergency);
   }
-
-
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1430,20 +1430,7 @@ void FleetUpdateHandle::Implementation::handle_target_emergency(
   }
 
   if (execute) {
-    if (emergency_signal->is_emergency == emergency_active)
-      return;
-  
-    emergency_active = emergency_signal->is_emergency;
-    if (emergency_signal->is_emergency)
-    {
-      update_emergency_planner();
-    }
-  
-    for (const auto& [context, _] : task_managers)
-    {
-      context->_set_emergency(emergency_signal->is_emergency);
-    }
-    emergency_publisher.get_subscriber().on_next(emergency_signal->is_emergency);
+    handle_emergency(emergency_signal->is_emergency);
   }
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<Node> Node::make(
 
   node->_target_emergency_notice_obs =
     node->create_observable<TargetEmergencyNotice>(
-    rmf_traffic_ros2::TargetEmergencyTopicName, transient_qos);
+    rmf_traffic_ros2::EmergencySignalTopicName, transient_qos);
 
   node->_ingestor_request_pub =
     node->create_publisher<IngestorRequest>(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -78,6 +78,10 @@ std::shared_ptr<Node> Node::make(
     node->create_observable<EmergencyNotice>(
     rmf_traffic_ros2::EmergencyTopicName, transient_qos);
 
+  node->_target_emergency_notice_obs =
+    node->create_observable<TargetEmergencyNotice>(
+    rmf_traffic_ros2::TargetEmergencyTopicName, transient_qos);
+
   node->_ingestor_request_pub =
     node->create_publisher<IngestorRequest>(
     IngestorRequestTopicName, default_qos);
@@ -230,6 +234,14 @@ auto Node::emergency_notice() const -> const EmergencyNoticeObs&
 {
   return _emergency_notice_obs->observe();
 }
+
+//==============================================================================
+auto Node::target_emergency_notice() const -> const TargetEmergencyNoticeObs&
+{
+  return _target_emergency_notice_obs->observe();
+}
+
+//==============================================================================
 
 auto Node::ingestor_request() const -> const IngestorRequestPub&
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
@@ -105,9 +105,13 @@ public:
   using DispenserStateObs = rxcpp::observable<DispenserState::SharedPtr>;
   const DispenserStateObs& dispenser_state() const;
 
-  using EmergencyNotice = rmf_fleet_msgs::msg::EmergencySignal;
+  using EmergencyNotice = std_msgs::msg::Bool;
   using EmergencyNoticeObs = rxcpp::observable<EmergencyNotice::SharedPtr>;
   const EmergencyNoticeObs& emergency_notice() const;
+
+  using TargetEmergencyNotice = rmf_fleet_msgs::msg::EmergencySignal;
+  using TargetEmergencyNoticeObs = rxcpp::observable<TargetEmergencyNotice::SharedPtr>;
+  const TargetEmergencyNoticeObs& target_emergency_notice() const;
 
   using IngestorRequest = rmf_ingestor_msgs::msg::IngestorRequest;
   using IngestorRequestPub = rclcpp::Publisher<IngestorRequest>::SharedPtr;
@@ -224,6 +228,7 @@ private:
   Bridge<DispenserResult> _dispenser_result_obs;
   Bridge<DispenserState> _dispenser_state_obs;
   Bridge<EmergencyNotice> _emergency_notice_obs;
+  Bridge<TargetEmergencyNotice> _target_emergency_notice_obs;
   IngestorRequestPub _ingestor_request_pub;
   Bridge<IngestorResult> _ingestor_result_obs;
   Bridge<IngestorState> _ingestor_state_obs;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
@@ -45,6 +45,7 @@
 #include <rmf_fleet_msgs/msg/fleet_state.hpp>
 #include <rmf_fleet_msgs/msg/mutex_group_request.hpp>
 #include <rmf_fleet_msgs/msg/mutex_group_states.hpp>
+#include <rmf_fleet_msgs/msg/emergency_signal.hpp>
 
 #include <rmf_task_msgs/msg/api_request.hpp>
 #include <rmf_task_msgs/msg/api_response.hpp>
@@ -104,7 +105,7 @@ public:
   using DispenserStateObs = rxcpp::observable<DispenserState::SharedPtr>;
   const DispenserStateObs& dispenser_state() const;
 
-  using EmergencyNotice = std_msgs::msg::Bool;
+  using EmergencyNotice = rmf_fleet_msgs::msg::EmergencySignal;
   using EmergencyNoticeObs = rxcpp::observable<EmergencyNotice::SharedPtr>;
   const EmergencyNoticeObs& emergency_notice() const;
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -42,6 +42,7 @@
 #include <rmf_fleet_msgs/msg/dock_summary.hpp>
 #include <rmf_fleet_msgs/msg/lane_states.hpp>
 #include <rmf_fleet_msgs/msg/charging_assignments.hpp>
+#include <rmf_fleet_msgs/msg/emergency_signal.hpp>
 
 #include <rmf_fleet_adapter/agv/FleetUpdateHandle.hpp>
 #include <rmf_fleet_adapter/StandardNames.hpp>
@@ -410,7 +411,7 @@ public:
       {
         if (const auto self = w.lock())
         {
-          self->_pimpl->handle_emergency(msg->data);
+          self->_pimpl->handle_emergency(msg);
         }
       });
     handle->_pimpl->emergency_planner =
@@ -686,7 +687,7 @@ public:
 
   void update_fleet_state() const;
   void update_fleet_logs() const;
-  void handle_emergency(bool is_emergency);
+  void handle_emergency(std::shared_ptr<rmf_fleet_msgs::msg::EmergencySignal> is_emergency);
   void update_emergency_planner();
 
   void update_charging_assignments(const ChargingAssignments& assignments);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -43,6 +43,7 @@
 #include <rmf_fleet_msgs/msg/lane_states.hpp>
 #include <rmf_fleet_msgs/msg/charging_assignments.hpp>
 #include <rmf_fleet_msgs/msg/emergency_signal.hpp>
+#include <std_msgs/msg/bool.hpp>
 
 #include <rmf_fleet_adapter/agv/FleetUpdateHandle.hpp>
 #include <rmf_fleet_adapter/StandardNames.hpp>
@@ -318,6 +319,7 @@ public:
   rclcpp::TimerBase::SharedPtr memory_trim_timer = nullptr;
 
   rxcpp::subscription emergency_sub;
+  rxcpp::subscription target_emergency_sub;
   rxcpp::subjects::subject<bool> emergency_publisher;
   rxcpp::observable<bool> emergency_obs;
   bool emergency_active = false;
@@ -411,9 +413,20 @@ public:
       {
         if (const auto self = w.lock())
         {
-          self->_pimpl->handle_emergency(msg);
+          self->_pimpl->handle_emergency(msg->data);
         }
       });
+    handle->_pimpl->target_emergency_sub = handle->_pimpl->node->target_emergency_notice()
+      .observe_on(rxcpp::identity_same_worker(handle->_pimpl->worker))
+      .subscribe(
+      [w = handle->weak_from_this()](const auto& msg)
+      {
+        if (const auto self = w.lock())
+        {
+          self->_pimpl->handle_target_emergency(msg);
+        }
+      });
+    
     handle->_pimpl->emergency_planner =
       std::make_shared<std::shared_ptr<const rmf_traffic::agv::Planner>>(nullptr);
 
@@ -687,7 +700,8 @@ public:
 
   void update_fleet_state() const;
   void update_fleet_logs() const;
-  void handle_emergency(std::shared_ptr<rmf_fleet_msgs::msg::EmergencySignal> is_emergency);
+  void handle_emergency(const bool is_emergency);
+  void handle_target_emergency(std::shared_ptr<rmf_fleet_msgs::msg::EmergencySignal> is_emergency);
   void update_emergency_planner();
 
   void update_charging_assignments(const ChargingAssignments& assignments);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -413,6 +413,10 @@ public:
       {
         if (const auto self = w.lock())
         {
+          RCLCPP_WARN_ONCE(
+            self->_pimpl->node->get_logger(),
+            "This topic is getting deprecated soon. Please use the topic 'emergency_signal instead.");
+          [[deprecated("Use target_emergency_sub instead")]]
           self->_pimpl->handle_emergency(msg->data);
         }
       });

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -416,7 +416,6 @@ public:
           RCLCPP_WARN_ONCE(
             self->_pimpl->node->get_logger(),
             "This topic is getting deprecated soon. Please use the topic 'emergency_signal instead.");
-          [[deprecated("Use target_emergency_sub instead")]]
           self->_pimpl->handle_emergency(msg->data);
         }
       });

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
@@ -76,8 +76,8 @@ const std::string BlockadeReleaseTopicName = Prefix +
 const std::string BlockadeSetTopicName = Prefix +
   "blockade_set";
 
-  const std::string EmergencyTopicName = "fire_alarm_trigger";
-  const std::string TargetEmergencyTopicName = "emergency_signal";
+const std::string EmergencyTopicName = "fire_alarm_trigger";
+const std::string EmergencySignalTopicName = "emergency_signal";
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
@@ -77,7 +77,7 @@ const std::string BlockadeSetTopicName = Prefix +
   "blockade_set";
 
   const std::string EmergencyTopicName = "fire_alarm_trigger";
-  const std::string TargetEmergencyTopicName = "target_fire_alarm_trigger";
+  const std::string TargetEmergencyTopicName = "emergency_signal";
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
@@ -76,6 +76,7 @@ const std::string BlockadeReleaseTopicName = Prefix +
 const std::string BlockadeSetTopicName = Prefix +
   "blockade_set";
 
+[[deprecated("Use EmergencySignalTopicName with the rmf_fleet_msgs/EmergencySignal message instead")]]
 const std::string EmergencyTopicName = "fire_alarm_trigger";
 const std::string EmergencySignalTopicName = "emergency_signal";
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
@@ -76,7 +76,8 @@ const std::string BlockadeReleaseTopicName = Prefix +
 const std::string BlockadeSetTopicName = Prefix +
   "blockade_set";
 
-const std::string EmergencyTopicName = "fire_alarm_trigger";
+  const std::string EmergencyTopicName = "fire_alarm_trigger";
+  const std::string TargetEmergencyTopicName = "target_fire_alarm_trigger";
 
 } // namespace rmf_traffic_ros2
 


### PR DESCRIPTION
Our current deployment uses one RMF instance for two buildings and when one fire alarm is triggered, the robots from another building will also go into emergency mode which is not ideal.

This PR, together with the PR [#82](https://github.com/open-rmf/rmf_internal_msgs/pull/82) in `rmf_internal_msgs`, aims to resolve this.

The fire alarm message will contain the fleet names which it wants to alert and the fleet adapter will filter to see if the signal is for them.