### PR TITLE
Support both JSON schema validator target names

### DIFF
--- a/rmf_task_ros2/CMakeLists.txt
+++ b/rmf_task_ros2/CMakeLists.txt
@@ -27,6 +27,12 @@ find_package(nlohmann_json REQUIRED)
 find_package(nlohmann_json_schema_validator_vendor REQUIRED)
 find_package(nlohmann_json_schema_validator REQUIRED)
 
+if(TARGET nlohmann_json_schema_validator)
+  set(json_schema_validator_target nlohmann_json_schema_validator)
+else()
+  set(json_schema_validator_target nlohmann_json_schema_validator::validator)
+endif()
+
 file(GLOB_RECURSE core_lib_srcs "src/rmf_task_ros2/*.cpp")
 add_library(rmf_task_ros2 SHARED ${core_lib_srcs})
 
@@ -40,7 +46,7 @@ target_link_libraries(rmf_task_ros2
     ${rmf_task_msgs_LIBRARIES}
     ${rclcpp_LIBRARIES}
     nlohmann_json::nlohmann_json
-    nlohmann_json_schema_validator::validator
+    ${json_schema_validator_target}
 )
 
 target_include_directories(rmf_task_ros2

--- a/rmf_websocket/CMakeLists.txt
+++ b/rmf_websocket/CMakeLists.txt
@@ -25,6 +25,12 @@ find_package(Boost REQUIRED)
 find_package(Threads)
 find_package(backward_ros REQUIRED)
 
+if(TARGET nlohmann_json_schema_validator)
+  set(json_schema_validator_target nlohmann_json_schema_validator)
+else()
+  set(json_schema_validator_target nlohmann_json_schema_validator::validator)
+endif()
+
 add_subdirectory(websocketpp)
 
 add_library(rmf_websocket SHARED
@@ -38,7 +44,7 @@ target_link_libraries(rmf_websocket
     ${rclcpp_LIBRARIES}
     rmf_utils::rmf_utils
     nlohmann_json::nlohmann_json
-    nlohmann_json_schema_validator::validator
+    ${json_schema_validator_target}
   PRIVATE
     ${Boost_LIBRARIES}
     Threads::Threads


### PR DESCRIPTION
Different releases of `nlohmann_json_schema_validator` export different CMake target names. The version pinned by `nlohmann_json_schema_validator_vendor` exports the unnamespaced `nlohmann_json_schema_validator` target, while newer releases provide `nlohmann_json_schema_validator::validator`.

Select the target that is actually available in both `rmf_websocket` and `rmf_task_ros2`. This fixes clean builds against the currently vendored validator without dropping compatibility with newer validator packages.

The unnamespaced target is checked first because `rmf_task_ros2` may see an unresolved namespaced target reference transitively from `rmf_websocket`.

Signed-off-by: Wolf Vollprecht <w.vollprecht@gmail.com>