### PR TITLE
feature/Add start_at_departure flag for GoToPlace

### DIFF
--- a/rmf_fleet_adapter/schemas/event_description__go_to_place.json
+++ b/rmf_fleet_adapter/schemas/event_description__go_to_place.json
@@ -55,6 +55,7 @@
     },
     "start_at_departure": {
       "type": "boolean",
+      "default": false,
       "description": "(Optional) Determines how [unix_millis_earliest_start_time] is interpreted. If true, the event is considered to start when the robot departs from its current location. If false (default), the event is considered to start when the robot arrives at the destination."
     }
   }

--- a/rmf_fleet_adapter/schemas/event_description__go_to_place.json
+++ b/rmf_fleet_adapter/schemas/event_description__go_to_place.json
@@ -15,7 +15,8 @@
           "description": "A list of places that the robot might go after it reaches this one. It will not actually go to these places unless other activities bring it there, but the traffic system will be told to expect the robot to proceed through these places.",
           "type": "array",
           "items": { "$ref": "place.json" }
-        }
+        },
+        "start_at_departure": { "$ref": "#/$defs/start_at_departure" }
       },
       "required": ["place"]
     },
@@ -32,7 +33,8 @@
           "type": "array",
           "description": "list of constraints to use",
           "items": {"$ref": "#/$defs/constraint"}
-        }
+        },
+        "start_at_departure": { "$ref": "#/$defs/start_at_departure" }
       },
       "required": ["one_of"]
     }
@@ -50,6 +52,10 @@
         }
       },
       "required": ["category"]
+    },
+    "start_at_departure": {
+      "type": "boolean",
+      "description": "(Optional) Determines how [unix_millis_earliest_start_time] is interpreted. If true, the event is considered to start when the robot departs from its current location. If false (default), the event is considered to start when the robot arrives at the destination."
     }
   }
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Patrol.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Patrol.cpp
@@ -87,6 +87,12 @@ void add_patrol(
           }
         }
 
+        if (const auto start_at_departure_it = msg.find("start_at_departure");
+          start_at_departure_it != msg.end())
+        {
+          desc->start_at_departure(start_at_departure_it->get<bool>());
+        }
+
         return {desc, errors};
       }
 
@@ -123,6 +129,12 @@ void add_patrol(
           followed_by.push_back(*f.description);
         }
         desc->expected_next_destinations(std::move(followed_by));
+      }
+
+      if (const auto start_at_departure_it = msg.find("start_at_departure");
+        start_at_departure_it != msg.end())
+      {
+        desc->start_at_departure(start_at_departure_it->get<bool>());
       }
 
       return {desc, std::move(place.errors)};


### PR DESCRIPTION

## New feature implementation

### Implemented feature

This PR is related to this open-rmf/rmf_task#128.

### Implementation description

- `start_at_departure` is added in go_to_place schema.
- and additional logic is added in Patrol.cpp to read this flag.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
