### PR TITLE
Accurate GoToPlace task update and reservation fixes

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/ReservationManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/ReservationManager.cpp
@@ -33,6 +33,11 @@ void ReservationManager::replace_ticket(
   {
     if (new_allocation.ticket.ticket_id != _allocation->ticket.ticket_id)
     {
+      // Do not publish release request if this is a re-allocation
+      if (new_allocation.resource == _allocation->resource)
+      {
+        return;
+      }
       RCLCPP_INFO(
         context->node()->get_logger(),
         "Releasing waypoint for ticket %lu as new ticket has become available",

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/internal_ReservationNodeNegotiator.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/internal_ReservationNodeNegotiator.hpp
@@ -150,16 +150,8 @@ public:
             return;
           }
 
-          if (self->_final_allocated_destination.has_value() && 
-              self->_final_allocated_destination.value()->resource == msg->resource)
-          {
-            // Do nothing
-          }
-          else
-          {
-            self->_context->_set_allocated_destination(*msg.get());
-          }
           self->_final_allocated_destination = msg;
+          self->_context->_set_allocated_destination(*msg.get());
 
           if (msg->instruction_type
           == rmf_reservation_msgs::msg::ReservationAllocation::IMMEDIATELY_PROCEED)

--- a/rmf_reservation_node/src/main.cpp
+++ b/rmf_reservation_node/src/main.cpp
@@ -177,6 +177,7 @@ public:
       positions[requests[i].location] = i;
     }
 
+    auto request_ticket = ticket_store.get_existing_ticket(ticket_id);
     std::sort(requests.begin(), requests.end());
     for (std::size_t i = 0; i < requests.size(); i++)
     {
@@ -196,18 +197,38 @@ public:
         _ticket_to_location.emplace(ticket_id, requests[i].location);
         return positions[parking->first];
       }
-      // Check if the requester already occupies one of the waitpoints
+    }
+
+    // If there is no free spot found, check if the robot is already sitting on
+    // one of the spot requested, re-allocate it
+    for (auto& it : _current_location_reservations)
+    {
+      if (!it.second.ticket.has_value())
+      {
+        continue;
+      }
       auto existing_ticket = ticket_store.get_existing_ticket(
-        parking->second.ticket.value());
-      auto request_ticket = ticket_store.get_existing_ticket(ticket_id);
+        it.second.ticket.value());
       if (existing_ticket.header.fleet_name == request_ticket.header.fleet_name &&
           existing_ticket.header.robot_name == request_ticket.header.robot_name)
       {
-        // Release the previous ticket for the same waitpoint and update with the current ticket
-        release(parking->second.ticket.value());
-        _current_location_reservations[requests[i].location].ticket = ticket_id;
-        _ticket_to_location.emplace(ticket_id, requests[i].location);
-        return positions[parking->first];
+        if (positions.find(it.first) == positions.end())
+        {
+          continue;
+        }
+        // Release the previous ticket for the same waitpoint and update with
+        // the current ticket
+        RCLCPP_INFO(node->get_logger(),
+          "Robot [%s] is already sitting on waitspot [%s], re-allocating it to "
+          "the same robot. Replacing ticket %lu with ticket %lu.",
+          request_ticket.header.robot_name.c_str(),
+          it.first.c_str(),
+          existing_ticket.ticket_id,
+          ticket_id);
+        release(it.second.ticket.value());
+        it.second.ticket = ticket_id;
+        _ticket_to_location.emplace(ticket_id, it.first);
+        return positions[it.first];
       }
     }
 
@@ -457,9 +478,10 @@ private:
       allocation.resource =
         requests_[request->ticket.ticket_id][result.value()].location;
 
-      RCLCPP_DEBUG(this->get_logger(), "Allocating %s to %s",
+      RCLCPP_DEBUG(this->get_logger(), "Allocating %s to %s with ticket %lu",
         allocation.resource.c_str(),
-        ticket_store_.debug_ticket(request->ticket.ticket_id).c_str());
+        ticket_store_.debug_ticket(request->ticket.ticket_id).c_str(),
+        allocation.ticket.ticket_id);
       allocation_pub_->publish(allocation);
       return;
     }
@@ -507,9 +529,10 @@ private:
         rmf_reservation_msgs::msg::ReservationAllocation::WAIT_IDENTIFIED;
       allocation.chosen_alternative = waitpoint_result.value();
       allocation.resource = wait_points[waitpoint_result.value()].location;
-      RCLCPP_INFO(this->get_logger(), "Allocating %s as waitpoint to %s",
+      RCLCPP_INFO(this->get_logger(), "Allocating %s as waitpoint to %s with ticket %lu",
         allocation.resource.c_str(),
-        ticket_store_.debug_ticket(request->ticket.ticket_id).c_str());
+        ticket_store_.debug_ticket(request->ticket.ticket_id).c_str(),
+        allocation.ticket.ticket_id);
       allocation_pub_->publish(allocation);
     }
     else
@@ -531,9 +554,7 @@ private:
     if (!previous_waiting_location.has_value())
     {
       RCLCPP_ERROR(
-        this->get_logger(),
-        "Could not find ticket %lu. It may have been released "
-        "in favor of a duplicate reservation request.",
+        this->get_logger(), "Could not find ticket %lu. Something is wrong.",
         request->ticket.ticket_id);
       return;
     }


### PR DESCRIPTION
This PR addresses https://github.com/open-rmf/rmf_demos/issues/342 with the following fixes:
- Ensures that the task status is reflected correctly during reservation-related go to place tasks
- Check whether the requester is already sitting on a valid parking spot before reporting that there are no free waitpoints available