### PR TITLE
Publish WaitForCharge phase completed

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -168,9 +168,8 @@ std::shared_ptr<LegacyTask::ActivePhase> WaitForCharge::Pending::begin()
         {
           StatusMsg msg;
           msg.state = msg.STATE_COMPLETED;
-          msg.status = "Completed phase [Charging ["
-            + active->_context->requester_id() + "] to "
-            + std::to_string(100.0 * *active->_charge_to_soc) + "]";
+          msg.status = "Reached target battery charge of "
+            + std::to_string(100.0 * *active->_charge_to_soc);
           active->_status_publisher.get_subscriber().on_next(msg);
 
           active->_status_publisher.get_subscriber().on_completed();


### PR DESCRIPTION
Targets https://github.com/open-rmf/rmf_demos/issues/343

Currently when a robot is assigned a Charge task (as finishing request or as emergency charging when its battery SOC falls below a threshold), the task would begin and ends only when
- The robot has sufficient battery to start on its next queued task, OR
- The robot has charged up to the [recharge_soc](https://github.com/open-rmf/rmf_demos/blob/main/rmf_demos/config/office/tinyRobot_config.yaml#L26)

When the Charge task ends, its Status remains in `Standby` instead of being marked as `Completed`. While this does not affect the robot's behavior (it can still proceed to execute subsequent tasks), the task status is reflected on the web dashboard and can be misleading. Over time the dashboard's Tasks tab can look like this, with the Charge tasks unresolved:
<img width="1104" height="790" alt="image" src="https://github.com/user-attachments/assets/9ceb21a4-e93a-40ab-9ee2-184cfe32da4c" />
(Charge tasks are those dated 1 Jan 1970)

This PR publishes a final StatusMsg to mark WaitForCharge with `STATE_COMPLETED` before moving onto the next phase.