### PR TITLE
Added RCL logging for BroadcastServer

### DIFF
--- a/rmf_fleet_adapter/test/tasks/test_Delivery.cpp
+++ b/rmf_fleet_adapter/test/tasks/test_Delivery.cpp
@@ -397,8 +397,8 @@ SCENARIO("Test Delivery")
         else
           at_least_one_incomplete = true;
       },
-    WebsocketServer::ApiMsgType::TaskStateUpdate,
-    adapter.node()->get_node_logging_interface()
+    adapter.node()->get_node_logging_interface(),
+    WebsocketServer::ApiMsgType::TaskStateUpdate
   );
   /* *INDENT-ON* */
 

--- a/rmf_fleet_adapter/test/tasks/test_Delivery.cpp
+++ b/rmf_fleet_adapter/test/tasks/test_Delivery.cpp
@@ -372,7 +372,7 @@ SCENARIO("Test Delivery")
   /// from the websocket connection
   /* *INDENT-OFF* */
   using WebsocketServer = rmf_websocket::BroadcastServer;
-	const auto ws_server = WebsocketServer::make(
+	const auto ws_server = WebsocketServer::make_with_logger(
 		37878,
     [ &cb_mutex, delivery_id, &completed_promise,
       &at_least_one_incomplete, &fulfilled_promise](
@@ -397,7 +397,8 @@ SCENARIO("Test Delivery")
         else
           at_least_one_incomplete = true;
       },
-    WebsocketServer::ApiMsgType::TaskStateUpdate
+    WebsocketServer::ApiMsgType::TaskStateUpdate,
+    adapter.node()->get_node_logging_interface()
   );
   /* *INDENT-ON* */
 

--- a/rmf_websocket/include/rmf_websocket/BroadcastServer.hpp
+++ b/rmf_websocket/include/rmf_websocket/BroadcastServer.hpp
@@ -45,7 +45,8 @@ public:
 
   using ApiMessageCallback = std::function<void(const nlohmann::json&)>;
 
-  /// Add a callback to convert from a Description into an active Task.
+  /// Create a wrapper around a websocket server for receiving states and logs for
+  /// fleets, robots and tasks
   ///
   /// \param[in] port
   ///   server url port number
@@ -61,7 +62,8 @@ public:
     ApiMessageCallback callback,
     std::optional<ApiMsgType> msg_selection = std::nullopt);
 
-  /// Add a callback to convert from a Description into an active Task.
+  /// Create a wrapper around a websocket server for receiving states and logs for
+  /// fleets, robots and tasks
   ///
   /// \param[in] port
   ///   server url port number
@@ -69,17 +71,19 @@ public:
   /// \param[in] callback
   ///   callback function when the message is received
   ///
+  /// \param[in] node_logging_interface
+  ///   node interface for logging. Default as nullptr which will result
+  ///   in errors and additional debug information not being logged
+  ///
   /// \param[in] msg_selection
   ///   selected msg type to listen. Will listen to all msg if nullopt
   ///
-  /// \param[in] node_logging_interface
-  ///   node for logging
   static std::shared_ptr<BroadcastServer> make_with_logger(
     const int port,
     ApiMessageCallback callback,
-    std::optional<ApiMsgType> msg_selection = std::nullopt,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
-      node_logging_interface = nullptr);
+      node_logging_interface,
+    std::optional<ApiMsgType> msg_selection = std::nullopt);
 
   /// Start Server
   void start();

--- a/rmf_websocket/include/rmf_websocket/BroadcastServer.hpp
+++ b/rmf_websocket/include/rmf_websocket/BroadcastServer.hpp
@@ -23,6 +23,8 @@
 #include <optional>
 #include <rmf_utils/impl_ptr.hpp>
 
+#include <rclcpp/rclcpp.hpp>
+
 namespace rmf_websocket {
 
 //==============================================================================
@@ -58,6 +60,26 @@ public:
     const int port,
     ApiMessageCallback callback,
     std::optional<ApiMsgType> msg_selection = std::nullopt);
+
+  /// Add a callback to convert from a Description into an active Task.
+  ///
+  /// \param[in] port
+  ///   server url port number
+  ///
+  /// \param[in] callback
+  ///   callback function when the message is received
+  ///
+  /// \param[in] msg_selection
+  ///   selected msg type to listen. Will listen to all msg if nullopt
+  ///
+  /// \param[in] node_logging_interface
+  ///   node for logging
+  static std::shared_ptr<BroadcastServer> make_with_logger(
+    const int port,
+    ApiMessageCallback callback,
+    std::optional<ApiMsgType> msg_selection = std::nullopt,
+    const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
+      node_logging_interface = nullptr);
 
   /// Start Server
   void start();

--- a/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
+++ b/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
@@ -42,10 +42,11 @@ public:
     std::optional<ApiMsgType> msg_selection,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
       node_logging_interface)
-  : _data(std::make_shared<Data>(std::move(callback), std::move(msg_selection))),
+  : _data(std::make_shared<Data>(std::move(callback),
+        std::move(msg_selection))),
     _logger_interface(node_logging_interface)
   {
-    if(_logger_interface)
+    if (_logger_interface)
     {
       RCLCPP_INFO_STREAM(
         _logger_interface->get_logger(),
@@ -75,7 +76,7 @@ public:
     }
     catch (const websocketpp::exception& e)
     {
-      if(_logger_interface)
+      if (_logger_interface)
       {
         RCLCPP_ERROR_STREAM(
           _logger_interface->get_logger(),
@@ -84,7 +85,7 @@ public:
     }
     catch (...)
     {
-      if(_logger_interface)
+      if (_logger_interface)
       {
         RCLCPP_ERROR(
           _logger_interface->get_logger(), "Unknown exception occured");
@@ -99,7 +100,7 @@ public:
     {
       websocketpp::lib::asio::error_code ec;
       auto endpoint = _data->echo_server.get_local_endpoint(ec);
-      if(ec)
+      if (ec)
       {
         RCLCPP_ERROR_STREAM(
           _logger_interface->get_logger(),

--- a/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
+++ b/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
@@ -39,10 +39,19 @@ public:
   Implementation(
     const int port,
     ApiMessageCallback callback,
-    std::optional<ApiMsgType> msg_selection)
-  : _data(std::make_shared<Data>(std::move(callback),
-      std::move(msg_selection)))
+    std::optional<ApiMsgType> msg_selection,
+    const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
+      node_logging_interface = nullptr)
+  : _data(std::make_shared<Data>(std::move(callback), std::move(msg_selection))),
+    _logger_interface(node_logging_interface)
   {
+    if(_logger_interface)
+    {
+      RCLCPP_INFO_STREAM(
+        _logger_interface->get_logger(),
+        "Running websocket server on port " << port);
+    }
+
     try
     {
       // Hide all logs from websocketpp
@@ -66,17 +75,42 @@ public:
     }
     catch (const websocketpp::exception& e)
     {
-      std::cout << e.what() << std::endl;
+      if(_logger_interface)
+      {
+        RCLCPP_ERROR_STREAM(
+          _logger_interface->get_logger(),
+          "WebSocket exception occured: " << e.what());
+      }
     }
     catch (...)
     {
-      std::cout << "other exception" << std::endl;
+      if(_logger_interface)
+      {
+        RCLCPP_ERROR(
+          _logger_interface->get_logger(), "Unknown exception occured");
+      }
     }
   }
 
   /// Start Server
   void start()
   {
+    if (_logger_interface)
+    {
+      websocketpp::lib::asio::error_code ec;
+      auto endpoint = _data->echo_server.get_local_endpoint(ec);
+      if(ec)
+      {
+        RCLCPP_ERROR_STREAM(
+          _logger_interface->get_logger(),
+          "Failed to create connection: " << ec.message());
+         return;
+      }
+      RCLCPP_INFO_STREAM(
+        _logger_interface->get_logger(),
+        "Starting BroadcastServer on port " << endpoint.port());
+    }
+
     // Start the ASIO io_service run loop
     _server_thread = std::thread(
       [data = _data]() { data->echo_server.run(); });
@@ -87,6 +121,12 @@ public:
   {
     if (_server_thread.joinable())
     {
+      if (_logger_interface)
+      {
+        RCLCPP_INFO(
+          _logger_interface->get_logger(),"Stopping BroadcastServer");
+      }
+
       _data->echo_server.get_io_service().post(
           [data = _data]()
           {
@@ -112,6 +152,7 @@ public:
         {ApiMsgType::FleetLogUpdate, "fleet_log_update"}});
     return map.at(type);
   }
+
 
 private:
 
@@ -154,6 +195,7 @@ private:
   };
   std::shared_ptr<Data> _data;
   std::thread _server_thread;
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr _logger_interface;
 };
 
 //==============================================================================
@@ -166,6 +208,21 @@ std::shared_ptr<BroadcastServer> BroadcastServer::make(
   server->_pimpl =
     rmf_utils::make_unique_impl<Implementation>(
     port, callback, msg_selection);
+  return server;
+}
+
+//==============================================================================
+std::shared_ptr<BroadcastServer> BroadcastServer::make_with_logger(
+  const int port,
+  ApiMessageCallback callback,
+  std::optional<ApiMsgType> msg_selection,
+  const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
+    node_logging_interface)
+{
+  auto server = std::shared_ptr<BroadcastServer>(new BroadcastServer());
+  server->_pimpl =
+    rmf_utils::make_unique_impl<Implementation>(
+        port, callback, msg_selection, node_logging_interface);
   return server;
 }
 

--- a/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
+++ b/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
@@ -41,7 +41,7 @@ public:
     ApiMessageCallback callback,
     std::optional<ApiMsgType> msg_selection,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
-      node_logging_interface = nullptr)
+      node_logging_interface)
   : _data(std::make_shared<Data>(std::move(callback), std::move(msg_selection))),
     _logger_interface(node_logging_interface)
   {
@@ -124,7 +124,7 @@ public:
       if (_logger_interface)
       {
         RCLCPP_INFO(
-          _logger_interface->get_logger(),"Stopping BroadcastServer");
+          _logger_interface->get_logger(), "Stopping BroadcastServer");
       }
 
       _data->echo_server.get_io_service().post(
@@ -152,7 +152,6 @@ public:
         {ApiMsgType::FleetLogUpdate, "fleet_log_update"}});
     return map.at(type);
   }
-
 
 private:
 
@@ -207,7 +206,7 @@ std::shared_ptr<BroadcastServer> BroadcastServer::make(
   auto server = std::shared_ptr<BroadcastServer>(new BroadcastServer());
   server->_pimpl =
     rmf_utils::make_unique_impl<Implementation>(
-    port, callback, msg_selection);
+    port, callback, msg_selection, nullptr);
   return server;
 }
 
@@ -215,9 +214,9 @@ std::shared_ptr<BroadcastServer> BroadcastServer::make(
 std::shared_ptr<BroadcastServer> BroadcastServer::make_with_logger(
   const int port,
   ApiMessageCallback callback,
-  std::optional<ApiMsgType> msg_selection,
   const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr
-    node_logging_interface)
+    node_logging_interface,
+  std::optional<ApiMsgType> msg_selection)
 {
   auto server = std::shared_ptr<BroadcastServer>(new BroadcastServer());
   server->_pimpl =


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Related to #456. Based on @aaronchongth's [comment](https://github.com/open-rmf/rmf_ros2/issues/456#issuecomment-3126276261) I have added a new builder function that takes in a node as an argument.

### Implementation description

A new builder function `make_with_logger` takes in an argument of type `const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr` which is then stored in `Implementation`. The validity of this node pointer is checked each time before printing a log.

The usage of this function can be seen in [`test_Delivery.cpp`](https://github.com/sauk2/rmf_ros2/blob/b7f865a50da3c98cd0c1f39584ef80a6816bad74/rmf_fleet_adapter/test/tasks/test_Delivery.cpp#L375) of `rmf_fleet_adapter`

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI