### PR TITLE
Force C++-17 for rmf_websocket

### DIFF
--- a/rmf_websocket/CMakeLists.txt
+++ b/rmf_websocket/CMakeLists.txt
@@ -2,9 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rmf_websocket)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+# Websocketpp is not compatible with CXX above 17
+set(CMAKE_CXX_STANDARD 17)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # we dont use add_compile_options with pedantic in message packages
   # because the Python C extensions dont comply with it


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fix builds of `rmf_websocket` for rolling by forcing it to build under C++-17.

### Fix applied

Discussion on Zulip [#Open-RMF PMC (Restricted posting) > rmf_websocket broken on Rolling](https://openrobotics.zulipchat.com/#narrow/channel/526047-Open-RMF-PMC-.28Restricted-posting.29/topic/rmf_websocket.20broken.20on.20Rolling/with/590356684)
ROS with Lyrical is moving to default to C++-20. This doesn't work for `rmf_websocket` since the underlying library does not compile with C++-20 (there is an [open PR](https://github.com/zaphoyd/websocketpp/pull/1182) for this to be fixed but the upstream repository doesn't see much activity.
I just changed the build to enforce C++-17.

### Test it!

Just try to build the library with C++-20 (which is what ament_cmake_ros package will do by default from now on, _I believe_):

```
$ colcon build --packages-up-to rmf_websocket --cmake-args -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON
```

It should fail before this PR, succeed afterwards.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI