### PR TITLE
Feature/Support Idle Robot Preferred in Task Planning

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -848,6 +848,13 @@ public:
   /// \sa strict_lanes
   std::unordered_set<std::size_t>& change_strict_lanes();
 
+  /// Should task planner prefer idle robots for tasks assignment?
+  bool prefer_idle_robots_for_tasks() const;
+
+  /// Set whether task planner should prefer idle robots for tasks assignment.
+  void set_prefer_idle_robots_for_tasks(
+    const bool prefer);
+
   class Implementation;
 private:
   rmf_utils::impl_ptr<Implementation> _pimpl;

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/EasyFullControl.hpp
@@ -36,6 +36,9 @@
 #include <rmf_traffic/agv/Graph.hpp>
 #include <rmf_traffic/agv/VehicleTraits.hpp>
 
+// rmf_task headers
+#include <rmf_task/TaskPlanner.hpp>
+
 #include <rmf_utils/impl_ptr.hpp>
 
 // System headers
@@ -848,12 +851,16 @@ public:
   /// \sa strict_lanes
   std::unordered_set<std::size_t>& change_strict_lanes();
 
-  /// Should task planner prefer idle robots for tasks assignment?
-  bool prefer_idle_robots_for_tasks() const;
+  /// Get the task planner node expansion policy.
+  /// This policy determines how the task planner will expand nodes in the task
+  /// assignment.
+  rmf_task::TaskPlanner::ExpansionPolicy task_node_expansion_policy() const;
 
-  /// Set whether task planner should prefer idle robots for tasks assignment.
-  void set_prefer_idle_robots_for_tasks(
-    const bool prefer);
+  /// Set the task planner expansion policy.
+  /// example: rmf_task::TaskPlanner::ExpansionPolicy::IdlePreferred,
+  /// rmf_task::TaskPlanner::ExpansionPolicy::ShortestPathFirst, etc.
+  void set_task_node_expansion_policy(
+    const rmf_task::TaskPlanner::ExpansionPolicy policy);
 
   class Implementation;
 private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -299,6 +299,9 @@ public:
   ///   A factory for a request that should be performed by each robot in this
   ///   fleet at the end of its assignments.
   ///
+  /// \param[in] idle_robot_preferred
+  ///   Specify whether idle robots are preferred for task planning.
+  ///
   /// \return true if task planner parameters were successfully updated.
   bool set_task_planner_params(
     rmf_battery::agv::ConstBatterySystemPtr battery_system,
@@ -308,7 +311,8 @@ public:
     double recharge_threshold,
     double recharge_soc,
     bool account_for_battery_drain,
-    rmf_task::ConstRequestFactoryPtr finishing_request = nullptr);
+    rmf_task::ConstRequestFactoryPtr finishing_request = nullptr,
+    bool idle_robot_preferred = false);
 
   /// A callback function that evaluates whether a fleet will accept a task
   /// request

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -35,6 +35,8 @@
 #include <rmf_task_sequence/Phase.hpp>
 #include <rmf_task_sequence/Event.hpp>
 
+#include <rmf_task/TaskPlanner.hpp>
+
 #include <rclcpp/node.hpp>
 
 namespace rmf_fleet_adapter {
@@ -299,8 +301,10 @@ public:
   ///   A factory for a request that should be performed by each robot in this
   ///   fleet at the end of its assignments.
   ///
-  /// \param[in] idle_robot_preferred
-  ///   Specify whether idle robots are preferred for task planning.
+  /// \param[in] expansion_policy
+  ///   The policy that defines how the planner expands search nodes during
+  ///   task assignment. Available options are in enum class ExpansionPolicy.
+  ///   If not specified, the default is ShortestFinishTime.
   ///
   /// \return true if task planner parameters were successfully updated.
   bool set_task_planner_params(
@@ -312,7 +316,8 @@ public:
     double recharge_soc,
     bool account_for_battery_drain,
     rmf_task::ConstRequestFactoryPtr finishing_request = nullptr,
-    bool idle_robot_preferred = false);
+    rmf_task::TaskPlanner::ExpansionPolicy expansion_policy =
+      rmf_task::TaskPlanner::ExpansionPolicy::ShortestFinishTime);
 
   /// A callback function that evaluates whether a fleet will accept a task
   /// request

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -306,7 +306,8 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     config.recharge_threshold(),
     config.recharge_soc(),
     config.account_for_battery_drain(),
-    config.finishing_request());
+    config.finishing_request(),
+    config.prefer_idle_robots_for_tasks());
 
   if (!planner_params_ok)
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -307,7 +307,7 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     config.recharge_soc(),
     config.account_for_battery_drain(),
     config.finishing_request(),
-    config.prefer_idle_robots_for_tasks());
+    config.task_node_expansion_policy());
 
   if (!planner_params_ok)
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -2270,6 +2270,7 @@ public:
   std::unordered_map<std::string, std::string> lift_emergency_levels;
   std::unordered_set<std::size_t> strict_lanes;
   bool use_parking_reservation;
+  bool prefer_idle_robots_for_tasks;
 };
 
 //==============================================================================
@@ -2327,7 +2328,8 @@ EasyFullControl::FleetConfiguration::FleetConfiguration(
         std::move(default_min_lane_length),
         {},
         {},
-        false // Parking reservation system
+        false, // Parking reservation system
+        false  // Prefer idle robots for tasks
       }))
 {
   // Do nothing
@@ -2989,6 +2991,13 @@ EasyFullControl::FleetConfiguration::from_config_files(
     }
   }
 
+  // idle robot preferred task planning option
+  bool prefer_idle_robots_for_tasks = false;
+  if (rmf_fleet["prefer_idle_robots_for_tasks"])
+  {
+    prefer_idle_robots_for_tasks = rmf_fleet["prefer_idle_robots_for_tasks"].as<bool>();
+  }
+
   auto config = FleetConfiguration(
     fleet_name,
     std::move(tf_dict),
@@ -3017,6 +3026,7 @@ EasyFullControl::FleetConfiguration::from_config_files(
   config.set_retreat_to_charger_interval(retreat_to_charger_interval);
   config.use_parking_reservation_system(use_simple_parking_reservation_system);
   config.change_strict_lanes() = std::move(strict_lanes);
+  config.set_prefer_idle_robots_for_tasks(prefer_idle_robots_for_tasks);
   return config;
 }
 
@@ -3426,6 +3436,19 @@ std::unordered_set<std::size_t>&
 EasyFullControl::FleetConfiguration::change_strict_lanes()
 {
   return _pimpl->strict_lanes;
+}
+
+//==============================================================================
+bool EasyFullControl::FleetConfiguration::prefer_idle_robots_for_tasks() const
+{
+  return _pimpl->prefer_idle_robots_for_tasks;
+}
+
+//==============================================================================
+void EasyFullControl::FleetConfiguration::set_prefer_idle_robots_for_tasks(
+  const bool prefer)
+{
+  _pimpl->prefer_idle_robots_for_tasks = prefer;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -2639,7 +2639,8 @@ bool FleetUpdateHandle::set_task_planner_params(
   double recharge_threshold,
   double recharge_soc,
   bool account_for_battery_drain,
-  rmf_task::ConstRequestFactoryPtr idle_task)
+  rmf_task::ConstRequestFactoryPtr idle_task,
+  bool idle_robot_preferred)
 {
   if (battery_system &&
     motion_sink &&
@@ -2667,7 +2668,8 @@ bool FleetUpdateHandle::set_task_planner_params(
       nullptr,
       // The finishing request is no longer handled by the planner, we handle
       // it separately as a waiting behavior now.
-      nullptr};
+      nullptr,
+      idle_robot_preferred};
 
     _pimpl->worker.schedule(
       [w = weak_from_this(), task_config, options, idle_task](const auto&)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -2640,7 +2640,7 @@ bool FleetUpdateHandle::set_task_planner_params(
   double recharge_soc,
   bool account_for_battery_drain,
   rmf_task::ConstRequestFactoryPtr idle_task,
-  bool idle_robot_preferred)
+  rmf_task::TaskPlanner::ExpansionPolicy expansion_policy)
 {
   if (battery_system &&
     motion_sink &&
@@ -2669,7 +2669,7 @@ bool FleetUpdateHandle::set_task_planner_params(
       // The finishing request is no longer handled by the planner, we handle
       // it separately as a waiting behavior now.
       nullptr,
-      idle_robot_preferred};
+      expansion_policy};
 
     _pimpl->worker.schedule(
       [w = weak_from_this(), task_config, options, idle_task](const auto&)


### PR DESCRIPTION

## New feature implementation

### Implemented feature

This PR is to support the new feature proposed at PR in rmf_task open-rmf/rmf_task#129

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

### Implementation description

A new parameter in fleet_config.yaml (**task_assignment_strategy**) is read and passed to EasyFullControl and to FleetUpdateHandle and finally to TaskPlanner.

Also, there is new functions added in `rmf_task::State`:
```
bool is_idle() const;
State& idle(bool is_idle);
```
purpose is to reflect whether the robot is in idle state, and it is set in TaskManager.cpp `TaskManager::expected_finish_state()`. Then this idle state will be stored in initial_states and passed to TaskPlanner.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
