### PR TITLE
handling of task_api_requests on active task during emergency pullover

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1737,12 +1737,6 @@ void TaskManager::_begin_next_task()
 //==============================================================================
 void TaskManager::_begin_pullover()
 {
-
-  if (_emergency_pullover && !_emergency_pullover.is_finished())
-  {
-    return;
-  }
-
   _finished_waiting = false;
   auto task_id = "emergency_pullover." + _context->name() + "."
     + _context->group() + "-"
@@ -1972,7 +1966,12 @@ void TaskManager::_resume_from_emergency()
           {"emergency finished"},
           self->_context->now());
         self->_emergency_pullover_interrupt_token = std::nullopt;
-        
+
+        RCLCPP_INFO(
+          self->_context->node()->get_logger(),
+          "Resume execution of task [%s] for [%s] after emergency pullover",
+          self->_active_task.id().c_str(),
+          self->_context->requester_id().c_str());
         self->_context->current_task_id(self->_active_task.id());
       }
       else

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1527,6 +1527,11 @@ bool TaskManager::cancel_task(
 {
   if (_active_task && _active_task.id() == task_id)
   {
+    if (_emergency_active)
+    {
+      return false;
+    }
+
     _task_state_update_available = true;
     _active_task.cancel(std::move(labels), _context->now());
     return true;
@@ -1551,6 +1556,11 @@ bool TaskManager::kill_task(
 {
   if (_active_task && _active_task.id() == task_id)
   {
+    if (_emergency_active)
+    {
+      return false;
+    }
+
     _task_state_update_available = true;
     _active_task.kill(std::move(labels), _context->now());
     return true;
@@ -1573,6 +1583,11 @@ bool TaskManager::quiet_cancel_task(
 {
   if (_active_task && _active_task.id() == task_id)
   {
+    if (_emergency_active)
+    {
+      return false;
+    }
+
     _task_state_update_available = true;
     _active_task.quiet_cancel(std::move(labels), _context->now());
     return true;
@@ -2979,11 +2994,6 @@ void TaskManager::_handle_cancel_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
-  if (_emergency_active)
-  {
-    return;
-  }
-
   const auto& task_id = request_json["task_id"].get<std::string>();
   if (cancel_task(task_id, get_labels(request_json)))
     _send_simple_success_response(request_id);
@@ -2999,11 +3009,6 @@ void TaskManager::_handle_kill_request(
 
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
-
-  if (_emergency_active)
-  {
-    return;
-  }
 
   const auto& task_id = request_json["task_id"].get<std::string>();
   if (kill_task(task_id, get_labels(request_json)))
@@ -3021,15 +3026,15 @@ void TaskManager::_handle_interrupt_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
-  if (_emergency_active)
-  {
-    return;
-  }
-
   const auto& task_id = request_json["task_id"].get<std::string>();
 
   if (_active_task && _active_task.id() == task_id)
   {
+    if (_emergency_active)
+    {
+      return;
+    }
+
     _task_state_update_available = true;
     return _send_token_success_response(
       _active_task.add_interruption(
@@ -3051,15 +3056,15 @@ void TaskManager::_handle_resume_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
-  if (_emergency_active)
-  {
-    return;
-  }
-
   const auto& task_id = request_json["for_task"].get<std::string>();
 
   if (_active_task && _active_task.id() == task_id)
   {
+    if (_emergency_active)
+    {
+      return;
+    }
+
     _task_state_update_available = true;
     auto unknown_tokens = _active_task.remove_interruption(
       request_json["for_tokens"].get<std::vector<std::string>>(),
@@ -3096,15 +3101,15 @@ void TaskManager::_handle_rewind_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
-  if (_emergency_active)
-  {
-    return;
-  }
-
   const auto& task_id = request_json["task_id"].get<std::string>();
 
   if (_active_task && _active_task.id() == task_id)
   {
+    if (_emergency_active)
+    {
+      return;
+    }
+
     _task_state_update_available = true;
     _active_task.rewind(request_json["phase_id"].get<uint64_t>());
     return _send_simple_success_response(request_id);
@@ -3124,15 +3129,16 @@ void TaskManager::_handle_skip_phase_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
-  if (_emergency_active)
-  {
-    return;
-  }
-
   const auto& task_id = request_json["task_id"].get<std::string>();
 
   if (_active_task && _active_task.id() == task_id)
   {
+
+    if (_emergency_active)
+    {
+      return;
+    }
+
     _task_state_update_available = true;
     return _send_token_success_response(
       _active_task.skip(
@@ -3156,15 +3162,15 @@ void TaskManager::_handle_undo_skip_phase_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
-  if (_emergency_active)
-  {
-    return;
-  }
-
   const auto& task_id = request_json["for_task"].get<std::string>();
 
   if (_active_task && _active_task.id() == task_id)
   {
+    if (_emergency_active)
+    {
+      return;
+    }
+
     _task_state_update_available = true;
     auto unknown_tokens = _active_task.remove_skips(
       request_json["for_tokens"].get<std::vector<std::string>>(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1972,6 +1972,8 @@ void TaskManager::_resume_from_emergency()
           {"emergency finished"},
           self->_context->now());
         self->_emergency_pullover_interrupt_token = std::nullopt;
+        
+        self->_context->current_task_id(self->_active_task.id());
       }
       else
       {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -1722,6 +1722,12 @@ void TaskManager::_begin_next_task()
 //==============================================================================
 void TaskManager::_begin_pullover()
 {
+
+  if (_emergency_pullover && !_emergency_pullover.is_finished())
+  {
+    return;
+  }
+
   _finished_waiting = false;
   auto task_id = "emergency_pullover." + _context->name() + "."
     + _context->group() + "-"
@@ -1936,6 +1942,7 @@ void TaskManager::_resume_from_emergency()
       }
 
       self->_emergency_pullover = ActiveTask();
+      self->_context->current_task_id(std::nullopt);
 
       if (!self->_emergency_pullover_interrupt_token.has_value())
       {
@@ -2972,6 +2979,11 @@ void TaskManager::_handle_cancel_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
+  if (_emergency_active)
+  {
+    return;
+  }
+
   const auto& task_id = request_json["task_id"].get<std::string>();
   if (cancel_task(task_id, get_labels(request_json)))
     _send_simple_success_response(request_id);
@@ -2988,6 +3000,11 @@ void TaskManager::_handle_kill_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
+  if (_emergency_active)
+  {
+    return;
+  }
+
   const auto& task_id = request_json["task_id"].get<std::string>();
   if (kill_task(task_id, get_labels(request_json)))
     _send_simple_success_response(request_id);
@@ -3003,6 +3020,11 @@ void TaskManager::_handle_interrupt_request(
 
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
+
+  if (_emergency_active)
+  {
+    return;
+  }
 
   const auto& task_id = request_json["task_id"].get<std::string>();
 
@@ -3028,6 +3050,11 @@ void TaskManager::_handle_resume_request(
 
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
+
+  if (_emergency_active)
+  {
+    return;
+  }
 
   const auto& task_id = request_json["for_task"].get<std::string>();
 
@@ -3069,6 +3096,11 @@ void TaskManager::_handle_rewind_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
+  if (_emergency_active)
+  {
+    return;
+  }
+
   const auto& task_id = request_json["task_id"].get<std::string>();
 
   if (_active_task && _active_task.id() == task_id)
@@ -3091,6 +3123,11 @@ void TaskManager::_handle_skip_phase_request(
 
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
+
+  if (_emergency_active)
+  {
+    return;
+  }
 
   const auto& task_id = request_json["task_id"].get<std::string>();
 
@@ -3119,7 +3156,12 @@ void TaskManager::_handle_undo_skip_phase_request(
   if (!_validate_request_message(request_json, request_validator, request_id))
     return;
 
-  const auto& task_id = request_json["for_task"];
+  if (_emergency_active)
+  {
+    return;
+  }
+
+  const auto& task_id = request_json["for_task"].get<std::string>();
 
   if (_active_task && _active_task.id() == task_id)
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/EmergencyPullover.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/EmergencyPullover.hpp
@@ -108,6 +108,8 @@ public:
       rmf_traffic::agv::Plan plan,
       rmf_traffic::schedule::Itinerary full_itinerary);
 
+    void _stop_and_clear();
+
     Negotiator::NegotiatePtr _respond(
       const Negotiator::TableViewerPtr& table_view,
       const Negotiator::ResponderPtr& responder);


### PR DESCRIPTION
Related to open-rmf/rmf_ros2#463

This PR implement the following enhancements:
1. `task_api_requests` on `active_task` during emergency pullover will be ignored.
2. After emergency signal is cleared, robot context `current_task_id` will be reset. 
3. After emergency pullover is cancelled, it will stop the robot. What the robot do if there is no active task is per finishing_request.


### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [ x] I did not use GenAI
