### PR TITLE
fix(python): wire maximum_delay property setters (#539)

### DIFF
--- a/rmf_fleet_adapter_python/CMakeLists.txt
+++ b/rmf_fleet_adapter_python/CMakeLists.txt
@@ -121,6 +121,7 @@ if(BUILD_TESTING)
   set(_rmf_fleet_adapter_python_tests
     tests/unit/test_geometry.py
     tests/unit/test_graph.py
+    tests/unit/test_property_setters.py
     tests/unit/test_RobotCommandHandle.py
     tests/unit/test_types.py
     tests/unit/test_vehicletraits.py

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -280,10 +280,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property("maximum_delay",
     py::overload_cast<>(
       &agv::RobotUpdateHandle::maximum_delay, py::const_),
-    [&](agv::RobotUpdateHandle& self)
-    {
-      return self.maximum_delay();
-    })
+    py::overload_cast<rmf_utils::optional<rmf_traffic::Duration>>(
+      &agv::RobotUpdateHandle::maximum_delay))
   .def("current_task_id",
     [&](agv::RobotUpdateHandle& self)
     {
@@ -650,10 +648,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property("default_maximum_delay",
     py::overload_cast<>(
       &agv::FleetUpdateHandle::default_maximum_delay, py::const_),
-    [&](agv::FleetUpdateHandle& self)
-    {
-      return self.default_maximum_delay();
-    })
+    py::overload_cast<std::optional<rmf_traffic::Duration>>(
+      &agv::FleetUpdateHandle::default_maximum_delay))
   .def("fleet_state_publish_period",
     &agv::FleetUpdateHandle::fleet_state_publish_period,
     py::arg("value"),
@@ -777,11 +773,9 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::return_value_policy::reference_internal)
   .def_property("errors",
     py::overload_cast<>(
-      &Confirmation::errors, py::const_),\
-      [&](Confirmation& self)
-    {
-      return self.errors();
-    });
+      &Confirmation::errors, py::const_),
+    py::overload_cast<std::vector<std::string>>(
+      &Confirmation::errors));
 
   // SPEED LIMIT REQUEST ===============================================
   py::class_<agv::FleetUpdateHandle::SpeedLimitRequest>(

--- a/rmf_fleet_adapter_python/tests/unit/test_property_setters.py
+++ b/rmf_fleet_adapter_python/tests/unit/test_property_setters.py
@@ -1,0 +1,42 @@
+# Regression tests for open-rmf/rmf_ros2#539:
+# broken def_property setters that accepted only `self` and raised TypeError
+# on every Python assignment.
+
+import rmf_adapter as adpt
+import rmf_adapter.fleet_update_handle as fuh
+
+
+def _setter_accepts_value(prop) -> bool:
+    """True if the pybind property setter takes a value argument (self + value).
+
+    Broken setters in this package expose docs like:
+      (arg0: SomeType) -> Optional[datetime.timedelta]
+    Fixed setters look like:
+      (arg0: SomeType, arg1: Optional[datetime.timedelta]) -> None
+    """
+    assert prop.fset is not None, "property has no setter"
+    doc = prop.fset.__doc__ or ""
+    # Count comma-separated parameters inside the leading (...) signature.
+    open_paren = doc.find("(")
+    close_paren = doc.find(")", open_paren + 1)
+    assert open_paren >= 0 and close_paren > open_paren, (
+        f"unexpected setter docstring: {doc!r}")
+    params = doc[open_paren + 1:close_paren].strip()
+    if not params:
+        return False
+    return params.count(",") >= 1
+
+
+def test_maximum_delay_setter_accepts_value():
+    assert _setter_accepts_value(adpt.RobotUpdateHandle.maximum_delay)
+
+
+def test_default_maximum_delay_setter_accepts_value():
+    assert _setter_accepts_value(adpt.FleetUpdateHandle.default_maximum_delay)
+
+
+def test_confirmation_errors_property_roundtrip():
+    """Confirmation is default-constructible; exercise the fixed errors setter."""
+    confirm = fuh.Confirmation()
+    confirm.errors = ["first", "second"]
+    assert list(confirm.errors) == ["first", "second"]


### PR DESCRIPTION
﻿## Summary
- Fix pybind `def_property` setters for `RobotUpdateHandle.maximum_delay` and `FleetUpdateHandle.default_maximum_delay` that took no value argument (every Python assignment raised `TypeError`).
- Same pattern fixed on `Confirmation.errors`.
- Add unit test covering setter arity and Confirmation round-trip.

Closes #539

## Test plan
- [ ] Build `rmf_fleet_adapter_python`
- [ ] Run `test_property_setters`
- [ ] Smoke: `handle.maximum_delay = datetime.timedelta(seconds=5)` succeeds
