### PR TITLE
Allow creating Auctioneer with node interfaces to support lifecycle nodes (#420)

### DIFF
--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories(rmf_task_ros2
 )
 
 ament_export_targets(rmf_task_ros2 HAS_LIBRARY_TARGET)
-ament_export_dependencies(rmf_traffic rmf_task_msgs rclcpp nlohmann_json)
+ament_export_dependencies(rmf_traffic rmf_task_msgs rclcpp nlohmann_json nlohmann_json_schema_validator rmf_api_msgs rmf_websocket)
 
 #===============================================================================
 set(TEST_UNCRUSTIFY "Off")

--- a/rmf_task_ros2/include/rmf_task_ros2/bidding/Auctioneer.hpp
+++ b/rmf_task_ros2/include/rmf_task_ros2/bidding/Auctioneer.hpp
@@ -20,6 +20,12 @@
 
 #include <queue>
 #include <rclcpp/node.hpp>
+#include <rclcpp/node_interfaces/node_base_interface.hpp>
+#include <rclcpp/node_interfaces/node_clock_interface.hpp>
+#include <rclcpp/node_interfaces/node_logging_interface.hpp>
+#include <rclcpp/node_interfaces/node_parameters_interface.hpp>
+#include <rclcpp/node_interfaces/node_timers_interface.hpp>
+#include <rclcpp/node_interfaces/node_topics_interface.hpp>
 #include <rmf_utils/impl_ptr.hpp>
 
 #include <rmf_task_ros2/bidding/Response.hpp>
@@ -77,6 +83,48 @@ public:
   /// \sa make()
   static std::shared_ptr<Auctioneer> make(
     const std::shared_ptr<rclcpp::Node>& node,
+    BiddingResultCallback result_callback,
+    ConstEvaluatorPtr evaluator);
+
+  /// Create an instance of the Auctioneer using node interfaces. This allows
+  /// support for lifecycle nodes. This instance will handle all the task
+  /// dispatching bidding mechanism. A default evaluator is used.
+  ///
+  /// \param[in] node_base_interface
+  ///   ros2 node base interface for managing callback groups and timers
+  ///
+  /// \param[in] node_clock_interface
+  ///   ros2 node clock interface for managing time
+  ///
+  /// \param[in] node_logging_interface
+  ///   ros2 node logging interface for enabling logging
+  ///
+  /// \param[in] node_timers_interface
+  ///   ros2 node timers interface for adding timers
+  ///
+  /// \param[in] node_topics_interface
+  ///   ros2 node topics interface for creating publishers and subscribers
+  ///
+  /// \param[in] node_parameters_interface
+  ///   ros2 node parameters interface for handling parameters
+  ///
+  /// \param[in] result_callback
+  ///   This callback fn will be called when a bidding result is concluded
+  ///
+  /// \sa make()
+  static std::shared_ptr<Auctioneer> make_with_node_interfaces(
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+    node_base_interface,
+    const rclcpp::node_interfaces::NodeClockInterface::SharedPtr
+    node_clock_interface,
+    const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
+    node_logging_interface,
+    const rclcpp::node_interfaces::NodeTimersInterface::SharedPtr
+    node_timers_interface,
+    const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
+    node_topics_interface,
+    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
+    node_parameters_interface,
     BiddingResultCallback result_callback,
     ConstEvaluatorPtr evaluator);
 

--- a/rmf_task_ros2/src/rmf_task_ros2/bidding/Auctioneer.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/bidding/Auctioneer.cpp
@@ -15,6 +15,10 @@
  *
 */
 
+#include <rclcpp/create_publisher.hpp>
+#include <rclcpp/create_subscription.hpp>
+#include <rclcpp/create_timer.hpp>
+
 #include "internal_Auctioneer.hpp"
 
 namespace rmf_task_ros2 {
@@ -22,10 +26,26 @@ namespace bidding {
 
 //==============================================================================
 Auctioneer::Implementation::Implementation(
-  const std::shared_ptr<rclcpp::Node>& node_,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+  node_base_interface_,
+  const rclcpp::node_interfaces::NodeClockInterface::SharedPtr
+  node_clock_interface_,
+  const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
+  node_logging_interface_,
+  const rclcpp::node_interfaces::NodeTimersInterface::SharedPtr
+  node_timers_interface_,
+  const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
+  node_topics_interface_,
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
+  node_parameters_interface_,
   BiddingResultCallback result_callback,
   ConstEvaluatorPtr evaluator_)
-: node{std::move(node_)},
+: node_base_interface{std::move(node_base_interface_)},
+  node_clock_interface{std::move(node_clock_interface_)},
+  node_logging_interface{std::move(node_logging_interface_)},
+  node_timers_interface{std::move(node_timers_interface_)},
+  node_topics_interface{std::move(node_topics_interface_)},
+  node_parameters_interface{std::move(node_parameters_interface_)},
   bidding_result_callback{std::move(result_callback)},
   evaluator(std::move(evaluator_))
 {
@@ -34,35 +54,50 @@ Auctioneer::Implementation::Implementation(
   {
     evaluator = std::make_shared<QuickestFinishEvaluator>();
     RCLCPP_INFO(
-      node->get_logger(),
+      node_logging_interface->get_logger(),
       "Dispatcher evaluator set to QuickestFinishEvaluator by default");
   }
   const auto dispatch_qos = rclcpp::ServicesQoS().reliable();
 
-  bid_notice_pub = node->create_publisher<BidNoticeMsg>(
-    rmf_task_ros2::BidNoticeTopicName, dispatch_qos);
+  bid_notice_pub = rclcpp::create_publisher<BidNoticeMsg>(
+    node_parameters_interface,
+    node_topics_interface,
+    rmf_task_ros2::BidNoticeTopicName,
+    dispatch_qos);
 
-  bid_proposal_sub = node->create_subscription<BidResponseMsg>(
-    rmf_task_ros2::BidResponseTopicName, dispatch_qos,
+  bid_proposal_sub = rclcpp::create_subscription<BidResponseMsg>(
+    node_parameters_interface,
+    node_topics_interface,
+    rmf_task_ros2::BidResponseTopicName,
+    dispatch_qos,
     [&](const BidResponseMsg::UniquePtr msg)
     {
       this->receive_response(*msg);
     });
 
-  timer = node->create_wall_timer(std::chrono::milliseconds(200), [&]()
+  timer = rclcpp::create_wall_timer(
+    std::chrono::milliseconds(200),
+    [&]()
       {
         this->finish_bidding_process();
-      });
+      },
+    nullptr,
+    node_base_interface.get(),
+    node_timers_interface.get());
 }
 
 //==============================================================================
 void Auctioneer::Implementation::request_bid(
   const BidNoticeMsg& bid_notice)
 {
-  RCLCPP_INFO(node->get_logger(), "Add Task [%s] to a bidding queue",
+  RCLCPP_INFO(
+    node_logging_interface->get_logger(),
+    "Add Task [%s] to a bidding queue",
     bid_notice.task_id.c_str());
 
-  open_bid_queue.push(OpenBid{bid_notice, node->now(), {}});
+  open_bid_queue.push(
+    OpenBid{bid_notice,
+      node_clock_interface->get_clock()->now(), {}});
 }
 
 //==============================================================================
@@ -73,14 +108,15 @@ void Auctioneer::Implementation::receive_response(const BidResponseMsg& msg)
   const auto response = convert(msg);
   if (response.proposal.has_value())
   {
-    RCLCPP_DEBUG(node->get_logger(),
+    RCLCPP_DEBUG(
+      node_logging_interface->get_logger(),
       "[Auctioneer] Receive proposal from task_id: %s | from: %s",
       id.c_str(), response.proposal->fleet_name.c_str());
   }
   else if (!response.errors.empty())
   {
     RCLCPP_DEBUG(
-      node->get_logger(),
+      node_logging_interface->get_logger(),
       "[Auctioneer] Received %lu errors from a bidder",
       response.errors.size());
   }
@@ -110,9 +146,12 @@ void Auctioneer::Implementation::finish_bidding_process()
   }
   else
   {
-    RCLCPP_INFO(node->get_logger(), " - Start new bidding task: %s",
+    RCLCPP_INFO(
+      node_logging_interface->get_logger(),
+      " - Start new bidding task: %s",
       front_task.bid_notice.task_id.c_str());
-    open_bid_queue.front().start_time = node->now();
+    open_bid_queue.front().start_time =
+      node_clock_interface->get_clock()->now();
     bid_notice_pub->publish(front_task.bid_notice);
     bidding_in_process = true;
   }
@@ -122,7 +161,8 @@ void Auctioneer::Implementation::finish_bidding_process()
 bool Auctioneer::Implementation::determine_winner(
   const OpenBid& bidding_task)
 {
-  const auto duration = node->now() - bidding_task.start_time;
+  const auto duration =
+    node_clock_interface->get_clock()->now() - bidding_task.start_time;
   if (duration < bidding_task.bid_notice.time_window)
     return false;
 
@@ -131,7 +171,7 @@ bool Auctioneer::Implementation::determine_winner(
 
   auto task_id = bidding_task.bid_notice.task_id;
   RCLCPP_DEBUG(
-    node->get_logger(),
+    node_logging_interface->get_logger(),
     "Bidding Deadline reached for [%s]",
     task_id.c_str());
 
@@ -143,7 +183,8 @@ bool Auctioneer::Implementation::determine_winner(
 
   if (bidding_task.responses.empty())
   {
-    RCLCPP_INFO(node->get_logger(),
+    RCLCPP_INFO(
+      node_logging_interface->get_logger(),
       "Task auction for [%s] did not received any bids", task_id.c_str());
 
     bidding_result_callback(task_id, std::nullopt, errors);
@@ -154,7 +195,7 @@ bool Auctioneer::Implementation::determine_winner(
   if (winner.has_value())
   {
     RCLCPP_INFO(
-      node->get_logger(),
+      node_logging_interface->get_logger(),
       "Determined winning Fleet Adapter: [%s], from %ld responses",
       winner->fleet_name.c_str(),
       bidding_task.responses.size());
@@ -175,7 +216,9 @@ std::optional<Response::Proposal> Auctioneer::Implementation::evaluate(
 
   if (!evaluator)
   {
-    RCLCPP_WARN(node->get_logger(), "Bidding Evaluator is not set");
+    RCLCPP_WARN(
+      node_logging_interface->get_logger(),
+      "Bidding Evaluator is not set");
     return std::nullopt;
   }
 
@@ -195,10 +238,45 @@ std::shared_ptr<Auctioneer> Auctioneer::make(
   BiddingResultCallback result_callback,
   ConstEvaluatorPtr evaluator)
 {
+  auto auctioneer = make_with_node_interfaces(
+    node->get_node_base_interface(),
+    node->get_node_clock_interface(),
+    node->get_node_logging_interface(),
+    node->get_node_timers_interface(),
+    node->get_node_topics_interface(),
+    node->get_node_parameters_interface(),
+    std::move(result_callback),
+    std::move(evaluator));
+  return auctioneer;
+}
+
+//==============================================================================
+std::shared_ptr<Auctioneer> Auctioneer::make_with_node_interfaces(
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+  node_base_interface,
+  const rclcpp::node_interfaces::NodeClockInterface::SharedPtr
+  node_clock_interface,
+  const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
+  node_logging_interface,
+  const rclcpp::node_interfaces::NodeTimersInterface::SharedPtr
+  node_timers_interface,
+  const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
+  node_topics_interface,
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
+  node_parameters_interface,
+  BiddingResultCallback result_callback,
+  ConstEvaluatorPtr evaluator)
+{
   auto auctioneer = std::shared_ptr<Auctioneer>(new Auctioneer());
   auctioneer->_pimpl = rmf_utils::make_unique_impl<Implementation>(
-    node, std::move(result_callback), std::move(evaluator));
-
+    std::move(node_base_interface),
+    std::move(node_clock_interface),
+    std::move(node_logging_interface),
+    std::move(node_timers_interface),
+    std::move(node_topics_interface),
+    std::move(node_parameters_interface),
+    std::move(result_callback),
+    std::move(evaluator));
   return auctioneer;
 }
 

--- a/rmf_task_ros2/src/rmf_task_ros2/bidding/internal_Auctioneer.hpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/bidding/internal_Auctioneer.hpp
@@ -34,7 +34,15 @@ class Auctioneer::Implementation
 {
 public:
 
-  std::shared_ptr<rclcpp::Node> node;
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface;
+  rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_interface;
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
+    node_logging_interface;
+  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers_interface;
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface;
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
+  node_parameters_interface;
+
   rclcpp::TimerBase::SharedPtr timer;
   BiddingResultCallback bidding_result_callback;
   ConstEvaluatorPtr evaluator;
@@ -56,7 +64,18 @@ public:
   BidResponseSub::SharedPtr bid_proposal_sub;
 
   Implementation(
-    const std::shared_ptr<rclcpp::Node>& node_,
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+    node_base_interface,
+    const rclcpp::node_interfaces::NodeClockInterface::SharedPtr
+    node_clock_interface,
+    const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
+    node_logging_interface,
+    const rclcpp::node_interfaces::NodeTimersInterface::SharedPtr
+    node_timers_interface,
+    const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
+    node_topics_interface,
+    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
+    node_parameters_interface_,
     BiddingResultCallback result_callback,
     ConstEvaluatorPtr evaluator);
 


### PR DESCRIPTION
* Export other dependencies of rmf_task_ros2



* Allow creating autioneer with node interfaces to support lifecycle nodes



* Export schema validator too



* Clean up API



* Clean up impl



* Fix naming



* Revert changes to be compatible with Humble



* Use a new function instead of an overload to maintain ABI compatibility



* Switch back to using wall timer



---------


(cherry picked from commit 2b3be4e1f2da0809c389db711c0561face36a875)