### PR TITLE
Submit bid as long as fleet name exists (in string or array)

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -520,17 +520,40 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
       });
   }
 
-  // If a fleet_name was specified in the request, only proceed if the value matches
-  // the name of this fleet.
-  if (request_msg.contains("fleet_name") &&
-    request_msg["fleet_name"].template get<std::string>() != name)
+  // If a fleet_name was specified in the request, only proceed if this
+  // fleet's name matches it. fleet_name may be a single string or an array
+  // of strings, in which case this fleet must be one of the listed names.
+  if (request_msg.contains("fleet_name"))
   {
-    RCLCPP_INFO(
-      node->get_logger(),
-      "Ignoring BidNotice request as it is for fleet [%s].",
-      request_msg["fleet_name"].template get<std::string>().c_str());
-    return;
+    const auto& fleet_name = request_msg["fleet_name"];
+    bool allowed = false;
+    if (fleet_name.is_array())
+    {
+      for (const auto& n : fleet_name)
+      {
+        if (n.template get<std::string>() == name)
+        {
+          allowed = true;
+          break;
+        }
+      }
+    }
+    else
+    {
+      allowed = fleet_name.template get<std::string>() == name;
+    }
+
+    if (!allowed)
+    {
+      RCLCPP_INFO(
+        node->get_logger(),
+        "Ignoring BidNotice request as fleet [%s] is not in the requested "
+        "fleet_name list.",
+        name.c_str());
+      return;
+    }
   }
+
 
   std::vector<std::string> errors = {};
   const auto new_request = convert(task_id, request_msg, errors);


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discourse [discussions page](https://discourse.openrobotics.org/c/open-rmf/open-rmf-general/103) or [proposals page](https://discourse.openrobotics.org/c/open-rmf/open-rmf-ideas/105).
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## New feature implementation

### Implemented feature

refer to [feature request](https://github.com/open-rmf/rmf_ros2/issues/522)

### Implementation description

Beside checking whether fleet name fully match in entire string, it shall be able to check also whether exist in string array. Another iteration is added.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [/] I used a GenAI tool in this PR.  (Claude Code Sonnet 5 for coding)
- [ ] I did not use GenAI
