### PR TITLE
Fix descrption typo in robot_state_aggregator launch file

### DIFF
--- a/rmf_fleet_adapter/launch/robot_state_aggregator.composition.launch.xml
+++ b/rmf_fleet_adapter/launch/robot_state_aggregator.composition.launch.xml
@@ -7,7 +7,7 @@
   <arg name="use_sim_time" default="false" description="Use the /clock topic for time to sync with simulation"/>
   
   <arg name="subns" default="yin" description="Names the composition of nodes"/>
-  <arg name="buddy_subns" default="yang" descrption="Names the buddy composition of nodes" />
+  <arg name="buddy_subns" default="yang" description="Names the buddy composition of nodes" />
   <arg name="active_node" default="true" description="Indicates if this is the active node"/>
   <arg name="verbose" default="true" description="Extra verbosity" />
   <arg name="failover_mode" default="false" description="Sets failover mode on or off"/>


### PR DESCRIPTION
The `buddy_subns` arg declaration in this launch file uses `descrption=` instead of `description=`. ROS 2 `launch_xml` rejects unknown attributes, so the file fails to load:

```
ValueError: Unexpected attribute(s) found in `arg`: {'descrption'}
```

Verified on `ros:humble` and `ros:jazzy`: after renaming, `ros2 launch <file> -s` prints arguments normally.