### PR TITLE
Make expected_finish_state reflect cumulative delay

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -288,6 +288,14 @@ const std::string& TaskManager::ActiveTask::id() const
   return _task->tag()->booking()->id();
 }
 
+//==============================================================================
+rmf_traffic::Duration TaskManager::ActiveTask::estimate_remaining_time() const
+{
+  if (!_task)
+    return rmf_traffic::Duration(0);
+  return _task->estimate_remaining_time();
+}
+
 namespace {
 
 //==============================================================================
@@ -856,6 +864,20 @@ auto TaskManager::expected_finish_state() const -> State
   if (!_direct_queue.empty())
   {
     rmf_task::State return_state = _direct_queue.rbegin()->assignment.finish_state();
+    if (_active_task && return_state.time().has_value())
+    {
+      // Shift the last queued direct task's finish time forward by the current active
+      // task's accumulated delay.
+      const auto projected_active_end =
+        _context->now() + _active_task.estimate_remaining_time();
+      const auto planned_active_end = _context->current_task_end_state().time();
+      if (planned_active_end.has_value()
+        && projected_active_end > *planned_active_end)
+      {
+        const auto shift = projected_active_end - *planned_active_end;
+        return_state.time(*return_state.time() + shift);
+      }
+    }
     return_state.idle(false);
     return return_state;
   }
@@ -863,6 +885,8 @@ auto TaskManager::expected_finish_state() const -> State
   if (_active_task)
   {
     rmf_task::State return_state = _context->current_task_end_state();
+    const auto t = _context->now() + _active_task.estimate_remaining_time();
+    return_state.time(t);
     return_state.idle(false);
     return return_state;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -298,6 +298,8 @@ private:
 
     bool is_finished() const;
 
+    rmf_traffic::Duration estimate_remaining_time() const;
+
     // Any unknown tokens that were included will be returned
     std::vector<std::string> remove_interruption(
       std::vector<std::string> for_tokens,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/events/GoToPlace.cpp
@@ -349,7 +349,22 @@ rmf_traffic::Duration GoToPlace::Active::remaining_time_estimate() const
     if (_execution->plan_id)
     {
       if (const auto delay = itin.cumulative_delay(*_execution->plan_id))
-        return finish - now + *delay;
+      {
+        // Parabolic frustration penalty (delay^2 / reference_delay):
+        // zero at zero delay, matches delay at reference_delay,
+        // grows much faster beyond.
+        // Used so remaining_time_estimate keeps growing with the stall
+        // instead of staying flat, which makes the task planner less likely
+        // to assign new tasks to robots stuck on lift/door/mutex events.
+        const auto reference_delay = std::chrono::seconds(60);
+        const double delay_s =
+          std::max(0.0, rmf_traffic::time::to_seconds(*delay));
+        const double reference_delay_s =
+          rmf_traffic::time::to_seconds(reference_delay);
+        const auto frustration_penalty =
+          rmf_traffic::time::from_seconds(delay_s * delay_s / reference_delay_s);
+        return finish - now + *delay + frustration_penalty;
+      }
     }
     else
     {


### PR DESCRIPTION
## Improvement

### Improved feature

This improvement addresses: #515.

`TaskManager::expected_finish_state()` is now delay-aware, and `GoToPlace::remaining_time_estimate()` includes a parabolic frustration penalty during long stalls.

### Improvement description
In existing RMF, a robot stuck at a mutex/lift/door can still be picked for new tasks even though it has a long delay in its  active task.

This happens because `TaskManager::expected_finish_state()` returns the optimistic dispatch-time finish, which drifts into the past during stalls, so the task planner treats the stuck robot as "nearly free" and available. See the issue thread for the full discussion and design decisions.

Summary of changes:
- Route `TaskManager::expected_finish_state()` through a new `ActiveTask::estimate_remaining_time()` accessor that delegates to `Task::Active::estimate_remaining_time()`. The `_active_task` branch returns `(now + remaining)`, while the `_direct_queue` branch shifts queued finish times forward by the active task's accumulated delay.
- Add a parabolic frustration penalty (`delay² / reference_delay`, `reference_delay = 60s`) in `GoToPlace::remaining_time_estimate()` so the estimate keeps growing during long stalls.

### How to Test

#### Setup

1. Use this modified office map for testing: https://github.com/kjchee/rmf_demos/blob/fix/expected-finish-state-delay-aware/rmf_demos_maps/maps/office/office.building.yaml

    <img width="1045" height="933" alt="fix_task_end_state" src="https://github.com/user-attachments/assets/6068af05-3907-469e-8771-a721c9099874" />

2. Set `finishing_request: nothing` so the robot stays where it is during launch (otherwise tinyRobot1 will be sent to `supplies`).
3. Manually turn off `mutex_group_supervisor` by commenting it out in `common.launch.xml` to let the robot get stuck at the mutex.

#### Steps (same for Before/After)

1. Launch office:
   ```bash
   ros2 launch rmf_demos_gz office.launch.xml
   ```
2. Send a patrol task to waypoint `patrol_D1`:
   ```bash
   ros2 run rmf_demos_tasks dispatch_patrol -p patrol_D1 --use_sim_time
   ```
3. RMF assigns the task to `tinyRobot1`.
4. When `tinyRobot1` reaches waypoint `mutex_entry` (and gets stuck), send a 2nd patrol task to waypoint `pantry`:
   ```bash
   ros2 run rmf_demos_tasks dispatch_patrol -p pantry --use_sim_time
   ```
5. RMF assigns the 2nd task to `tinyRobot1` as well (because `expected_finish_state()` is still optimistic at this point).
6. Wait for the next `reassign_task_interval` (default 120s) and observe the reassignment behavior.

#### Before fix

At step 6: the 2nd task remains assigned to `tinyRobot1` even though it is still stuck at the mutex entry.

#### After fix

At step 6: the 2nd task is reassigned to `tinyRobot2` (even though `tinyRobot2` is physically further from `pantry`) because `tinyRobot1`'s accumulated delay + frustration penalty now makes it look more expensive to the task planner.


### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

