### PR TITLE
Backport to jazzy

### DIFF
--- a/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp
+++ b/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp
@@ -25,6 +25,7 @@
 #include <rclcpp/executors.hpp>
 
 #include <unordered_map>
+#include <unordered_set>
 #include <queue>
 #include <chrono>
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyTrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyTrafficLight.cpp
@@ -522,6 +522,10 @@ void EasyTrafficLight::Implementation::Shared::update_delay(
   {
     const auto slices = state.current_itinerary_slice();
 
+    const auto existing_cumulative_delay =
+      state.itinerary->cumulative_delay(state.itinerary->current_plan_id())
+      .value_or(rmf_traffic::Duration(0));
+
     for (const auto& slice : slices)
     {
       try
@@ -530,7 +534,8 @@ void EasyTrafficLight::Implementation::Shared::update_delay(
           rmf_traffic::agv::interpolate_time_along_quadratic_straight_line(
           slice.trajectory(), location->block<2, 1>(0, 0));
 
-        new_cumulative_delay = hooks.node->rmf_now() - expected_time;
+        const auto delay_delta = hooks.node->rmf_now() - expected_time;
+        new_cumulative_delay = existing_cumulative_delay + delay_delta;
         break;
       }
       catch (const std::exception& e)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyTrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/EasyTrafficLight.cpp
@@ -253,8 +253,10 @@ auto EasyTrafficLight::Implementation::State::location() const
     return std::nullopt;
 
   const auto& g_wp = graph.get_waypoint(wp);
-  const auto p = g_wp.get_location();
-  return Location{g_wp.get_map_name(), {p[0], p[1], 0.0}};
+  const Eigen::Vector2d pos = last_known_location->location()
+    .value_or(g_wp.get_location());
+  const double yaw = last_known_location->orientation();
+  return Location{g_wp.get_map_name(), {pos[0], pos[1], yaw}};
 }
 
 //==============================================================================
@@ -1082,6 +1084,12 @@ void EasyTrafficLight::Implementation::Shared::publish_fleet_state() const
     .battery_percent(battery_soc*100.0)
     .location(std::move(location))
     .path({});
+
+  const auto& fleet_state = rmf_fleet_msgs::build<rmf_fleet_msgs::msg::FleetState>()
+    .name(fleet_name)
+    .robots({std::move(robot_state)});
+
+  hooks.fleet_state_pub->publish(fleet_state);
 }
 
 //==============================================================================

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -1031,6 +1031,7 @@ void ScheduleNode::request_changes(
   const RequestChanges::Request::SharedPtr& request,
   const RequestChanges::Response::SharedPtr& response)
 {
+  response->node_id = node_id;
   const auto query = registered_queries.find(request->query_id);
   if (query == registered_queries.end())
   {

--- a/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
+++ b/rmf_websocket/src/rmf_websocket/BroadcastServer.cpp
@@ -80,7 +80,7 @@ public:
       {
         RCLCPP_ERROR_STREAM(
           _logger_interface->get_logger(),
-          "WebSocket exception occured: " << e.what());
+          "WebSocket exception occurred: " << e.what());
       }
     }
     catch (...)
@@ -88,7 +88,7 @@ public:
       if (_logger_interface)
       {
         RCLCPP_ERROR(
-          _logger_interface->get_logger(), "Unknown exception occured");
+          _logger_interface->get_logger(), "Unknown exception occurred");
       }
     }
   }


### PR DESCRIPTION
### Backport

* #524 
* #525 
* #533 
* #535 
* #538 

This should go in only after https://github.com/open-rmf/rmf_ros2/pull/547, as rebase-and-merge

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
