### PR TITLE
Migrate reservation node to target_link_libraries

### DIFF
--- a/rmf_reservation_node/CMakeLists.txt
+++ b/rmf_reservation_node/CMakeLists.txt
@@ -13,10 +13,12 @@ find_package(rmf_building_map_msgs REQUIRED)
 find_package(rmf_fleet_adapter REQUIRED)
 
 add_executable(queue_manager src/main.cpp)
-ament_target_dependencies(queue_manager
-  rclcpp rmf_reservation_msgs rmf_building_map_msgs)
-target_link_libraries(queue_manager rmf_fleet_adapter::rmf_fleet_adapter)
-target_include_directories(queue_manager PRIVATE ${rmf_fleet_adapter_INCLUDE_DIRS})
+target_link_libraries(queue_manager
+  rclcpp::rclcpp
+  rmf_fleet_adapter::rmf_fleet_adapter
+  ${rmf_building_map_msgs_TARGETS}
+  ${rmf_reservation_msgs_TARGETS}
+)
 
 install(TARGETS
   queue_manager


### PR DESCRIPTION
`ament_target_dependencies` is deprecated and is generating warnings / errors, migrate to `target_link_libraries` instead.