### PR TITLE
Adds a check for numpy version

### DIFF
--- a/rmf_fleet_adapter_python/CMakeLists.txt
+++ b/rmf_fleet_adapter_python/CMakeLists.txt
@@ -19,11 +19,19 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(Python3 COMPONENTS Interpreter Development)
+find_package(Python3 COMPONENTS Interpreter Development Numpy)
 find_package(rmf_fleet_adapter REQUIRED)
 find_package(rmf_task REQUIRED)
 find_package(rmf_battery REQUIRED)
 find_package(rmf_task_msgs REQUIRED)
+
+# Get the NumPy version string via Python interpreter
+execute_process(COMMAND ${Python_EXECUTABLE} -c "import numpy; print(numpy.__version__)"
+                OUTPUT_VARIABLE NUMPY_VERSION_STRING
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Define the macro for C++ compilation
+add_compile_definitions(BUILT_AGAINST_NUMPY_VERSION="${NUMPY_VERSION_STRING}")
 
 include_directories(
   include


### PR DESCRIPTION


## Bug fix

### Fixed bug

This PR adds a simple check to check the version of numpy loaded by the python interpretter is the same as the version of numpy loaded by the user. This should prevent ABI incompatibilities and undefined behaviour which may arise from the user installing a newer version of numpy than what we build against.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR. 
- [ ] I did not use GenAI

Generated-by: 
