### PR TITLE
Fix early cull of negotiations

### DIFF
--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -843,7 +843,7 @@ void ScheduleNode::cull()
     std::vector<std::size_t> cull_wait;
     for (const auto& [v, wait] : active_conflicts._waiting)
     {
-      if (wait.conclusion_time + std::chrono::seconds(30) > time)
+      if (wait.conclusion_time + std::chrono::seconds(30) < time)
       {
         cull_wait.push_back(v);
       }
@@ -864,7 +864,7 @@ void ScheduleNode::cull()
       if (open.has_value())
       {
         // TODO(MXG): Make this deadline configurable
-        if (open->last_active_time + std::chrono::seconds(30) > time)
+        if (open->last_active_time + std::chrono::seconds(30) < time)
         {
           cull_negotiation.push_back(v);
         }


### PR DESCRIPTION

## Bug fix

### Fixed bug

This PR fixed an minor issue in `ScheduleNode::cull()` where negotiations and _waiting were being culled too early due to an inverted timeout check.

### Fix applied
Updated with corrrect timeout check.

