### PR TITLE
fix: correct return in 'use_parking_reservation_system' setter

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -272,6 +272,8 @@ RobotUpdateHandle& RobotUpdateHandle::use_parking_reservation_system(bool use)
           self->requester_id().c_str());
       });
   }
+
+  return *this;
 }
 
 //==============================================================================


### PR DESCRIPTION
## Bug fix

### Fixed bug
segmentation fault when setting 'use_parking_reservation_system' flag using python binding.

### Fix applied

add 'return *this;'


### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x ] I did not use GenAI

Generated-by:
