### PR TITLE
Fix phase key for skip requests

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -537,7 +537,7 @@ void TaskManager::ActiveTask::publish_task_state(TaskManager& mgr)
 
   for (const auto& [phase, skip_info] : _skip_info_map)
   {
-    auto& skip_requests = phases[phase]["skip_requests"];
+    auto& skip_requests = phases[std::to_string(phase)]["skip_requests"];
     for (const auto& s : {&skip_info.active_skips, &skip_info.removed_skips})
     {
       for (const auto& [token, msg] : *s)


### PR DESCRIPTION
## Bug fix

### Fixed bug

A recorded phase skip made `TaskManager::publish_task_state()` index the JSON `phases` object with a numeric ID. `nlohmann::json` rejects numeric indexing on an object, so the fleet adapter terminated on the next state publish.

Fixes #542.

### Fix applied

Use the same string-key convention already used by every other phase entry when attaching active and removed skip requests. This keeps the metadata under the matching published phase and avoids `type_error.305`.

### Testing

- `git diff --check`
- Full ROS/colcon tests were not run locally because the ROS toolchain is not available on this macOS host; the repository build and ASAN workflows require maintainer approval for this external-fork PR.

### GenAI Use

- [x] I used a GenAI tool in this PR.
- [ ] I did not use GenAI

Generated-by: OpenAI Codex (GPT-5)