### PR TITLE
Remove potential data races

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/jobs/Planning.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/jobs/Planning.cpp
@@ -41,6 +41,12 @@ Planning::Planning(rmf_traffic::agv::Planner::Result _setup)
 //==============================================================================
 void Planning::resume()
 {
+  if (_resume_scheduled.exchange(true))
+  {
+    // This has already been scheduled to resume
+    return;
+  }
+
   _resume();
 }
 
@@ -60,25 +66,13 @@ bool Planning::active() const
 //==============================================================================
 rmf_traffic::agv::Planner::Result& Planning::progress()
 {
-  return *_current_result;
+  return _current_result.value();
 }
 
 //==============================================================================
 const rmf_traffic::agv::Planner::Result& Planning::progress() const
 {
-  return *_current_result;
-}
-
-//==============================================================================
-std::unique_lock<std::mutex> Planning::_lock_resume() const
-{
-  std::unique_lock<std::mutex> lock(_resume_mutex, std::defer_lock);
-  while (!lock.try_lock())
-  {
-    // Intentionally busy wait to obtain the mutex as fast as possible
-  }
-
-  return lock;
+  return _current_result.value();
 }
 
 } // namespace jobs

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/jobs/Planning.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/jobs/Planning.hpp
@@ -23,6 +23,8 @@
 #include <rmf_traffic/agv/RouteValidator.hpp>
 #include <rmf_traffic/schedule/Snapshot.hpp>
 
+#include <atomic>
+
 namespace rmf_fleet_adapter {
 namespace jobs {
 
@@ -58,11 +60,9 @@ public:
   const rmf_traffic::agv::Planner::Result& progress() const;
 
 private:
-  mutable std::mutex _resume_mutex;
+  std::atomic_bool _resume_scheduled = {false};
   std::function<void()> _resume;
-  rmf_utils::optional<rmf_traffic::agv::Planner::Result> _current_result;
-
-  std::unique_lock<std::mutex> _lock_resume() const;
+  std::optional<rmf_traffic::agv::Planner::Result> _current_result;
 };
 
 } // namespace jobs

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/jobs/SearchForPath.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/jobs/SearchForPath.cpp
@@ -100,27 +100,27 @@ void SearchForPath::interrupt()
 }
 
 //==============================================================================
-Planning& SearchForPath::greedy()
+const std::shared_ptr<Planning>& SearchForPath::greedy()
 {
-  return *_greedy_job;
+  return _greedy_job;
 }
 
 //==============================================================================
-const Planning& SearchForPath::greedy() const
+std::shared_ptr<const Planning> SearchForPath::greedy() const
 {
-  return *_greedy_job;
+  return _greedy_job;
 }
 
 //==============================================================================
-Planning& SearchForPath::compliant()
+const std::shared_ptr<Planning>& SearchForPath::compliant()
 {
-  return *_compliant_job;
+  return _compliant_job;
 }
 
 //==============================================================================
-const Planning& SearchForPath::compliant() const
+std::shared_ptr<const Planning> SearchForPath::compliant() const
 {
-  return *_compliant_job;
+  return _compliant_job;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/jobs/SearchForPath.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/jobs/SearchForPath.hpp
@@ -19,6 +19,7 @@
 #define SRC__RMF_FLEET_ADAPTER__JOBS__SEARCHFORPATH_HPP
 
 #include "Planning.hpp"
+#include <memory>
 
 namespace rmf_fleet_adapter {
 namespace jobs {
@@ -65,11 +66,11 @@ public:
 
   void set_cost_limit(double cost);
 
-  Planning& greedy();
-  const Planning& greedy() const;
+  const std::shared_ptr<Planning>& greedy();
+  std::shared_ptr<const Planning> greedy() const;
 
-  Planning& compliant();
-  const Planning& compliant() const;
+  const std::shared_ptr<Planning>& compliant();
+  std::shared_ptr<const Planning> compliant() const;
 
 private:
   std::shared_ptr<const rmf_traffic::agv::Planner> _planner;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/services/ProgressEvaluator.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/services/ProgressEvaluator.hpp
@@ -19,6 +19,7 @@
 #define SRC__RMF_FLEET_ADAPTER__SERVICES__PROGRESSEVALUATOR_HPP
 
 #include <rmf_traffic/agv/Planner.hpp>
+#include "../jobs/Planning.hpp"
 
 namespace rmf_fleet_adapter {
 namespace services {
@@ -37,19 +38,19 @@ struct ProgressEvaluator
     double estimate_leeway_ = DefaultEstimateLeeway,
     double max_cost_threshold_ = DefaultMaxCostThreshold);
 
-  using Result = rmf_traffic::agv::Plan::Result;
+  using Planning = rmf_fleet_adapter::jobs::Planning;
 
   struct Info
   {
     double cost = std::numeric_limits<double>::infinity();
-    const Result* progress = nullptr;
+    std::shared_ptr<const Planning> planning = nullptr;
   };
 
-  bool initialize(const Result& setup);
+  bool initialize(std::shared_ptr<const Planning> setup);
 
-  bool evaluate(Result& progress);
+  bool evaluate(std::shared_ptr<Planning> progress);
 
-  void discard(Result& progress);
+  void discard(std::shared_ptr<Planning> progress);
 
   Info best_estimate;
   Info second_best_estimate;


### PR DESCRIPTION
This PR fixes #462 

Initially I thought the crashing was related to the use of loose raw pointers in `ProgressEvaluator`, so most of the changes in this PR are to replace those raw pointers with `std::shared_ptr`. While those raw pointers may have been the cause of a small fraction of the crashes, I believe most of the crashes were actually related to the `_resume` callback.

It turns out that there was a narrow race condition in which it was possible for the `_resume` callback of `Planning` to get overwritten while it was being executed. As the `std::function` is being dropped, its captured variables become invalid memory. If the `std::function` is being run **_while_** it gets dropped, those captured variables can become invalid memory **_while they are being used_**.

There was already a `_resume_mutex` being used to prevent this situation, but its usage wasn't rigorous enough. There was still a very slim window in between when the `_resume` callback gets called and when it gets locked inside the callback. If the `std::function` gets dropped inside that narrow window then we can get a segmentation fault.

I've updated the way `_resume` works so that it only gets instantiated once: the first time the planning job is started. After that there is no risk of the `std::function _resume` becoming invalid as long as the `Planning` object is still valid, and there is no way to trigger `_resume` without the `Planning` object being alive. This should guarantee all the memory remains valid.

Furthermore I've added a `_resume_scheduled` flag that tracks whether a `Planning` job has already been scheduled to resume. This makes sure we never have multiple threads trying to make progress on the same planning job at the same time.

As an extra layer of protection, I've opened https://github.com/open-rmf/rmf_traffic/pull/124 which will guarantee that access to the `Planner::Result` class is always thread-safe, in case there are other places in this codebase where a data race may be happening that we haven't caught yet.