### PR TITLE
Remove icecream as a dependency entirely

### DIFF
--- a/rmf_charging_schedule/package.xml
+++ b/rmf_charging_schedule/package.xml
@@ -9,7 +9,6 @@
 
   <depend>rclpy</depend>
   <depend>rmf_fleet_msgs</depend>
-  <depend>python3-icecream</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/rmf_charging_schedule/rmf_charging_schedule/main.py
+++ b/rmf_charging_schedule/rmf_charging_schedule/main.py
@@ -7,8 +7,6 @@ import bisect
 from functools import total_ordering
 from zoneinfo import ZoneInfo
 
-from icecream import ic
-
 import rclpy
 from rclpy.node import Node, Publisher
 from rclpy.qos import (


### PR DESCRIPTION
It turns out we haven't been using icecream in `rmf_charging_schedule` anyway, so this PR just removes it completely as a dependency.