### PR TITLE
Reduce churn in lift supervisor

### DIFF
--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -61,6 +61,8 @@ void Node::_adapter_lift_request_update(LiftRequest::UniquePtr msg)
     {
       if (msg->request_type != LiftRequest::REQUEST_END_SESSION)
       {
+        // Set the timestamp to be the same so it doesn't confuse the comparison.
+        msg->request_time = curr_request->request_time;
         if (*curr_request != *msg)
         {
           RCLCPP_INFO(

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -113,7 +113,8 @@ void Node::_lift_state_update(LiftState::UniquePtr state)
   if (lift_request)
   {
     if ((lift_request->destination_floor != state->destination_floor) ||
-      (lift_request->door_state != state->door_state))
+      (lift_request->door_state != state->door_state) ||
+      (lift_request->session_id != state->session_id))
     {
       lift_request->request_time = this->now();
       _lift_request_pub->publish(*lift_request);

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -112,7 +112,10 @@ void Node::_lift_state_update(LiftState::UniquePtr state)
 
   if (lift_request)
   {
-    if ((lift_request->destination_floor != state->destination_floor) ||
+    const bool correct_floor = lift_request->destination_floor == state->destination_floor
+      || (lift_request->destination_floor == state->current_floor && state->destination_floor.empty());
+
+    if (!correct_floor ||
       (lift_request->door_state != state->door_state) ||
       (lift_request->session_id != state->session_id))
     {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1609,7 +1609,10 @@ void RobotContext::_check_lift_state(
       state.session_id.c_str());
   }
 
-  _publish_lift_destination();
+  if (_lift_destination && _lift_destination->lift_name == state.lift_name)
+  {
+    _publish_lift_destination();
+  }
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
+++ b/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
@@ -103,14 +103,14 @@ SCENARIO_METHOD(MockAdapterFixture, "request lift phase", "[phases]")
       CHECK(test->received_requests.front().destination_floor == destination);
     }
 
-    THEN("it should continuously send lift requests when the lift state includes its requester ID")
+    THEN("it should continuously send lift requests when the lift state has the target lift name")
     {
       auto t = std::thread([&]()
           {
             for (std::size_t i = 0; i < 10; ++i)
             {
               LiftState state;
-              state.session_id = context->requester_id();
+              state.lift_name = lift_name;
               lift_state_pub->publish(state);
               std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }

--- a/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
+++ b/rmf_fleet_adapter/test/phases/test_RequestLift.cpp
@@ -103,13 +103,15 @@ SCENARIO_METHOD(MockAdapterFixture, "request lift phase", "[phases]")
       CHECK(test->received_requests.front().destination_floor == destination);
     }
 
-    THEN("it should continuously send lift requests while lift states arrive")
+    THEN("it should continuously send lift requests when the lift state includes its requester ID")
     {
       auto t = std::thread([&]()
           {
             for (std::size_t i = 0; i < 10; ++i)
             {
-              lift_state_pub->publish(LiftState());
+              LiftState state;
+              state.session_id = context->requester_id();
+              lift_state_pub->publish(state);
               std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
           });


### PR DESCRIPTION
This PR is meant to address https://github.com/open-rmf/rmf_ros2/issues/415 and https://github.com/open-rmf/rmf/discussions/638

Mostly this should reduce excessive logging by only logging activity where we expect something to change.

This might also help reduce unnecessary publishing somewhat, but probably not very much. We're filtering out lift commands using

```
    if ((lift_request->destination_floor != state->destination_floor) ||
      (lift_request->door_state != state->door_state))
```

which means if the door isn't currently in the requested state then we publish the command again. A lift door will be closed far more often than it's open, and it a lift request will generally ask for the door to be open, so I expect this won't filter very much of the lift request publishing. We could improve this if the lift state included a field for the current **_target_** door state, but that would be introducing a new field for lift adapters to account for, and I don't want to do that without significant community engagement.

I've run some tests in the hotel world and the lifts appear to still be working correctly, but those tests aren't very comprehensive. Given how crucial it is to keep lift behavior correct, I would appreciate help testing this PR on heavy traffic scenarios @TanJunKiat @cwrx777 . A test on hardware would be especially good since it would indicate that the behavior of a real hardware lift adapter has not been negatively impacted.