### PR TITLE
Set schedule node ID when changes are explicitly requested

### DIFF
--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -1039,6 +1039,7 @@ void ScheduleNode::request_changes(
   const RequestChanges::Request::SharedPtr& request,
   const RequestChanges::Response::SharedPtr& response)
 {
+  response->node_id = node_id;
   const auto query = registered_queries.find(request->query_id);
   if (query == registered_queries.end())
   {


### PR DESCRIPTION
This fixes the issue reported by https://github.com/open-rmf/rmf_ros2/issues/537

Thanks @amerm for identifying the cause and providing the solution.