### PR TITLE
Add Python binding for RobotUpdateHandle::release_lift

### DIFF
--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -443,7 +443,10 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def("reassign_dispatched_tasks",
     &agv::RobotUpdateHandle::reassign_dispatched_tasks)
   .def("lift_destination",
-    &agv::RobotUpdateHandle::lift_destination);
+    &agv::RobotUpdateHandle::lift_destination)
+  .def("release_lift",
+    &agv::RobotUpdateHandle::release_lift,
+    "Release any lift session currently held by this robot.");
 
   // ACTION EXECUTOR   =======================================================
   auto m_robot_update_handle = m.def_submodule("robot_update_handle");


### PR DESCRIPTION
## Summary

Add a Python binding for the existing `RobotUpdateHandle::release_lift()` API.

Python fleet adapters can inspect the current lift destination, but currently cannot explicitly release a held lift session. This binding allows Python integrations to use the same recovery API that is already available in C++.

This PR only adds the missing binding and does not change the existing lift behavior.

## Testing

- `colcon build --packages-select rmf_fleet_adapter_python`
- `colcon test --packages-select rmf_fleet_adapter_python` — 20 tests passed
- Imported the Jazzy build with Python 3.12 and confirmed `rmf_adapter.RobotUpdateHandle.release_lift` is available

## GenAI use

- [x] I used a GenAI tool in this PR.
- [ ] I did not use a GenAI tool in this PR.

Generated-by: OpenAI Codex
