### PR TITLE
Restore writable delay properties in rmf_fleet_adapter_python

### DIFF
--- a/rmf_fleet_adapter_python/CMakeLists.txt
+++ b/rmf_fleet_adapter_python/CMakeLists.txt
@@ -119,6 +119,7 @@ install(PROGRAMS
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   set(_rmf_fleet_adapter_python_tests
+    tests/unit/test_delay_properties.py
     tests/unit/test_geometry.py
     tests/unit/test_graph.py
     tests/unit/test_RobotCommandHandle.py

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -58,6 +58,18 @@ std::unordered_map<std::string, ConsiderRequest> convert(
   return output;
 }
 
+template<typename DelaySetter>
+void set_optional_delay(py::handle value, DelaySetter&& setter)
+{
+  if (value.is_none())
+  {
+    setter(rmf_utils::nullopt);
+    return;
+  }
+
+  setter(value.cast<rmf_traffic::Duration>());
+}
+
 using ActivityIdentifier = agv::RobotUpdateHandle::ActivityIdentifier;
 using ActionExecution = agv::RobotUpdateHandle::ActionExecution;
 using RobotInterruption = agv::RobotUpdateHandle::Interruption;
@@ -280,9 +292,12 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property("maximum_delay",
     py::overload_cast<>(
       &agv::RobotUpdateHandle::maximum_delay, py::const_),
-    [&](agv::RobotUpdateHandle& self)
+    [&](agv::RobotUpdateHandle& self, py::object value)
     {
-      return self.maximum_delay();
+      set_optional_delay(value, [&](const auto& delay)
+      {
+        self.maximum_delay(delay);
+      });
     })
   .def("current_task_id",
     [&](agv::RobotUpdateHandle& self)
@@ -650,9 +665,12 @@ PYBIND11_MODULE(rmf_adapter, m) {
   .def_property("default_maximum_delay",
     py::overload_cast<>(
       &agv::FleetUpdateHandle::default_maximum_delay, py::const_),
-    [&](agv::FleetUpdateHandle& self)
+    [&](agv::FleetUpdateHandle& self, py::object value)
     {
-      return self.default_maximum_delay();
+      set_optional_delay(value, [&](const auto& delay)
+      {
+        self.default_maximum_delay(delay);
+      });
     })
   .def("fleet_state_publish_period",
     &agv::FleetUpdateHandle::fleet_state_publish_period,

--- a/rmf_fleet_adapter_python/tests/unit/test_delay_properties.py
+++ b/rmf_fleet_adapter_python/tests/unit/test_delay_properties.py
@@ -1,0 +1,11 @@
+import rmf_adapter as adpt
+
+
+def test_robot_update_handle_maximum_delay_setter_accepts_value():
+    doc = adpt.RobotUpdateHandle.maximum_delay.fset.__doc__
+    assert "arg1" in doc, doc
+
+
+def test_fleet_update_handle_default_maximum_delay_setter_accepts_value():
+    doc = adpt.FleetUpdateHandle.default_maximum_delay.fset.__doc__
+    assert "arg1" in doc, doc


### PR DESCRIPTION
Fixes #539

## Summary
- give RobotUpdateHandle.maximum_delay and FleetUpdateHandle.default_maximum_delay real pybind setters
- accept either a duration value or None, matching the existing optional-delay semantics
- add a focused unit test that checks the bound setters expose a value parameter

## Testing
- git diff --check
- python -m py_compile rmf_fleet_adapter_python/tests/unit/test_delay_properties.py
- full build/import tests are still blocked locally because RMF dependencies are not installed in this workspace