### PR TITLE
Resolve compilation warnings

### DIFF
--- a/rmf_fleet_adapter/src/close_lanes/main.cpp
+++ b/rmf_fleet_adapter/src/close_lanes/main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
     for (const auto& f : failed_conversions)
       extra_message += " " + std::to_string(f);
 
-    extra_message + " into integers";
+    extra_message += " into integers";
     return help(extra_message);
   }
 

--- a/rmf_fleet_adapter/src/open_lanes/main.cpp
+++ b/rmf_fleet_adapter/src/open_lanes/main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
     for (const auto& f : failed_conversions)
       extra_message += " " + std::to_string(f);
 
-    extra_message + " into integers";
+    extra_message += " into integers";
     return help(extra_message);
   }
 

--- a/rmf_fleet_adapter/src/read_only_blockade/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/read_only_blockade/FleetAdapterNode.cpp
@@ -202,7 +202,11 @@ void FleetAdapterNode::register_robot(const RobotState& state)
             const rmf_traffic::Duration t)
           {
             *negotiated_delay += t;
-            participant->delay(t);
+            const auto plan_id = participant->current_plan_id();
+            const auto current =
+              participant->cumulative_delay(plan_id)
+              .value_or(rmf_traffic::Duration(0));
+            participant->cumulative_delay(plan_id, current + t);
             return participant->version();
           };
 
@@ -319,7 +323,12 @@ void FleetAdapterNode::update_robot(
       {
         // The robot is still at the same location that it was in last time, so
         // we can just add a delay to the schedule
-        robot->schedule->delay(make_delay(*robot->schedule, now));
+        const auto plan_id = robot->schedule->current_plan_id();
+        const auto current =
+          robot->schedule->cumulative_delay(plan_id)
+          .value_or(rmf_traffic::Duration(0));
+        robot->schedule->cumulative_delay(
+          plan_id, current + make_delay(*robot->schedule, now));
         return;
       }
     }
@@ -614,7 +623,10 @@ void FleetAdapterNode::update_arrival(
     rmf_traffic::agv::Interpolate::positions(_traits, now, input_positions)
     .back().time();
 
-  const auto current_delay = robot.schedule->delay();
+  const auto sched_plan_id = robot.schedule->current_plan_id();
+  const auto current_delay =
+    robot.schedule->cumulative_delay(sched_plan_id)
+    .value_or(rmf_traffic::Duration(0));
   const auto planned_time = robot.expectation->timing.at(next_waypoint);
   const auto previously_expected_arrival = planned_time + current_delay;
   const auto new_delay = newly_expected_arrival - previously_expected_arrival;
@@ -640,7 +652,10 @@ void FleetAdapterNode::update_delay(
     new_delay = 0s;
   }
 
-  robot.schedule->delay(new_delay);
+  const auto plan_id = robot.schedule->current_plan_id();
+  const auto current =
+    robot.schedule->cumulative_delay(plan_id).value_or(rmf_traffic::Duration(0));
+  robot.schedule->cumulative_delay(plan_id, current + new_delay);
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.cpp
@@ -71,7 +71,10 @@ void ScheduleManager::push_routes(const std::vector<rmf_traffic::Route>& routes)
 //==============================================================================
 void ScheduleManager::push_delay(const rmf_traffic::Duration duration)
 {
-  _participant.delay(duration);
+  const auto plan_id = _participant.current_plan_id();
+  const auto current =
+    _participant.cumulative_delay(plan_id).value_or(rmf_traffic::Duration(0));
+  _participant.cumulative_delay(plan_id, current + duration);
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyFullControl.cpp
@@ -1806,7 +1806,6 @@ void EasyCommandHandle::dock(
       lane.properties().speed_limit(),
       wp0.in_lift());
 
-    const double w = std::max(traits.rotational().get_nominal_velocity(), 0.001);
     queue.push_back(
       EasyFullControl::CommandExecution::Implementation::make(
         context,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -408,7 +408,7 @@ public:
       {
         RCLCPP_ERROR(
           node->get_logger(),
-          "[AllocateTasks] Unable to find a robot associated with index [%d]",
+          "[AllocateTasks] Unable to find a robot associated with index [%zu]",
           i);
         continue;
       }
@@ -922,7 +922,7 @@ double FleetUpdateHandle::Implementation::compute_cost(
 {
   rmf_task::TaskPlanner::Assignments raw_assignments;
   raw_assignments.reserve(assignments.size());
-  for (const auto [_, queue] : assignments)
+  for (const auto& [_, queue] : assignments)
   {
     raw_assignments.push_back(queue);
   }
@@ -1452,7 +1452,7 @@ public:
   void execute(const LiftSessionEnd&) override {}
   void execute(const LiftMove&) override {}
   void execute(const Wait&) override {}
-  void execute(const Dock& dock) override {}
+  void execute(const Dock& /*dock*/) override {}
   void execute(const LiftSessionBegin& info) override
   {
     lift = info.lift_name();
@@ -1486,8 +1486,6 @@ std::vector<std::size_t> find_emergency_lift_closures(
     if (const auto* event = lane.exit().event())
       event->execute(executor);
 
-    const auto wp0 = lane.entry().waypoint_index();
-    const auto wp1 = lane.exit().waypoint_index();
     if (executor.enter)
     {
       if (emergency_level_for_lift.count(executor.lift) > 0)
@@ -2570,7 +2568,7 @@ FleetUpdateHandle::retreat_to_charger_interval() const
 
 //==============================================================================
 FleetUpdateHandle& FleetUpdateHandle::set_retreat_to_charger_interval(
-  std::optional<rmf_traffic::Duration> duration)
+  std::optional<rmf_traffic::Duration> /*duration*/)
 {
   RCLCPP_WARN(
     _pimpl->node->get_logger(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<Node> Node::make(
 
   node->_target_emergency_notice_obs =
     node->create_observable<TargetEmergencyNotice>(
-    "emergency_signal", transient_qos);
+    rmf_traffic_ros2::EmergencySignalTopicName, transient_qos);
 
   node->_ingestor_request_pub =
     node->create_publisher<IngestorRequest>(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -72,11 +72,11 @@ std::shared_ptr<Node> Node::make(
 
   node->_emergency_notice_obs =
     node->create_observable<EmergencyNotice>(
-    rmf_traffic_ros2::EmergencyTopicName, transient_qos);
+    "fire_alarm_trigger", transient_qos);
 
   node->_target_emergency_notice_obs =
     node->create_observable<TargetEmergencyNotice>(
-    rmf_traffic_ros2::EmergencySignalTopicName, transient_qos);
+    "emergency_signal", transient_qos);
 
   node->_ingestor_request_pub =
     node->create_publisher<IngestorRequest>(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<Node> Node::make(
 
   node->_emergency_notice_obs =
     node->create_observable<EmergencyNotice>(
-    "fire_alarm_trigger", transient_qos);
+    rmf_traffic_ros2::EmergencyTopicName, transient_qos);
 
   node->_target_emergency_notice_obs =
     node->create_observable<TargetEmergencyNotice>(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -280,15 +280,15 @@ public:
   rclcpp::TimerBase::SharedPtr fleet_state_update_timer = nullptr;
   rclcpp::TimerBase::SharedPtr memory_trim_timer = nullptr;
 
-  rxcpp::subscription emergency_sub;
-  rxcpp::subscription target_emergency_sub;
-  rxcpp::subjects::subject<bool> emergency_publisher;
-  rxcpp::observable<bool> emergency_obs;
+  rxcpp::subscription emergency_sub = {};
+  rxcpp::subscription target_emergency_sub = {};
+  rxcpp::subjects::subject<bool> emergency_publisher = {};
+  rxcpp::observable<bool> emergency_obs = {};
   bool emergency_active = false;
   // When an emergency (fire alarm) is active, this map says which level each
   // lift will "home" to (if any).
-  std::unordered_map<std::string, std::string> emergency_level_for_lift;
-  SharedPlanner emergency_planner;
+  std::unordered_map<std::string, std::string> emergency_level_for_lift = {};
+  SharedPlanner emergency_planner = nullptr;
 
   rclcpp::Subscription<rmf_fleet_msgs::msg::ChargingAssignments>::SharedPtr
     charging_assignments_sub = nullptr;
@@ -297,7 +297,7 @@ public:
   // Keep track of charging assignments for robots that have not been registered
   // yet.
   std::unordered_map<std::string, ChargingAssignment>
-  unregistered_charging_assignments;
+  unregistered_charging_assignments = {};
 
   using DockParamMap =
     std::unordered_map<
@@ -323,9 +323,9 @@ public:
   // This is checked before and after the task reassignment procedure to ensure
   // that no new task came in from the dispatcher while the reassignment was
   // being calculated.
-  std::string last_bid_assignment;
-  std::vector<rmf_task::ConstRequestPtr> unassigned_requests;
-  rxcpp::schedulers::worker reassignment_worker;
+  std::string last_bid_assignment = {};
+  std::vector<rmf_task::ConstRequestPtr> unassigned_requests = {};
+  rxcpp::schedulers::worker reassignment_worker = {};
 
   using BidNoticeMsg = rmf_task_msgs::msg::BidNotice;
 
@@ -351,11 +351,11 @@ public:
   std::unordered_map<std::size_t, double> speed_limited_lanes = {};
   std::unordered_set<std::size_t> closed_lanes = {};
 
-  std::shared_ptr<AllocateTasks> calculate_bid;
-  rmf_rxcpp::subscription_guard calculate_bid_subscription;
+  std::shared_ptr<AllocateTasks> calculate_bid = nullptr;
+  rmf_rxcpp::subscription_guard calculate_bid_subscription = {};
 
-  rclcpp::TimerBase::SharedPtr memory_utilization_timer;
-  std::optional<std::size_t> planner_cache_reset_size;
+  rclcpp::TimerBase::SharedPtr memory_utilization_timer = nullptr;
+  std::optional<std::size_t> planner_cache_reset_size = std::nullopt;
 
   template<typename... Args>
   static std::shared_ptr<FleetUpdateHandle> make(Args&&... args)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ExecutePlan.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/ExecutePlan.cpp
@@ -90,7 +90,7 @@ MakeStandby make_wait_for_mutex(
   const rmf_task_sequence::Event::AssignIDPtr& id,
   const LockMutexGroup::Data& data)
 {
-  return [context, id, data](UpdateFn update)
+  return [context, id, data](UpdateFn /*update*/)
     {
       return LockMutexGroup::Standby::make(context, id, data);
     };
@@ -606,7 +606,7 @@ public:
   std::string current_name;
   bool still_using = false;
 
-  void execute(const Dock& dock) final {}
+  void execute(const Dock& /*dock*/) final {}
   void execute(const Wait&) final {}
   void execute(const DoorOpen&) final {}
   void execute(const DoorClose&) final {}
@@ -647,7 +647,7 @@ public:
   std::string current_name;
   bool still_using;
 
-  void execute(const Dock& dock) final {}
+  void execute(const Dock& /*dock*/) final {}
   void execute(const Wait&) final {}
   void execute(const DoorOpen& open) final
   {
@@ -659,10 +659,10 @@ public:
     if (close.name() == current_name)
       still_using = true;
   }
-  void execute(const LiftSessionBegin& e) final {}
-  void execute(const LiftMove& e) final {}
-  void execute(const LiftDoorOpen& e) final {}
-  void execute(const LiftSessionEnd& e) final {}
+  void execute(const LiftSessionBegin& /*e*/) final {}
+  void execute(const LiftMove& /*e*/) final {}
+  void execute(const LiftDoorOpen& /*e*/) final {}
+  void execute(const LiftSessionEnd& /*e*/) final {}
 };
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/LockMutexGroup.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/LockMutexGroup.cpp
@@ -161,9 +161,6 @@ LockMutexGroup::Active::Active(Data data)
 void LockMutexGroup::Active::_initialize()
 {
   _state->update_status(State::Status::Underway);
-  using MutexGroupStatesPtr =
-    std::shared_ptr<rmf_fleet_msgs::msg::MutexGroupStates>;
-
   _remaining = _data.mutex_groups;
   for (const auto& [locked, _] : _context->locked_mutex_groups())
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DoorOpen.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DoorOpen.cpp
@@ -128,16 +128,23 @@ void DoorOpen::ActivePhase::_init_obs()
           // supervisor sees our request.
           me->_publish_open_door();
 
+          const auto plan_id =
+            me->_context->itinerary().current_plan_id();
+          const auto current_cumulative =
+            me->_context->itinerary().cumulative_delay(plan_id)
+            .value_or(rmf_traffic::Duration(0));
           const auto current_expected_finish =
-          me->_expected_finish + me->_context->itinerary().delay();
+            me->_expected_finish + current_cumulative;
 
           const auto delay = me->_context->now() - current_expected_finish;
           if (delay > std::chrono::seconds(0))
           {
             me->_context->worker().schedule(
-              [context = me->_context, delay](const auto&)
+              [context = me->_context, plan_id, current_cumulative, delay](
+                const auto&)
               {
-                context->itinerary().delay(delay);
+                context->itinerary().cumulative_delay(
+                  plan_id, current_cumulative + delay);
               });
           }
         });

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DoorOpen.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/DoorOpen.cpp
@@ -139,12 +139,12 @@ void DoorOpen::ActivePhase::_init_obs()
           const auto delay = me->_context->now() - current_expected_finish;
           if (delay > std::chrono::seconds(0))
           {
+            const auto new_cumulative = current_cumulative + delay;
             me->_context->worker().schedule(
-              [context = me->_context, plan_id, current_cumulative, delay](
+              [context = me->_context, plan_id, new_cumulative](
                 const auto&)
               {
-                context->itinerary().cumulative_delay(
-                  plan_id, current_cumulative + delay);
+                context->itinerary().cumulative_delay(plan_id, new_cumulative);
               });
           }
         });

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.cpp
@@ -150,8 +150,8 @@ MoveRobot::Action::Action(
   rmf_traffic::PlanId plan_id,
   std::optional<rmf_traffic::Duration> tail_period)
 : _context{context},
-  _has_nav_elements(false),
   _waypoints{waypoints},
+  _has_nav_elements(false),
   _plan_id{plan_id},
   _tail_period{tail_period}
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
@@ -302,10 +302,6 @@ void MoveRobot::Action::operator()(const Subscriber& s)
               std::unordered_set<std::string> retain_mutexes;
               for (const auto& wp : self->_waypoints)
               {
-                const auto s_100 =
-                (int)(rmf_traffic::time::to_seconds(adjusted_now -
-                wp.time()) * 100);
-                const auto s = (double)(s_100)/100.0;
                 if (wp.time() < adjusted_now)
                 {
                   continue;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/WaitForCharge.cpp
@@ -122,11 +122,11 @@ _reservation_client = std::move(reservation::ReservationNodeNegotiator::make(
           _context,
           std::vector<rmf_traffic::agv::Plan::Goal>{ charging_waypoint},
           true,
-          [](const rmf_traffic::agv::Plan::Goal& goal)
+          [](const rmf_traffic::agv::Plan::Goal& /*goal*/)
           {
             // Do Nothing
           },
-          [](const rmf_traffic::agv::Plan::Goal& goal)
+          [](const rmf_traffic::agv::Plan::Goal& /*goal*/)
           {
             // Do Nothing
           }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/ChargeBattery.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/ChargeBattery.cpp
@@ -492,7 +492,7 @@ public:
           [
             assign_id = _assign_id,
             context = _context
-          ](UpdateFn update) -> StandbyPtr
+          ](UpdateFn /*update*/) -> StandbyPtr
           {
             return events::WaitForCancel::Standby::make(context, assign_id);
           });
@@ -677,7 +677,6 @@ void add_charge_battery(
   rmf_task_sequence::Event::Initializer& event_initializer,
   std::function<rmf_traffic::Time()> clock)
 {
-  using Bundle = rmf_task_sequence::events::Bundle;
   using Phase = rmf_task_sequence::phases::SimplePhase;
   using ChargeBatteryTask = rmf_task::requests::ChargeBattery;
 

--- a/rmf_fleet_adapter/test/tasks/test_Loop.cpp
+++ b/rmf_fleet_adapter/test/tasks/test_Loop.cpp
@@ -149,16 +149,12 @@ SCENARIO("Test loop requests", "[.flaky]")
   auto task_0_completed_future = task_0_completed_promise.get_future();
   std::size_t completed_0_count = 0;
   bool at_least_one_incomplete_task_0 = false;
-  std::size_t finding_a_plan_0_count = 0;
-  std::vector<std::string> finding_a_plan_0_statuses;
 
   const std::string loop_1 = "loop_1";
   std::promise<bool> task_1_completed_promise;
   auto task_1_completed_future = task_1_completed_promise.get_future();
   std::size_t completed_1_count = 0;
   bool at_least_one_incomplete_task_1 = false;
-  std::size_t finding_a_plan_1_count = 0;
-  std::vector<std::string> finding_a_plan_1_statuses;
 
   /// Mock Task State observer server, This checks the task_state
   /// of the targeted task id, by listening to the task_state_update

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -55,6 +55,7 @@ std::unordered_map<std::string, ConsiderRequest> convert(
       confirm = consider(description);
     };
   }
+  return output;
 }
 
 using ActivityIdentifier = agv::RobotUpdateHandle::ActivityIdentifier;

--- a/rmf_fleet_adapter_python/src/schedule/schedule.cpp
+++ b/rmf_fleet_adapter_python/src/schedule/schedule.cpp
@@ -34,10 +34,16 @@ void bind_schedule(py::module& m)
     "current_plan_id",
     &schedule::Participant::current_plan_id)
   .def_property("delay",
-    py::overload_cast<>(
-      &schedule::Participant::delay, py::const_),
-    py::overload_cast<
-      rmf_traffic::Duration>(&schedule::Participant::delay))
+    [](const schedule::Participant& p) {
+      return p.cumulative_delay(p.current_plan_id())
+        .value_or(rmf_traffic::Duration(0));
+    },
+    [](schedule::Participant& p, rmf_traffic::Duration d) {
+      const auto plan_id = p.current_plan_id();
+      const auto current =
+        p.cumulative_delay(plan_id).value_or(rmf_traffic::Duration(0));
+      p.cumulative_delay(plan_id, current + d);
+    })
   .def("clear", &schedule::Participant::clear)
   .def("get_itinerary", &schedule::Participant::itinerary)
   .def("set_itinerary",

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
@@ -78,6 +78,7 @@ const std::string BlockadeSetTopicName = Prefix +
 
 [[deprecated("Use EmergencySignalTopicName with the rmf_fleet_msgs/EmergencySignal message instead")]]
 const std::string EmergencyTopicName = "fire_alarm_trigger";
+
 const std::string EmergencySignalTopicName = "emergency_signal";
 
 } // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Negotiation.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Negotiation.cpp
@@ -1171,7 +1171,7 @@ public:
     const TableViewerPtr& table_viewer,
     const ResponderPtr& responder) final
   {
-    _respond(std::move(table_viewer), std::move(responder));
+    _respond(table_viewer, responder);
   }
 
 private:

--- a/rmf_traffic_ros2/test/mock_participants/repetitive_delay_participant.cpp
+++ b/rmf_traffic_ros2/test/mock_participants/repetitive_delay_participant.cpp
@@ -67,7 +67,10 @@ int main(int argc, char* argv[])
       }
 
       std::cout << "Applying delay" << std::endl;
-      participant->delay(1s);
+      const auto plan_id = participant->current_plan_id();
+      const auto current =
+        participant->cumulative_delay(plan_id).value_or(rmf_traffic::Duration(0));
+      participant->cumulative_delay(plan_id, current + 1s);
     });
 
   rclcpp::spin(node);

--- a/rmf_websocket/src/rmf_websocket/BroadcastClient.cpp
+++ b/rmf_websocket/src/rmf_websocket/BroadcastClient.cpp
@@ -39,10 +39,10 @@ public:
     const std::shared_ptr<rclcpp::Node>& node,
     ProvideJsonUpdates get_json_updates_cb)
   : _uri{std::move(uri)},
-    _node{std::move(node)},
-    _get_json_updates_cb{std::move(get_json_updates_cb)},
-    _queue(1000),
     _io_service{},
+    _node{std::move(node)},
+    _queue(1000),
+    _get_json_updates_cb{std::move(get_json_updates_cb)},
     _endpoint(_uri,
       _node,
       &_io_service,


### PR DESCRIPTION
## Bug fix

### Fixed bug

Taking inspiration from https://github.com/open-rmf/rmf_traffic/pull/132, I performed source builds of Open-RMF and asked the agent to list out compilation warnings with easy and non-intrusive fixes throughout the code base.

More PRs will be opened in other repositories.

### Fix applied

* typos, syntax issues, re-ordering of initialization
* missing references, unused parameters or variables
* unnecessary `std::move` calls
* uninitialized members
* instead of using variables that have been marked `deprecated`, use string literals instead
* replacing the use of deprecated `.delay(...)` with `.cumulative_delay(...)`, as mentioned in https://github.com/open-rmf/rmf_traffic/blob/d5de7f3a982bd503a7424255a74362337b1fe584/rmf_traffic/include/rmf_traffic/schedule/Participant.hpp#L80
  * this change was slightly more involved, so should be reviewed carefully, just in case I am misusing the `.cumulative_delay(...)` API

I've skipped any of the required changes that were too intrusive to reduce the compiler warnings.

Overall stats regarding compilation warnings that were not related to thirdparty libraries or vendored libraries,
* compilation warnings on main: ~187
* after fixes throughout codebase: ~86
* reduced 101 warnings (-54%)

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [x] I used a GenAI tool in this PR.
- [ ] I did not use GenAI

Generated-by: Claude Sonnet 4.6
