### PR TITLE
Add missing include to unordered_set

### DIFF
--- a/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp
+++ b/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp
@@ -25,6 +25,7 @@
 #include <rclcpp/executors.hpp>
 
 #include <unordered_map>
+#include <unordered_set>
 #include <queue>
 #include <chrono>
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fix missing include that is now making our builds red in Rolling https://github.com/open-rmf/rmf_ros2/actions/runs/29672617827/job/88154228989.

### Fix applied

Add include for `unordered_set` that is used in the file.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI