### PR TITLE
fix(mutex): compare full claim_time instead of nanosec only

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -1377,7 +1377,8 @@ const rxcpp::observable<std::string>& RobotContext::request_mutex_groups(
     const auto [it, inserted] = _requesting_mutex_groups.insert({group, t});
     if (!inserted)
     {
-      if (t.nanosec < it->second.nanosec)
+      const auto& prev = it->second;
+      if (t.sec < prev.sec || (t.sec == prev.sec && t.nanosec < prev.nanosec))
         it->second = t;
     }
   }


### PR DESCRIPTION
## Summary

`request_mutex_groups()` compares only the `nanosec` field and ignores `sec` when keeping the earliest claim time:

https://github.com/open-rmf/rmf_ros2/blob/3c71d70042528892d9505511808efc40aa15b665/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp#L1377-L1382

The supervisor side does the same check correctly in `pick_next()`, comparing the whole `rclcpp::Time` value:

https://github.com/open-rmf/rmf_ros2/blob/3c71d70042528892d9505511808efc40aa15b665/rmf_fleet_adapter/src/mutex_group_supervisor/main.cpp#L234-L245

The same logic exists twice and only one side is correct. The claim time is the queue position in `pick_next()`, which has no aging or preemption, so a robot can lose its place in the queue when it replans.

## Test plan

A unit check using `rclcpp::Time` as the oracle found 4952 of 10000 random claim time pairs disagreed before this fix and 0 after. `rmf_fleet_adapter` builds cleanly with this change (colcon, ROS 2 Jazzy).

## GenAI use

- [x] I used a GenAI tool in this PR.
- [ ] I did not use a GenAI tool in this PR.

We hit this while investigating a robot that waited far longer than expected for a mutex group it should have been next in line for. This change, this investigation, and this PR description were prepared with the assistance of an AI coding assistant (Claude).
