### PR TITLE
Fix indefinite growth of active_dispatch_states

### DIFF
--- a/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
+++ b/rmf_task_ros2/src/rmf_task_ros2/Dispatcher.cpp
@@ -920,6 +920,7 @@ public:
     }
 
     finished_dispatch_states[active_it->first] = active_it->second;
+    active_dispatch_states.erase(active_it);
   }
 
   void publish_dispatch_states()


### PR DESCRIPTION
## Bug fix

### Fixed bug

Finished-dispatched tasks remained in `active_dispatch_states` after being added to `finished_dispatch_states`, causing unbounded growth. This PR makes `move_to_finished()` erase the task from `active_dispatch_states` after moving it to `finished_dispatch_states`.

Reproduce the bug:
1. send a rmf task using `dispatch_task_request`, eg. using dispatch_patrol.py with `payload['type'] = 'dispatch_task_request'`
2. After the task is awarded to any robot, echo the topic /dispatch_states.
3. Can see those dispatched tasks still remain in `active` field


### Fix applied

Task is erased from `active_dispatch_states` in `move_to_finished()` .


### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
