### PR TITLE
Fix goal orientation constraint

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -1657,7 +1657,9 @@ PlaceDeserializer make_place_deserializer(
       {
         const auto& ori_it = msg.find("orientation");
         if (ori_it != msg.end())
+        {
           place->orientation(ori_it->get<double>());
+        }
       }
 
       return {place, {}};

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/internal_ReservationNodeNegotiator.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/internal_ReservationNodeNegotiator.hpp
@@ -150,7 +150,7 @@ public:
             self->_current_reservation_state = ReservationState::ReceivedResponseProceedImmediate;
             self->_selected_final_destination_cb(self->_goals[self->
             _final_allocated_destination.value()->
-            chosen_alternative].waypoint());
+            chosen_alternative]);
           }
 
           if (msg->instruction_type


### PR DESCRIPTION
This fixes a subtle bug reported by #425 introduced in #325

We were accidentally constructing a new goal using only the waypoint information of the goal that the user originally passed in. The waypoint value was being implicitly converted into a complete goal description by the compiler.