### PR TITLE
Migrate fleet_adapter to target_link_libraries

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -78,28 +78,24 @@ add_library(rmf_fleet_adapter SHARED
   ${rmf_fleet_adapter_srcs}
 )
 
-ament_target_dependencies(rmf_fleet_adapter
-  PUBLIC
-    rmf_traffic_ros2
-    rmf_task_ros2
-    yaml-cpp
-    rmf_fleet_msgs
-    rmf_task_msgs
-    rmf_door_msgs
-    rmf_lift_msgs
-    rmf_dispenser_msgs
-    rmf_ingestor_msgs
-    rmf_building_map_msgs
-    rmf_reservation_msgs
-    rclcpp
-    rclcpp_action
-)
-
 target_link_libraries(rmf_fleet_adapter
   PUBLIC
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    rmf_battery::rmf_battery
     rmf_task::rmf_task
     rmf_task_sequence::rmf_task_sequence
-    rmf_battery::rmf_battery
+    rmf_task_ros2::rmf_task_ros2
+    rmf_traffic_ros2::rmf_traffic_ros2
+    ${rmf_building_map_msgs_TARGETS}
+    ${rmf_dispenser_msgs_TARGETS}
+    ${rmf_door_msgs_TARGETS}
+    ${rmf_fleet_msgs_TARGETS}
+    ${rmf_ingestor_msgs_TARGETS}
+    ${rmf_lift_msgs_TARGETS}
+    ${rmf_reservation_msgs_TARGETS}
+    ${rmf_task_msgs_TARGETS}
+    yaml-cpp::yaml-cpp
   PRIVATE
     rmf_rxcpp
     rmf_websocket::rmf_websocket
@@ -114,15 +110,8 @@ target_include_directories(rmf_fleet_adapter
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/rmf_api_generate_schema_headers/include> # for auto-generated schema headers
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
-    ${rmf_door_msgs_INCLUDE_DIRS}
-    ${rmf_lift_msgs_INCLUDE_DIRS}
-    ${rmf_dispenser_msgs_INCLUDE_DIRS}
-    ${rmf_ingestor_msgs_INCLUDE_DIRS}
     ${rmf_api_msgs_INCLUDE_DIRS}
-    ${rmf_reservation_msgs_INCLUDE_DIRS}
     ${rmf_websocket_INCLUDE_DIR}
-    ${rmf_traffic_ros2_INCLUDE_DIRS}
-    ${rmf_building_map_msgs_INCLUDE_DIRS}
     ${nlohmann_json_schema_validator_INCLUDE_DIRS}
 )
 
@@ -147,18 +136,6 @@ if (BUILD_TESTING)
       test/test_Task.cpp
     TIMEOUT 300
   )
-  ament_target_dependencies(test_rmf_fleet_adapter
-    PUBLIC
-      rmf_task_msgs
-      rmf_door_msgs
-      rmf_lift_msgs
-      rmf_dispenser_msgs
-      rmf_ingestor_msgs
-      std_msgs
-      rmf_building_map_msgs
-      rmf_websocket
-      rmf_reservation_msgs
-  )
   target_include_directories(test_rmf_fleet_adapter
     PRIVATE
       # private includes of rmf_fleet_adapter
@@ -167,6 +144,16 @@ if (BUILD_TESTING)
       ${nlohmann_json_schema_validator_INCLUDE_DIRS}
   )
   target_link_libraries(test_rmf_fleet_adapter
+    PUBLIC
+      ${rmf_building_map_msgs_TARGETS}
+      ${rmf_dispenser_msgs_TARGETS}
+      ${rmf_door_msgs_TARGETS}
+      ${rmf_ingestor_msgs_TARGETS}
+      ${rmf_lift_msgs_TARGETS}
+      ${rmf_reservation_msgs_TARGETS}
+      ${rmf_task_msgs_TARGETS}
+      rmf_websocket::rmf_websocket
+      ${std_msgs_TARGETS}
     PRIVATE
       # private libraries of rmf_fleet_adapter
       rmf_rxcpp
@@ -342,27 +329,27 @@ target_compile_definitions(robot_state_aggregator_main
 
 if(DEFINED ENV{RMF_ENABLE_FAILOVER})
   if($ENV{RMF_ENABLE_FAILOVER} EQUAL 1)
-    ament_target_dependencies(robot_state_aggregator_main
-      "rclcpp"
-      "rclcpp_components"
-      "std_msgs"
-      "stubborn_buddies_msgs"
-      "rmf_fleet_msgs"
+    target_link_libraries(robot_state_aggregator_main
+      rclcpp::rclcpp
+      rclcpp_components::component
+      ${std_msgs_TARGETS}
+      ${stubborn_buddies_msgs_TARGETS}
+      ${rmf_fleet_msgs_TARGETS}
     )
   else()
-    ament_target_dependencies(robot_state_aggregator_main
-      "rclcpp"
-      "rclcpp_components"
-      "std_msgs"
-      "rmf_fleet_msgs"
+    target_link_libraries(robot_state_aggregator_main
+      rclcpp::rclcpp
+      rclcpp_components::component
+      ${std_msgs_TARGETS}
+      ${rmf_fleet_msgs_TARGETS}
     )
   endif()
 else()
-  ament_target_dependencies(robot_state_aggregator_main
-    "rclcpp"
-    "rclcpp_components"
-    "std_msgs"
-    "rmf_fleet_msgs"
+  target_link_libraries(robot_state_aggregator_main
+    rclcpp::rclcpp
+    rclcpp_components::component
+    ${std_msgs_TARGETS}
+    ${rmf_fleet_msgs_TARGETS}
   )
 endif()
 
@@ -405,12 +392,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 target_link_libraries(robot_state_aggregator
-  ${robot_state_aggregator_main_libs})
-
-ament_target_dependencies(robot_state_aggregator
-  "class_loader"
-  "rclcpp"
-  "rclcpp_components"
+  ${robot_state_aggregator_main_libs}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  class_loader::class_loader
 )
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Same as https://github.com/open-rmf/rmf_ros2/pull/437, `ament_target_dependencies` is deprecated