### PR TITLE
Fix parameter validation logic for recharge_soc in set_task_planner_params function

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -2646,7 +2646,7 @@ bool FleetUpdateHandle::set_task_planner_params(
     ambient_sink &&
     tool_sink &&
     (recharge_threshold >= 0.0 && recharge_threshold <= 1.0) &&
-    (recharge_soc >= 0.0 && recharge_threshold <= 1.0))
+    (recharge_soc >= 0.0 && recharge_soc <= 1.0))
   {
     const rmf_task::Parameters parameters{
       *_pimpl->planner,


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discourse [discussions page](https://discourse.openrobotics.org/c/open-rmf/open-rmf-general/103) or [proposals page](https://discourse.openrobotics.org/c/open-rmf/open-rmf-ideas/105).
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

Fixed a logical error in the parameter validation within FleetUpdateHandle::set_task_planner_params() method where the wrong variable was being used for boundary checking.

Please review this change and let me know if you have any questions or concerns.

