### PR TITLE
Fix spelling: occured -> occurred in rmf_websocket exception logs

### DIFF
--- a/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
+++ b/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
@@ -80,7 +80,7 @@ public:
       {
         RCLCPP_ERROR_STREAM(
           _logger_interface->get_logger(),
-          "WebSocket exception occured: " << e.what());
+          "WebSocket exception occurred: " << e.what());
       }
     }
     catch (...)
@@ -88,7 +88,7 @@ public:
       if (_logger_interface)
       {
         RCLCPP_ERROR(
-          _logger_interface->get_logger(), "Unknown exception occured");
+          _logger_interface->get_logger(), "Unknown exception occurred");
       }
     }
   }


### PR DESCRIPTION
Corrects a spelling error in two exception log messages in `BroadcastServer` (`occured` → `occurred`), emitted to the ROS log via `RCLCPP_ERROR`/`RCLCPP_ERROR_STREAM`. No behavior change.