### PR TITLE
Completely Excise Reservation Cancellation pathways (Supercedes #411)

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -86,7 +86,6 @@ const std::string ReservationClaimTopicName = "rmf/reservations/claim";
 const std::string ReservationAllocationTopicName =
   "rmf/reservations/allocation";
 const std::string ReservationReleaseTopicName = "rmf/reservations/release";
-const std::string ReservationCancelTopicName = "rmf/reservations/cancel";
 
 const uint64_t Unclaimed = (uint64_t)(-1);
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -139,10 +139,6 @@ std::shared_ptr<Node> Node::make(
     node->create_publisher<ReservationRelease>(
     ReservationReleaseTopicName, transient_local_qos);
 
-  node->_reservation_cancel_pub =
-    node->create_publisher<ReservationCancel>(
-    ReservationCancelTopicName, transient_local_qos);
-
   return node;
 }
 
@@ -314,10 +310,5 @@ auto Node::release_location() const -> const ReservationReleasePub&
   return _reservation_release_pub;
 }
 
-//==============================================================================
-auto Node::cancel_reservation() const -> const ReservationCancelPub&
-{
-  return _reservation_cancel_pub;
-}
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
@@ -166,12 +166,6 @@ public:
     rclcpp::Publisher<ReservationRelease>::SharedPtr;
   const ReservationReleasePub& release_location() const;
 
-  using ReservationCancel = rmf_reservation_msgs::msg::ReleaseRequest;
-  using ReservationCancelPub =
-    rclcpp::Publisher<ReservationCancel>::SharedPtr;
-  const ReservationCancelPub& cancel_reservation() const;
-
-
   template<typename DurationRepT, typename DurationT, typename CallbackT>
   rclcpp::TimerBase::SharedPtr try_create_wall_timer(
     std::chrono::duration<DurationRepT, DurationT> period,
@@ -237,7 +231,6 @@ private:
   ReservationClaimPub _reservation_claim_pub;
   Bridge<ReservationAllocation> _reservation_alloc_obs;
   ReservationReleasePub _reservation_release_pub;
-  ReservationCancelPub _reservation_cancel_pub;
 };
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/ReservationManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/ReservationManager.cpp
@@ -53,7 +53,7 @@ void ReservationManager::cancel()
   {
     return;
   }
-  if (has_ticket())
+  if (!has_ticket())
     return;
 
   RCLCPP_INFO(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/ReservationManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/ReservationManager.cpp
@@ -46,27 +46,6 @@ void ReservationManager::replace_ticket(
 }
 
 //==============================================================================
-void ReservationManager::cancel()
-{
-  auto context = _context.lock();
-  if (!context)
-  {
-    return;
-  }
-  if (!has_ticket())
-    return;
-
-  RCLCPP_INFO(
-    context->node()->get_logger(),
-    "Cancelling ticket %lu",
-    _allocation->ticket.ticket_id);
-  rmf_reservation_msgs::msg::ReleaseRequest msg;
-  msg.ticket = _allocation->ticket;
-  context->node()->cancel_reservation()->publish(msg);
-  _allocation = std::nullopt;
-}
-
-//==============================================================================
 std::string ReservationManager::get_reserved_location() const
 {
   if (has_ticket())

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1862,12 +1862,6 @@ bool RobotContext::_parking_spot_manager_enabled()
 }
 
 //==============================================================================
-void RobotContext::_cancel_allocated_destination()
-{
-  return _reservation_mgr.cancel();
-}
-
-//==============================================================================
 std::string RobotContext::_get_reserved_location()
 {
   return _reservation_mgr.get_reserved_location();

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/EmergencyPullover.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/EmergencyPullover.cpp
@@ -262,10 +262,6 @@ void EmergencyPullover::Active::cancel()
   _execution = std::nullopt;
   _state->update_status(Status::Canceled);
   _state->update_log().info("Received signal to cancel");
-  if (_context->_parking_spot_manager_enabled())
-  {
-    _reservation_client->cancel();
-  }
   _finished();
 }
 
@@ -275,10 +271,6 @@ void EmergencyPullover::Active::kill()
   _execution = std::nullopt;
   _state->update_status(Status::Killed);
   _state->update_log().info("Received signal to kill");
-  if (_context->_parking_spot_manager_enabled())
-  {
-    _reservation_client->cancel();
-  }
   _finished();
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
@@ -423,11 +423,6 @@ void GoToPlace::Active::cancel()
   _stop_and_clear();
   _state->update_status(Status::Canceled);
   _state->update_log().info("Received signal to cancel");
-
-  if (_context->_parking_spot_manager_enabled())
-  {
-    _reservation_client->cancel();
-  }
   _finished();
 }
 
@@ -437,10 +432,6 @@ void GoToPlace::Active::kill()
   _stop_and_clear();
   _state->update_status(Status::Killed);
   _state->update_log().info("Received signal to kill");
-  if (_context->_parking_spot_manager_enabled())
-  {
-    _reservation_client->cancel();
-  }
   _finished();
 }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/internal_ReservationNodeNegotiator.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/internal_ReservationNodeNegotiator.hpp
@@ -31,11 +31,6 @@ class ReservationNodeNegotiator :
   public std::enable_shared_from_this<ReservationNodeNegotiator>
 {
 public:
-  void cancel()
-  {
-    _context->_cancel_allocated_destination();
-  }
-
   static std::shared_ptr<ReservationNodeNegotiator> make(
     std::shared_ptr<agv::RobotContext> context,
     const std::vector<rmf_traffic::agv::Plan::Goal> goals,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/internal_ReservationNodeNegotiator.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/internal_ReservationNodeNegotiator.hpp
@@ -33,18 +33,7 @@ class ReservationNodeNegotiator :
 public:
   void cancel()
   {
-    _context->worker().schedule(
-      [ptr = weak_from_this()](
-        const auto&)
-    {
-      auto self = ptr.lock();
-      if(!self)
-      {
-        return;
-      }
-
-      self->_context->_cancel_allocated_destination();
-    });
+    _context->_cancel_allocated_destination();
   }
 
   static std::shared_ptr<ReservationNodeNegotiator> make(

--- a/rmf_reservation_node/src/main.cpp
+++ b/rmf_reservation_node/src/main.cpp
@@ -358,10 +358,6 @@ public:
       this->create_subscription<rmf_reservation_msgs::msg::ReleaseRequest>(
         ReservationReleaseTopicName, qos,
         std::bind(&ReservationNode::release, this, std::placeholders::_1));
-    cancel_subscription_ =
-      this->create_subscription<rmf_reservation_msgs::msg::ReleaseRequest>(
-        ReservationCancelTopicName, qos,
-        std::bind(&ReservationNode::cancel, this, std::placeholders::_1));
     graph_subscription_ =
       this->create_subscription<rmf_building_map_msgs::msg::Graph>(
         NavGraphTopicName, qos,
@@ -514,13 +510,6 @@ private:
     }
   }
 
-  void cancel(
-    const rmf_reservation_msgs::msg::ReleaseRequest::ConstSharedPtr& request)
-  {
-    queue_manager_.remove_ticket(request->ticket.ticket_id);
-    release(request);
-  }
-
   void release(
     const rmf_reservation_msgs::msg::ReleaseRequest::ConstSharedPtr& request)
   {
@@ -612,8 +601,6 @@ private:
     claim_subscription_;
   rclcpp::Subscription<rmf_reservation_msgs::msg::ReleaseRequest>::SharedPtr
     release_subscription_;
-  rclcpp::Subscription<rmf_reservation_msgs::msg::ReleaseRequest>::SharedPtr
-    cancel_subscription_;
   rclcpp::Subscription<rmf_building_map_msgs::msg::Graph>::SharedPtr
     graph_subscription_;
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

As noticed by @piliwilliam0306 in https://github.com/open-rmf/rmf_ros2/pull/411, the cancellation pathway was not being called. This PR completely excises the reservation cancellation API. The rationale for this is that in most cases, we should be using the Finishing Tasks.  In cases we are not, the use of a reservation system is actually somewhat ill-defined. For instance say a robot is going from place A->B. Without a finishing task, it is not clear at all whether the robot should hold A or B or None of them as the robot may be closer to A, closer to B or just stuck midway when a cancellation occurs.

In the case when a finishing task is assigned, every time the robot needs to move (see GoToPlace.cpp) the reservation negotiator is invoked. The reservation negotiator will check if a previous reservation was held. If it was, then it will go release any ticket that was previously held. In the event of a cancellation, the finishing task will simply take over.

### Testing It

I have some scripts here that do such stress tests.
https://github.com/arjo129/stress_test_rmf_chope