### PR TITLE
Ignore waypoints that have already been passed when graph changes

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
@@ -231,10 +231,13 @@ auto GoToPlace::Active::make(
 
       if (self->_execution.has_value())
       {
-        // TODO(@mxgrey): Consider ignoring waypoints that have already been
-        // passed.
+        const auto now = self->_context->now();
         for (const auto& wp : self->_execution->plan.get_waypoints())
         {
+          // Ignore waypoints that have already been passed.
+          if (wp.time() < now)
+            continue;
+
           for (const std::size_t lane : wp.approach_lanes())
           {
             const auto closed = std::find(


### PR DESCRIPTION

## New feature implementation

### Implemented feature

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

Ignoring waypoints that have already been passed when graph changes.

### Implementation description

<!-- Describe the approach taken to implement the feature.
Provide a link to a detailed design document and discussion of that design.
Implementations without design documentation will not be accepted until design documentation has been provided and discussed.
Usually this is done via the feature request issue. -->

When the graph changes due to a lane closure, the robot checks whether the affected lane is part of the current execution plan, even if it has already passed through it.
In this implementation, each waypoint’s scheduled time `wp.time()` is compared with the current time `now`. If a waypoint’s time is earlier than the current time, it is considered “passed,” and lane closure checks related to that waypoint are skipped.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI


