### PR TITLE
Fix double coordinate transformation during action execution

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -167,32 +167,13 @@ public:
       if (!context)
         return;
 
-      const auto nav_params = context->nav_params();
-      if (nav_params)
-      {
-        if (const auto p = nav_params->to_rmf_coordinates(map, location))
-        {
-          location = *p;
-        }
-        else
-        {
-          RCLCPP_ERROR(
-            context->node()->get_logger(),
-            "[EasyFullControl] Unable to find a robot transform for map [%s] "
-            "while updating the location of robot [%s] performing an activity. "
-            "We cannot update the robot's location.",
-            map.c_str(),
-            context->requester_id().c_str());
-          return;
-        }
-      }
-
       if (schedule_override.has_value())
       {
         return schedule_override->overridden_update(
           context, map, location);
       }
 
+      const auto nav_params = context->nav_params();
       if (nav_params)
       {
         if (context->debug_positions)


### PR DESCRIPTION
## Bug fix
This pull request fixes #492.

### Fixed bug
Robot position was being incorrectly transformed twice during action execution, causing position misalignment. The coordinate transformation (to_rmf_coordinates()) was called both in EasyRobotUpdateHandle::update() and again in ActionExecution::Data::update_location(), resulting in incorrect robot location updates.


### Fix applied
Removed the redundant to_rmf_coordinates() call from ActionExecution::Data::update_location() in internal_RobotUpdateHandle.hpp. The location is already in RMF coordinates when this function is called, as the transformation is performed earlier in the call chain.

