### PR TITLE
added path guide fleet adapter

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
@@ -20,6 +20,7 @@
 #include <rmf_fleet_adapter/agv/FleetUpdateHandle.hpp>
 #include <rmf_fleet_adapter/agv/EasyTrafficLight.hpp>
 #include <rmf_fleet_adapter/agv/EasyFullControl.hpp>
+#include <rmf_fleet_adapter/agv/PathGuide.hpp>
 
 #include <rmf_traffic/agv/VehicleTraits.hpp>
 #include <rmf_traffic/agv/Graph.hpp>
@@ -86,6 +87,19 @@ public:
   /// \return The handle for adding new robots to the fleet.
   std::shared_ptr<EasyFullControl> add_easy_fleet(
     const EasyFullControl::FleetConfiguration& config);
+
+  /// Add a Path Guide fleet to be adapted.
+  ///
+  /// A Path Guide fleet behaves like an Easy Full Control fleet in every way
+  /// except that it hands the downstream integrator the entire path in one
+  /// request instead of one destination at a time. \sa PathGuide
+  ///
+  /// \param[in] config
+  ///   Configuration for the new Path Guide fleet.
+  ///
+  /// \return The handle for adding new robots to the fleet.
+  std::shared_ptr<PathGuide> add_path_guide_fleet(
+    const PathGuide::FleetConfiguration& config);
 
   /// Add a fleet to be adapted.
   ///

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/PathGuide.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/PathGuide.hpp
@@ -1,0 +1,1029 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_FLEET_ADAPTER__AGV__PATHGUIDE_HPP
+#define RMF_FLEET_ADAPTER__AGV__PATHGUIDE_HPP
+
+// ROS 2 headers
+#include <rclcpp/rclcpp.hpp>
+
+// rmf_fleet_adapter headers
+#include <rmf_fleet_adapter/agv/FleetUpdateHandle.hpp>
+#include <rmf_fleet_adapter/agv/RobotUpdateHandle.hpp>
+#include <rmf_fleet_adapter/agv/Transformation.hpp>
+
+// rmf_battery headers
+#include <rmf_battery/agv/BatterySystem.hpp>
+#include <rmf_battery/agv/MechanicalSystem.hpp>
+#include <rmf_battery/agv/SimpleMotionPowerSink.hpp>
+#include <rmf_battery/agv/SimpleDevicePowerSink.hpp>
+
+// rmf_traffic headers
+#include <rmf_traffic/agv/Graph.hpp>
+#include <rmf_traffic/agv/VehicleTraits.hpp>
+
+// rmf_task headers
+#include <rmf_task/TaskPlanner.hpp>
+
+#include <rmf_utils/impl_ptr.hpp>
+
+// System headers
+#include <Eigen/Geometry>
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+/// A full_control fleet adapter that hands the downstream integrator an entire
+/// path at once, instead of one destination at a time.
+///
+/// PathGuide is a sibling of EasyFullControl, not a subclass. It offers the same
+/// feature set — traffic schedule participation and negotiation, schedule
+/// overrides, lifts, docking, coordinate transformations, YAML fleet
+/// configuration, responsive wait and battery-aware task planning — and differs
+/// only in how navigation work reaches the integrator:
+///
+/// * EasyFullControl issues one `NavigationRequest` per graph vertex and waits
+///   for `CommandExecution::finished()` before revealing the next one.
+/// * PathGuide issues a single `PathRequest` carrying every remaining waypoint,
+///   each bundled with its own `CommandExecution`. The integrator acknowledges
+///   waypoints as the robot reaches them.
+///
+/// This lets a fleet manager smooth, spline or velocity-profile across the whole
+/// route, and removes the round trip that EasyFullControl pays at every vertex.
+///
+/// \par Acknowledgement ordering
+/// The integrator **must** acknowledge waypoints strictly in order, from the
+/// waypoint PathGuide is currently tracking through to the last. A
+/// `finished()` call on any other waypoint is rejected with a warning and the
+/// path does not advance. If the robot physically passes a vertex without
+/// noticing, acknowledge the missed waypoints in sequence before the one it
+/// actually reached; several acknowledgements in one update cycle are fine.
+///
+/// By default the adapter will be configured to accept all tasks. To disable
+/// specific tasks, call the respective consider_*_requests() method on the
+/// FleetUpdateHandle that can be accessed within this adapter.
+//==============================================================================
+class PathGuide : public std::enable_shared_from_this<PathGuide>
+{
+public:
+
+  // Aliases
+  using Graph = rmf_traffic::agv::Graph;
+  using VehicleTraits = rmf_traffic::agv::VehicleTraits;
+  using ActionExecutor = RobotUpdateHandle::ActionExecutor;
+  using ActivityIdentifier = RobotUpdateHandle::ActivityIdentifier;
+  using ActivityIdentifierPtr = RobotUpdateHandle::ActivityIdentifierPtr;
+  using ConstActivityIdentifierPtr =
+    RobotUpdateHandle::ConstActivityIdentifierPtr;
+  using Stubbornness = RobotUpdateHandle::Unstable::Stubbornness;
+  using ConsiderRequest = FleetUpdateHandle::ConsiderRequest;
+  using AssignmentStrategy = rmf_task::TaskPlanner::TaskAssignmentStrategy;
+
+  // Nested class declarations
+  class PathRobotUpdateHandle;
+  class RobotState;
+  class RobotConfiguration;
+  class RobotCallbacks;
+  class Destination;
+  class PathWaypoint;
+  class Path;
+  class FleetConfiguration;
+  class CommandExecution;
+
+  /// Signature for a function that handles path requests. The request contains
+  /// every waypoint the robot should visit, in order.
+  ///
+  /// \param[in] path
+  ///   The path for the robot to follow. Acknowledge each waypoint in order by
+  ///   calling `finished()` on its `CommandExecution` once the robot is inside
+  ///   that waypoint's `merge_radius()`.
+  ///
+  /// \note A new path request supersedes any previous one. The
+  /// `CommandExecution`s belonging to a superseded path stop being `okay()`.
+  using PathRequest = std::function<void(Path path)>;
+
+  /// Signature for a function to handle stop requests.
+  using StopRequest = std::function<void(ConstActivityIdentifierPtr)>;
+
+  /// Signature for a function that handles localization requests. The request
+  /// will specify an approximate location for the robot.
+  ///
+  /// \param[in] location_estimate
+  ///   An estimate for where the robot is currently located.
+  ///
+  /// \param[in] execution
+  ///   The command execution progress updater. Use this to keep the fleet
+  ///   adapter updated on the progress of localizing.
+  ///
+  /// \note Localization is a single pose, not a path, so this keeps the
+  /// destination-shaped signature.
+  using LocalizationRequest = std::function<void(
+        Destination location_estimate,
+        CommandExecution execution)>;
+
+  /// Add a robot to the fleet once it is available.
+  ///
+  /// \param[in] name
+  ///   Name of the robot. This must be unique per fleet.
+  ///
+  /// \param[in] initial_state
+  ///   The initial state of the robot when it is added to the fleet.
+  ///
+  /// \param[in] configuration
+  ///   The configuration of the robot.
+  ///
+  /// \param[in] callbacks
+  ///   The callbacks that will be used to issue commands for the robot.
+  ///
+  /// \return a path robot update handle on success. A nullptr if an error
+  /// occurred.
+  std::shared_ptr<PathRobotUpdateHandle> add_robot(
+    std::string name,
+    RobotState initial_state,
+    RobotConfiguration configuration,
+    RobotCallbacks callbacks);
+
+  /// Get the FleetUpdateHandle that this adapter will be using.
+  /// This may be used to perform more specialized customizations using the
+  /// base FleetUpdateHandle API.
+  std::shared_ptr<FleetUpdateHandle> more();
+
+  /// Immutable reference to the base FleetUpdateHandle API.
+  std::shared_ptr<const FleetUpdateHandle> more() const;
+
+  class Implementation;
+private:
+  PathGuide();
+  rmf_utils::unique_impl_ptr<Implementation> _pimpl;
+};
+
+using PathGuidePtr = std::shared_ptr<PathGuide>;
+
+/// Handle used to update information about one robot
+class PathGuide::PathRobotUpdateHandle
+{
+public:
+  /// Recommended function for updating information about a robot in a PathGuide
+  /// fleet.
+  ///
+  /// \param[in] state
+  ///   The current state of the robot
+  ///
+  /// \param[in] current_activity
+  ///   The activity that the robot is currently executing. While following a
+  ///   path this is the identifier of the waypoint currently being approached,
+  ///   i.e. the first waypoint that has not been acknowledged yet.
+  void update(
+    RobotState state,
+    ConstActivityIdentifierPtr current_activity);
+
+  /// Get the maximum allowed merge waypoint distance for this robot.
+  double max_merge_waypoint_distance() const;
+
+  /// Modify the maximum allowed merge distance between the robot and a waypoint.
+  ///
+  /// \param[in] distance
+  ///   The maximum merge waypoint distance for this robot.
+  void set_max_merge_waypoint_distance(double distance);
+
+  /// Get the maximum allowed merge lane distance for this robot.
+  double max_merge_lane_distance() const;
+
+  /// Modify the maximum allowed merge distance between the robot and a lane.
+  ///
+  /// \param[in] distance
+  ///   The maximum merge lane distance for this robot.
+  void set_max_merge_lane_distance(double distance);
+
+  /// Get the minimum lane length for this robot.
+  double min_lane_length() const;
+
+  /// Modify the minimum lane length for this robot.
+  ///
+  /// \param[in] length
+  ///   The minimum length of a lane.
+  void set_min_lane_length(double length);
+
+  /// Get more options for updating the robot's state
+  std::shared_ptr<RobotUpdateHandle> more();
+
+  /// Immutable reference to the base robot update API
+  std::shared_ptr<const RobotUpdateHandle> more() const;
+
+  class Implementation;
+private:
+  PathRobotUpdateHandle();
+  rmf_utils::unique_impl_ptr<Implementation> _pimpl;
+};
+
+/// The current state of a robot, passed into PathRobotUpdateHandle::update
+class PathGuide::RobotState
+{
+public:
+  /// Constructor
+  ///
+  /// \param[in] map_name
+  ///   The name of the map the robot is currently on
+  ///
+  /// \param[in] position
+  ///   The current position of the robot
+  ///
+  /// \param[in] battery_soc
+  ///   the current battery level of the robot, specified by its state of
+  ///   charge as a fraction of its total charge capacity, i.e. a value from 0.0
+  ///   to 1.0.
+  RobotState(
+    std::string map_name,
+    Eigen::Vector3d position,
+    double battery_soc);
+
+  /// Current map the robot is on
+  const std::string& map() const;
+
+  /// Set the current map the robot is on
+  void set_map(std::string value);
+
+  /// Current position of the robot
+  Eigen::Vector3d position() const;
+
+  /// Set the current position of the robot
+  void set_position(Eigen::Vector3d value);
+
+  /// Current state of charge of the battery, as a fraction from 0.0 to 1.0.
+  double battery_state_of_charge() const;
+
+  /// Set the state of charge of the battery, as a fraction from 0.0 to 1.0.
+  void set_battery_state_of_charge(double value);
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+/// The configuration of a robot. These are parameters that typically do not
+/// change over time.
+class PathGuide::RobotConfiguration
+{
+public:
+
+  /// Constructor
+  ///
+  /// \param[in] compatible_chargers
+  ///   List of chargers that this robot is compatible with
+  ///
+  /// \param[in] responsive_wait
+  ///   Should this robot use the responsive wait behavior? true / false / fleet
+  ///   default.
+  ///
+  /// \warning This must contain a single string value until a later release of
+  /// RMF. We are using a vector for forward API compatibility. For now, make
+  /// sure each robot has only one unique compatible charger to avoid charging
+  /// conflicts.
+  RobotConfiguration(
+    std::vector<std::string> compatible_chargers,
+    std::optional<bool> responsive_wait = std::nullopt,
+    std::optional<double> max_merge_waypoint_distance = 1e-3,
+    std::optional<double> max_merge_lane_distance = 0.3,
+    std::optional<double> min_lane_length = 1e-8);
+
+  /// List of chargers that this robot is compatible with
+  const std::vector<std::string>& compatible_chargers() const;
+
+  /// Set the list of chargers compatible with this robot.
+  void set_compatible_chargers(std::vector<std::string> chargers);
+
+  /// Should this robot use the responsive wait behavior? Responsive wait means
+  /// that when the robot is idle on a point, it will report to the traffic
+  /// schedule that it is waiting on that point, and it will negotiate with
+  /// other robots to let them pass while ultimately remaining on the point.
+  ///
+  /// If std::nullopt is used, then the fleet-wide responsive wait behavior will
+  /// be used.
+  std::optional<bool> responsive_wait() const;
+
+  /// Toggle responsive wait on (true), off (false), or use fleet default
+  /// (std::nullopt).
+  void set_responsive_wait(std::optional<bool> enable);
+
+  /// Get the maximum merge distance between a robot and a waypoint. This refers
+  /// to the maximum distance allowed to consider a robot to be on a particular
+  /// waypoint.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default merge waypoint
+  /// distance will be used.
+  std::optional<double> max_merge_waypoint_distance() const;
+
+  /// Set the maximum merge distance between a robot and a waypoint.
+  void set_max_merge_waypoint_distance(std::optional<double> distance);
+
+  /// Get the maximum merge distance between a robot and a lane. This refers
+  /// to the maximum distance allowed to consider a robot to be on a particular
+  /// lane.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default merge lane
+  /// distance will be used.
+  std::optional<double> max_merge_lane_distance() const;
+
+  /// Set the maximum merge distance between a robot and a lane.
+  void set_max_merge_lane_distance(std::optional<double> distance);
+
+  /// Get the minimum lane length.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default minimum lane length
+  /// will be used.
+  std::optional<double> min_lane_length() const;
+
+  /// Set the minimum lane length.
+  void set_min_lane_length(std::optional<double> distance);
+
+  /// Get the idle behavior.
+  ///
+  /// If std::nullopt is used, then the fleet-wide default finishing request
+  /// will be used.
+  std::optional<rmf_task::ConstRequestFactoryPtr> finishing_request() const;
+
+  /// Set the finishing request.
+  void set_finishing_request(
+    std::optional<rmf_task::ConstRequestFactoryPtr> request);
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+class PathGuide::RobotCallbacks
+{
+public:
+
+  /// Constructor
+  ///
+  /// \param[in] follow_path
+  ///   A function that receives the entire path for the robot to follow.
+  ///
+  /// \param[in] stop
+  ///   A function to stop the robot.
+  ///
+  /// \param[in] action_executor
+  ///   The ActionExecutor callback to request the robot to perform an action.
+  RobotCallbacks(
+    PathRequest follow_path,
+    StopRequest stop,
+    ActionExecutor action_executor);
+
+  /// Get the callback for following a path
+  PathRequest follow_path() const;
+
+  /// Get the callback for stopping
+  StopRequest stop() const;
+
+  /// Get the action executor.
+  ActionExecutor action_executor() const;
+
+  /// Give the robot a localization callback. Unlike the callbacks used by the
+  /// constructor, this callback is optional.
+  RobotCallbacks& with_localization(LocalizationRequest localization);
+
+  /// Get the callback for localizing if available.
+  LocalizationRequest localize() const;
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+/// Used by system integrators to give feedback on the progress of reaching one
+/// waypoint of a path, or of a localization request.
+class PathGuide::CommandExecution
+{
+public:
+
+  /// Trigger this when the robot has reached the waypoint that this execution
+  /// belongs to. No other function in this CommandExecution instance will be
+  /// usable after this.
+  ///
+  /// \warning Waypoints must be acknowledged in order. Calling this on a
+  /// waypoint that PathGuide is not currently tracking logs a warning and does
+  /// nothing.
+  void finished();
+
+  /// Returns false if the command has been stopped, already finished, or
+  /// belongs to a path that has been superseded by a replan.
+  bool okay() const;
+
+  /// Use this to override the traffic schedule for the agent while it performs
+  /// this command.
+  ///
+  /// If the given trajectory results in a traffic conflict then a negotiation
+  /// will be triggered. Hold onto the `Stubbornness` returned by this function
+  /// to ask other agents to plan around your trajectory, otherwise the
+  /// negotiation may result in a replan for this agent and a new command will
+  /// be issued.
+  ///
+  /// \note Using this will function always trigger a replan once the agent
+  /// finishes the command.
+  ///
+  /// \warning Too many overridden/stubborn agents can cause a deadlock. It's
+  ///   recommended to use this API sparingly and only over short distances or
+  ///   small deviations.
+  ///
+  /// \param[in] map
+  ///   Name of the map where the trajectory will take place
+  ///
+  /// \param[in] path
+  ///   The path of the agent
+  ///
+  /// \param[in] hold
+  ///   How long the agent will wait at the end of the path
+  ///
+  /// \return a Stubbornness handle that tells the fleet adapter to not let the
+  /// overridden path be negotiated. The returned handle will stop having an
+  /// effect after this command execution is finished.
+  Stubbornness override_schedule(
+    std::string map,
+    std::vector<Eigen::Vector3d> path,
+    rmf_traffic::Duration hold = rmf_traffic::Duration(0));
+
+  /// Activity handle for this command. Pass this into
+  /// PathRobotUpdateHandle::update while the robot is approaching this
+  /// waypoint.
+  ConstActivityIdentifierPtr identifier() const;
+
+  class Implementation;
+private:
+  CommandExecution();
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+class PathGuide::Destination
+{
+public:
+  /// The name of the map where the destination is located.
+  const std::string& map() const;
+
+  /// The (x, y, yaw) position of the destination.
+  Eigen::Vector3d position() const;
+
+  /// The (x, y) position of the destination.
+  Eigen::Vector2d xy() const;
+
+  /// The intended orientation of the robot at the destination, represented in
+  /// radians.
+  double yaw() const;
+
+  /// If the destination has an index in the navigation graph, you can get it
+  /// from this field.
+  std::optional<std::size_t> graph_index() const;
+
+  /// The name of this destination, if it has one. Nameless destinations will
+  /// give an empty string.
+  std::string name() const;
+
+  /// If there is a speed limit that should be respected while approaching the
+  /// destination, this will indicate it.
+  std::optional<double> speed_limit() const;
+
+  /// If the destination should be reached by performing a dock maneuver, this
+  /// will contain the name of the dock.
+  std::optional<std::string> dock() const;
+
+  /// Get whether the destination is inside of a lift, and if so get the
+  /// properties of the lift.
+  ///
+  /// Non-null exactly when this waypoint is inside a lift cabin. **You are
+  /// expected to use this.** PathGuide does not tighten `merge_radius()`
+  /// inside lifts — deciding when the robot is far enough in for the doors to
+  /// close safely is yours to make, because only you know your true footprint
+  /// shape, your heading on arrival, and your controller's stopping accuracy.
+  /// Acknowledging a lift waypoint on `merge_radius()` alone will close the
+  /// doors on a robot that is still partly outside; see `merge_radius()` for
+  /// the incident that demonstrates it.
+  ///
+  /// \warning **Coordinate frames differ within this object.** The returned
+  /// LiftProperties — `location()`, `orientation()`, `dimensions()`, and the
+  /// positions `is_in_lift()` expects — are all in **RMF canonical
+  /// coordinates**, straight from the navigation graph. But `position()`,
+  /// `xy()` on this Destination, and `merge_radius()` on the PathWaypoint
+  /// that carries it, are in **robot
+  /// coordinates**, having been through the fleet's configured transform.
+  ///
+  /// So `inside_lift()->is_in_lift(my_robot_frame_position)` is **wrong** on
+  /// any fleet that configures a `transforms` entry, and wrong in the
+  /// dangerous direction: it silently reports a plausible answer. It happens to
+  /// work when the transform is identity, which is how it escapes notice.
+  ///
+  /// Either convert your position back to RMF coordinates before calling
+  /// `is_in_lift()`, or apply your own transform to the cabin geometry. If you
+  /// would rather not deal with frames at all, judging your distance to
+  /// `xy()` against your own footprint — entirely in robot coordinates — avoids
+  /// the issue, at the cost of not knowing where the cabin walls are.
+  rmf_traffic::agv::Graph::LiftPropertiesPtr inside_lift() const;
+
+  class Implementation;
+private:
+  Destination();
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+/// One waypoint of a Path, bundled with the handle used to acknowledge it.
+class PathGuide::PathWaypoint
+{
+public:
+  /// Where the robot should go for this waypoint.
+  const Destination& destination() const;
+
+  /// How far off its lane RMF can still localize this robot here.
+  ///
+  /// **This is a tolerance, not an arrival radius.** PathGuide has no opinion
+  /// about when this waypoint counts as reached — that is yours, exactly as it
+  /// is under EasyFullControl, where you decide arrival outright by choosing
+  /// when to call `finished()`. What this gives you is an **upper bound** on
+  /// how loose your arrival test may safely be.
+  ///
+  /// Acknowledging a path's *final* waypoint ends the movement phase, so the
+  /// robot stops wherever it happens to be. Credit it further out than this and
+  /// RMF may be unable to merge the stopped robot back onto its lane — it is
+  /// declared lost, replans, and a lift already summoned for it can be
+  /// re-summoned to the wrong floor.
+  ///
+  /// It is `max(this robot's max_merge_lane_distance, the graph vertex's own
+  /// merge_radius)`. A graph may be more permissive at an unusually open
+  /// vertex, never stricter.
+  ///
+  /// \warning **In robot coordinates**, like `destination().position()`, so the
+  /// two compare directly. Do not convert it again.
+  ///
+  /// \warning **Not lift-aware, deliberately.** Deciding when a robot is far
+  /// enough inside a cabin for the doors to close safely needs your true
+  /// footprint shape, arrival heading and stopping accuracy — none of which the
+  /// adapter knows. Use `destination().inside_lift()` and tighten this bound
+  /// yourself. Not hypothetical: a 2.7 m square cabin with a 0.9 m footprint
+  /// radius leaves 0.45 m of clearance from the cabin centre, and a robot
+  /// credited on 1.0 m had its centre only 0.35 m past the door plane with
+  /// 0.778 m still outside when the doors closed on it.
+  double merge_radius() const;
+
+  /// This waypoint's position in the path, counting from 0.
+  std::size_t index() const;
+
+  /// The handle used to tell PathGuide that the robot has reached this
+  /// waypoint. Waypoints must be acknowledged in order.
+  CommandExecution execution() const;
+
+  class Implementation;
+private:
+  PathWaypoint();
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+/// An entire route for the robot to follow, handed over in one piece.
+class PathGuide::Path
+{
+public:
+  /// Every waypoint the robot should visit, in the order it should visit them.
+  const std::vector<PathWaypoint>& waypoints() const;
+
+  /// The traffic schedule plan that produced this path. This increases whenever
+  /// RMF replans, so it can be used to recognise and discard acknowledgements
+  /// that belong to a superseded path.
+  std::size_t plan_id() const;
+
+  /// The map that the robot is starting this path on.
+  const std::string& map() const;
+
+  class Implementation;
+private:
+  Path();
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+/// The Configuration class contains parameters necessary to initialize a
+/// PathGuide fleet instance and add fleets to the adapter.
+class PathGuide::FleetConfiguration
+{
+public:
+
+  /// Constructor
+  ///
+  /// \param[in] fleet_name
+  ///   The name of the fleet that is being added.
+  ///
+  /// \param[in] transformations_to_robot_coordinates
+  ///   A dictionary of transformations from RMF canonical coordinates to the
+  ///   the coordinate system used by the robot. Each map should be assigned its
+  ///   own transformation. If this is not nullptr, then a warning will be
+  ///   logged whenever the dictionary is missing a transform for a map, and the
+  ///   canonical RMF coordinates will be used.
+  ///
+  /// \param[in] known_robot_configurations
+  ///   Configurations for the robots that are expected to join this fleet.
+  ///
+  /// \param[in] traits
+  ///   Specify the approximate traits of the vehicles in this fleet.
+  ///
+  /// \param[in] graph
+  ///   Specify the navigation graph used by the vehicles in this fleet.
+  ///
+  /// \param[in] battery_system
+  ///   Specify the battery system used by the vehicles in this fleet.
+  ///
+  /// \param[in] motion_sink
+  ///   Specify the motion sink that describes the vehicles in this fleet.
+  ///
+  /// \param[in] ambient_sink
+  ///   Specify the device sink for ambient sensors used by the vehicles in this
+  ///   fleet.
+  ///
+  /// \param[in] tool_sink
+  ///   Specify the device sink for special tools used by the vehicles in this
+  ///   fleet.
+  ///
+  /// \param[in] recharge_threshold
+  ///   The threshold for state of charge below which robots in this fleet
+  ///   will cease to operate and require recharging. A value between 0.0 and
+  ///   1.0 should be specified.
+  ///
+  /// \param[in] recharge_soc
+  ///   The state of charge to which robots in this fleet should be charged up
+  ///   to by automatic recharging tasks. A value between 0.0 and 1.0 should be
+  ///   specified.
+  ///
+  /// \param[in] account_for_battery_drain
+  ///   Specify whether battery drain is to be considered while allocating
+  ///   tasks. If false, battery drain will not be considered when planning for
+  ///   tasks. As a consequence, charging tasks will not be automatically
+  ///   assigned to vehicles in this fleet when battery levels fall below the
+  ///   recharge_threshold.
+  ///
+  /// \param[in] retreat_to_charger_interval
+  ///   Specify whether to allow automatic retreat to charger if the robot's
+  ///   battery is estimated to fall below its recharge_threshold before it is
+  ///   able to complete its current task. Provide a duration between checks in
+  ///   seconds. If nullopt, retreat to charger would be disabled.
+  ///
+  /// \param[in] task_consideration
+  ///   Provide callbacks for considering tasks belonging to each category.
+  ///
+  /// \param[in] action_consideration
+  ///   List of actions that this fleet can perform. Each item represents a
+  ///   category in the PerformAction description.
+  ///
+  /// \param[in] finishing_request
+  ///   A factory for a request that should be performed by each robot in this
+  ///   fleet at the end of its assignments.
+  ///
+  /// \param[in] server_uri
+  ///   The URI for the websocket server that receives updates on tasks and
+  ///   states. If nullopt, data will not be published.
+  ///
+  /// \param[in] max_delay
+  ///   Specify the default value for how high the delay of the current
+  ///   itinerary can become before it gets interrupted and replanned.
+  ///
+  /// \param[in] update_interval
+  ///   The duration between positional state updates that are sent to
+  ///   the fleet adapter.
+  ///
+  /// \param[in] default_responsive_wait
+  ///   Should the robots in this fleet have responsive wait enabled (true) or
+  ///   disabled (false) by default?
+  ///
+  /// \param[in] default_max_merge_waypoint_distance
+  ///   The maximum merge distance between a robot position and a waypoint.
+  ///
+  /// \param[in] default_max_merge_lane_distance
+  ///   The maximum merge distance between a robot position and a lane.
+  ///
+  /// \param[in] min_lane_length
+  ///   The minimum length that a lane should have.
+  ///
+  ///
+  ///   This is deliberately separate from max_merge_lane_distance, which the
+  ///   two used to share. They pull in opposite directions: lane merging wants
+  ///   a tight tolerance so that genuine drift is noticed, while arrival wants
+  ///   one loose enough to cover however wide the robot actually rounds a
+  ///   corner. Sharing one value meant loosening drift detection just to stop
+  ///   paths stranding.
+  ///
+  ///   If left at its default of 0.0 it falls back to
+  ///   default_max_merge_lane_distance, preserving the old coupled behaviour
+  ///   for configurations that do not set it.
+  ///
+  /// \note Unlike EasyFullControl, there is no `skip_rotation_commands`
+  /// parameter. PathGuide never emits a rotate-in-place waypoint, because such
+  /// a waypoint is meaningless inside a path that the robot is expected to
+  /// smooth over. Every destination carries the final orientation for its
+  /// vertex and the robot owns its own in-place turns.
+  FleetConfiguration(
+    const std::string& fleet_name,
+    std::optional<std::unordered_map<std::string, Transformation>>
+    transformations_to_robot_coordinates,
+    std::unordered_map<std::string, RobotConfiguration>
+    known_robot_configurations,
+    std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
+    std::shared_ptr<const rmf_traffic::agv::Graph> graph,
+    rmf_battery::agv::ConstBatterySystemPtr battery_system,
+    rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+    rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+    rmf_battery::ConstDevicePowerSinkPtr tool_sink,
+    double recharge_threshold,
+    double recharge_soc,
+    bool account_for_battery_drain,
+    std::unordered_map<std::string, ConsiderRequest> task_consideration,
+    std::unordered_map<std::string, ConsiderRequest> action_consideration,
+    rmf_task::ConstRequestFactoryPtr finishing_request = nullptr,
+    std::optional<std::string> server_uri = std::nullopt,
+    rmf_traffic::Duration max_delay = rmf_traffic::time::from_seconds(10.0),
+    rmf_traffic::Duration update_interval = rmf_traffic::time::from_seconds(
+      0.5),
+    bool default_responsive_wait = false,
+    double default_max_merge_waypoint_distance = 1e-3,
+    double default_max_merge_lane_distance = 0.3,
+    double min_lane_length = 1e-8
+  );
+
+  /// Create a FleetConfiguration object using a set of configuration parameters
+  /// imported from YAML files that follow the defined schema. This is an
+  /// alternative to constructing the FleetConfiguration using the RMF objects
+  /// if users do not require specific tool systems for their fleets. The
+  /// FleetConfiguration object will be instantiated with instances of
+  /// SimpleMotionPowerSink and SimpleDevicePowerSink.
+  ///
+  /// The schema is the same one EasyFullControl uses, so an existing
+  /// `config.yaml` can be reused as-is. The `skip_rotation_commands` key is
+  /// ignored, and a warning is logged if it is present.
+  ///
+  /// \param[in] config_file
+  ///   The path to a configuration YAML file containing data about the fleet's
+  ///   vehicle traits and task capabilities. This file needs to follow the
+  ///   pre-defined config.yaml structure to successfully load the parameters
+  ///   into the FleetConfiguration object.
+  ///
+  /// \param[in] nav_graph_path
+  ///   The path to a navigation path file that includes map information
+  ///   necessary to create a rmf_traffic::agv::Graph object
+  ///
+  /// \param[in] server_uri
+  ///   The URI for the websocket server that receives updates on tasks and
+  ///   states. If nullopt, data will not be published.
+  ///
+  /// \return A FleetConfiguration object with the essential config parameters
+  /// loaded.
+  static std::optional<FleetConfiguration> from_config_files(
+    const std::string& config_file,
+    const std::string& nav_graph_path,
+    std::optional<std::string> server_uri = std::nullopt);
+
+  /// Get the fleet name.
+  const std::string& fleet_name() const;
+
+  /// Set the fleet name.
+  void set_fleet_name(std::string value);
+
+  /// Get the transformations into robot coordinates for this fleet.
+  const std::optional<std::unordered_map<std::string, Transformation>>&
+  transformations_to_robot_coordinates() const;
+
+  /// Set the transformation into robot coordinates for a map. This will replace
+  /// any transformation previously set for the map. If the transformation
+  /// dictionary was previously nullopt, this will initialize it with an empty
+  /// value before inserting this transformation.
+  void add_robot_coordinate_transformation(
+    std::string map,
+    Transformation transformation);
+
+  /// Get a dictionary of known robot configurations. The key is the name of the
+  /// robot belonging to this fleet. These configurations are usually parsed
+  /// from a fleet configuration file.
+  const std::unordered_map<std::string, RobotConfiguration>&
+  known_robot_configurations() const;
+
+  /// Get the names of all robots with known robot configurations.
+  std::vector<std::string> known_robots() const;
+
+  /// Provide a known configuration for a named robot.
+  ///
+  /// \param[in] robot_name
+  ///   The unique name of the robot.
+  ///
+  /// \param[in] configuration
+  ///   The configuration for the robot.
+  void add_known_robot_configuration(
+    std::string robot_name,
+    RobotConfiguration configuration);
+
+  /// Get a known configuration for a robot based on its name.
+  std::optional<RobotConfiguration> get_known_robot_configuration(
+    const std::string& robot_name) const;
+
+  /// Get the fleet vehicle traits.
+  const std::shared_ptr<const VehicleTraits>& vehicle_traits() const;
+
+  /// Set the vehicle traits.
+  void set_vehicle_traits(std::shared_ptr<const VehicleTraits> value);
+
+  /// Get the fleet navigation graph.
+  const std::shared_ptr<const Graph>& graph() const;
+
+  /// Set the fleet navigation graph.
+  void set_graph(std::shared_ptr<const Graph> value);
+
+  /// Get the battery system.
+  rmf_battery::agv::ConstBatterySystemPtr battery_system() const;
+
+  /// Set the battery system.
+  void set_battery_system(rmf_battery::agv::ConstBatterySystemPtr value);
+
+  /// Get the motion sink.
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink() const;
+
+  /// Set the motion sink.
+  void set_motion_sink(rmf_battery::ConstMotionPowerSinkPtr value);
+
+  /// Get the ambient sink.
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink() const;
+
+  /// Set the ambient sink.
+  void set_ambient_sink(rmf_battery::ConstDevicePowerSinkPtr value);
+
+  /// Get the tool sink.
+  rmf_battery::ConstDevicePowerSinkPtr tool_sink() const;
+
+  /// Set the tool sink.
+  void set_tool_sink(rmf_battery::ConstDevicePowerSinkPtr value);
+
+  /// Get the recharge threshold.
+  double recharge_threshold() const;
+
+  /// Set the recharge threshold.
+  void set_recharge_threshold(double value);
+
+  /// Get the recharge state of charge. If the robot's state of charge dips
+  /// below this value then its next task will be to recharge.
+  double recharge_soc() const;
+
+  /// Set the recharge state of charge.
+  void set_recharge_soc(double value);
+
+  /// Get whether or not to account for battery drain during task planning.
+  bool account_for_battery_drain() const;
+
+  /// Set whether or not to account for battery drain during task planning.
+  void set_account_for_battery_drain(bool value);
+
+  /// Get the duration between retreat to charger checks.
+  std::optional<rmf_traffic::Duration> retreat_to_charger_interval() const;
+
+  /// Set the duration between retreat to charger checks. Passing in a nullopt
+  /// will turn off these checks entirely.
+  void set_retreat_to_charger_interval(
+    std::optional<rmf_traffic::Duration> value);
+
+  /// Get the task categories
+  const std::unordered_map<std::string, ConsiderRequest>&
+  task_consideration() const;
+
+  /// Mutable access to the task consideration map.
+  std::unordered_map<std::string, ConsiderRequest>& task_consideration();
+
+  /// Get the action categories
+  const std::unordered_map<std::string, ConsiderRequest>&
+  action_consideration() const;
+
+  /// Mutable access to the action consideration map.
+  std::unordered_map<std::string, ConsiderRequest>& action_consideration();
+
+  /// Get the finishing request.
+  rmf_task::ConstRequestFactoryPtr finishing_request() const;
+
+  /// Set the finishing request.
+  void set_finishing_request(rmf_task::ConstRequestFactoryPtr value);
+
+  /// Get the server uri.
+  std::optional<std::string> server_uri() const;
+
+  /// Set the server uri.
+  void set_server_uri(std::optional<std::string> value);
+
+  /// Get the max delay.
+  rmf_traffic::Duration max_delay() const;
+
+  /// Set the max delay.
+  void set_max_delay(rmf_traffic::Duration value);
+
+  /// Get the update interval.
+  rmf_traffic::Duration update_interval() const;
+
+  /// Set the update interval.
+  void set_update_interval(rmf_traffic::Duration value);
+
+  /// Should robots in this fleet have responsive wait enabled by default?
+  bool default_responsive_wait() const;
+
+  /// Should robots use the parking reservation system.
+  bool using_parking_reservation_system() const;
+
+  /// Set whether this fleet uses the parking reservation system.
+  void use_parking_reservation_system(
+    const bool use);
+
+  /// Set whether robots in this fleet should have responsive wait enabled by
+  /// default.
+  void set_default_responsive_wait(bool enable);
+
+  /// Get the maximum merge distance between a robot position and a waypoint.
+  double default_max_merge_waypoint_distance() const;
+
+  /// Set the maximum merge distance between a robot position and a waypoint.
+  void set_default_max_merge_waypoint_distance(double distance);
+
+  /// Get the maximum merge distance between a robot position and a lane.
+  double default_max_merge_lane_distance() const;
+
+  /// Set the maximum merge distance between a robot position and a lane.
+  void set_default_max_merge_lane_distance(double distance);
+
+  /// Get the minimum lane length allowed.
+  double default_min_lane_length() const;
+
+  /// Set the minimum lane length.
+  void set_default_min_lane_length(double distance);
+
+  /// Get the arrival radius that waypoints are published with.
+  ///
+  /// Returns the effective value: if no arrival radius was configured this is
+  /// default_max_merge_lane_distance, which is what the two shared before they
+  /// were separated.
+ 
+  /// During a fire emergency, real-life lifts might be required to move to a
+  /// specific level and refuse to stop or go to any other level. This function
+  /// lets you provide this information to the fleet adapter so that it can
+  /// produce reasonable emergency pullover plans for robots that happen to be
+  /// inside of a lift when the fire alarm goes off.
+  ///
+  /// Internally, this will close all lanes that go into the specified lift and
+  /// close all lanes exiting this lift (except on the designated level) when a
+  /// fire emergency begins. Lifts that were not specified in a call to this
+  /// function will not behave any differently during a fire emergency.
+  ///
+  /// \param[in] lift_name
+  ///   The name of the lift whose behavior is being specified
+  ///
+  /// \param[in] emergency_level_name
+  ///   The level that lift will go to when a fire emergency is happening
+  void set_lift_emergency_level(
+    std::string lift_name,
+    std::string emergency_level_name);
+
+  /// Get mutable access to the level that each specified lift will go to during
+  /// a fire emergency.
+  ///
+  /// \sa set_lift_emergency_level
+  std::unordered_map<std::string, std::string>& change_lift_emergency_levels();
+
+  /// Get the level that each specified lift will go to during a fire emergency.
+  ///
+  /// \sa set_lift_emergency_level
+  const std::unordered_map<std::string, std::string>&
+  lift_emergency_levels() const;
+
+  /// A set of lanes which must strictly be navigated from from the start to end
+  /// of the lane when used. This means when replanning, the planner cannot ask
+  /// a robot in the middle of one of these lanes to immediately go to the end
+  /// of the lane.
+  const std::unordered_set<std::size_t>& strict_lanes() const;
+
+  /// Get a mutable reference to the set of strict lanes.
+  ///
+  /// \sa strict_lanes
+  std::unordered_set<std::size_t>& change_strict_lanes();
+
+  /// Get the task planner assignment strategy.
+  const AssignmentStrategy& task_assignment_strategy() const;
+
+  /// Set the task planner assignment strategy.
+  void set_task_assignment_strategy(
+    const AssignmentStrategy& strategy);
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+} // namespace agv
+} // namespace rmf_fleet_adapter
+
+#endif // RMF_FLEET_ADAPTER__AGV__PATHGUIDE_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -21,6 +21,7 @@
 #include "Node.hpp"
 #include "internal_FleetUpdateHandle.hpp"
 #include "internal_EasyFullControl.hpp"
+#include "internal_PathGuide.hpp"
 
 #include <rmf_traffic_ros2/schedule/MirrorManager.hpp>
 #include <rmf_traffic_ros2/schedule/Negotiation.hpp>
@@ -231,16 +232,26 @@ public:
   std::unordered_set<std::string> visited_docks;
   std::unordered_set<std::string> duplicate_docks;
 };
-} // anonymous namespace
 
 //==============================================================================
-std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
-  const EasyFullControl::FleetConfiguration& config)
+/// Validate a fleet configuration and apply every setting that EasyFullControl
+/// and PathGuide handle identically, returning the FleetUpdateHandle on success
+/// or nullptr if the configuration is unusable.
+///
+/// Both configuration types expose the same API for these settings, so this is
+/// a template rather than two copies that could drift apart.
+template<typename Config>
+std::shared_ptr<FleetUpdateHandle> make_configured_fleet(
+  Adapter& adapter,
+  const Config& config,
+  const char* adapter_label)
 {
+  const auto node = adapter.node();
+
   if (!config.graph())
   {
     RCLCPP_ERROR(
-      this->node()->get_logger(),
+      node->get_logger(),
       "Graph missing in the configuration for fleet [%s]. The fleet will not "
       "be added.",
       config.fleet_name().c_str());
@@ -250,7 +261,7 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
   if (!config.vehicle_traits())
   {
     RCLCPP_ERROR(
-      this->node()->get_logger(),
+      node->get_logger(),
       "Vehicle traits missing in the configuration for fleet [%s]. The fleet "
       "will not be added.",
       config.fleet_name().c_str());
@@ -272,7 +283,7 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
   if (!finder.duplicate_docks.empty())
   {
     RCLCPP_ERROR(
-      this->node()->get_logger(),
+      node->get_logger(),
       "Graph provided for fleet [%s] has %lu duplicate lanes:",
       config.fleet_name().c_str(),
       finder.duplicate_docks.size());
@@ -280,19 +291,19 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     for (const auto& dock : finder.duplicate_docks)
     {
       RCLCPP_ERROR(
-        this->node()->get_logger(),
+        node->get_logger(),
         "- [%s]",
         dock.c_str());
     }
 
     RCLCPP_ERROR(
-      this->node()->get_logger(),
+      node->get_logger(),
       "Each dock name on a graph must be unique, so we cannot add fleet [%s]",
       config.fleet_name().c_str());
     return nullptr;
   }
 
-  auto fleet_handle = this->add_fleet(
+  auto fleet_handle = adapter.add_fleet(
     config.fleet_name(),
     *config.vehicle_traits(),
     *config.graph(),
@@ -308,12 +319,11 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     config.account_for_battery_drain(),
     config.finishing_request(),
     config.task_assignment_strategy());
-    
 
   if (!planner_params_ok)
   {
     RCLCPP_WARN(
-      this->node()->get_logger(),
+      node->get_logger(),
       "Failed to initialize task planner parameters for fleet [%s]. "
       "It will not respond to bid requests for tasks",
       config.fleet_name().c_str());
@@ -328,7 +338,7 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     {
       fleet_handle->consider_delivery_requests(consider, consider);
       RCLCPP_INFO(
-        this->node()->get_logger(),
+        node->get_logger(),
         "Fleet [%s] is configured to perform delivery tasks",
         config.fleet_name().c_str());
     }
@@ -337,7 +347,7 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     {
       fleet_handle->consider_patrol_requests(consider);
       RCLCPP_INFO(
-        this->node()->get_logger(),
+        node->get_logger(),
         "Fleet [%s] is configured to perform patrol tasks",
         config.fleet_name().c_str());
     }
@@ -346,7 +356,7 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
     {
       fleet_handle->consider_cleaning_requests(consider);
       RCLCPP_INFO(
-        this->node()->get_logger(),
+        node->get_logger(),
         "Fleet [%s] is configured to perform cleaning tasks",
         config.fleet_name().c_str());
     }
@@ -360,27 +370,72 @@ std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
   fleet_handle->default_maximum_delay(config.max_delay());
   fleet_handle->fleet_state_topic_publish_period(config.update_interval());
 
-  RCLCPP_INFO(
-    this->node()->get_logger(),
-    "Finished configuring Easy Full Control adapter for fleet [%s]",
-    config.fleet_name().c_str());
-
-  std::shared_ptr<TransformDictionary> tf_dict;
-  if (config.transformations_to_robot_coordinates().has_value())
-  {
-    tf_dict = std::make_shared<TransformDictionary>(
-      *config.transformations_to_robot_coordinates());
-  }
-
   for (const auto& [lift, level] : config.lift_emergency_levels())
   {
     fleet_handle->set_lift_emergency_level(lift, level);
   }
 
+  RCLCPP_INFO(
+    node->get_logger(),
+    "Finished configuring %s adapter for fleet [%s]",
+    adapter_label,
+    config.fleet_name().c_str());
+
+  return fleet_handle;
+}
+
+//==============================================================================
+template<typename Config>
+std::shared_ptr<TransformDictionary> make_transform_dictionary(
+  const Config& config)
+{
+  if (config.transformations_to_robot_coordinates().has_value())
+  {
+    return std::make_shared<TransformDictionary>(
+      *config.transformations_to_robot_coordinates());
+  }
+
+  return nullptr;
+}
+} // anonymous namespace
+
+//==============================================================================
+std::shared_ptr<EasyFullControl> Adapter::add_easy_fleet(
+  const EasyFullControl::FleetConfiguration& config)
+{
+  auto fleet_handle = make_configured_fleet(*this, config, "Easy Full Control");
+  if (!fleet_handle)
+  {
+    return nullptr;
+  }
+
   return EasyFullControl::Implementation::make(
     fleet_handle,
     config.skip_rotation_commands(),
-    tf_dict,
+    make_transform_dictionary(config),
+    config.strict_lanes(),
+    config.default_responsive_wait(),
+    config.default_max_merge_waypoint_distance(),
+    config.default_max_merge_lane_distance(),
+    config.default_min_lane_length(),
+    config.using_parking_reservation_system());
+}
+
+//==============================================================================
+std::shared_ptr<PathGuide> Adapter::add_path_guide_fleet(
+  const PathGuide::FleetConfiguration& config)
+{
+  auto fleet_handle = make_configured_fleet(*this, config, "Path Guide");
+  if (!fleet_handle)
+  {
+    return nullptr;
+  }
+
+  // No skip_rotation_commands argument: PathGuide never issues a
+  // rotate-in-place command, so the behaviour is not configurable.
+  return PathGuide::Implementation::make(
+    fleet_handle,
+    make_transform_dictionary(config),
     config.strict_lanes(),
     config.default_responsive_wait(),
     config.default_max_merge_waypoint_distance(),

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/PathGuide.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/PathGuide.cpp
@@ -1,0 +1,4061 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Derived from EasyFullControl.cpp. PathGuide keeps the whole EasyFullControl
+ * feature set and differs only in how navigation work is dispatched to the
+ * downstream integrator: the entire path is handed over in one PathRequest,
+ * and the integrator acknowledges each waypoint in order as the robot reaches
+ * it. See PathGuide.hpp for the rationale.
+ *
+ * EasyFullControl.cpp is intentionally left untouched, so the two adapters can
+ * evolve independently.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_fleet_adapter/agv/Adapter.hpp>
+#include <rmf_fleet_adapter/agv/PathGuide.hpp>
+#include <rmf_fleet_adapter/agv/RobotCommandHandle.hpp>
+#include <rmf_fleet_adapter/agv/Transformation.hpp>
+#include "internal_PathGuide.hpp"
+#include "internal_RobotUpdateHandle.hpp"
+#include "internal_FleetUpdateHandle.hpp"
+
+// Public rmf_task API headers
+#include <rmf_task/Event.hpp>
+#include <rmf_task/events/SimpleEventState.hpp>
+#include <rmf_task/requests/ChargeBatteryFactory.hpp>
+#include <rmf_task/requests/ParkRobotFactory.hpp>
+
+// ROS2 utilities for rmf_traffic
+#include <rmf_traffic/Trajectory.hpp>
+#include <rmf_traffic/agv/Interpolate.hpp>
+#include <rmf_traffic/agv/Planner.hpp>
+
+#include <rmf_traffic/geometry/Circle.hpp>
+#include <rmf_traffic_ros2/Time.hpp>
+#include <rmf_utils/math.hpp>
+
+#include <rmf_battery/agv/BatterySystem.hpp>
+#include <rmf_battery/agv/SimpleMotionPowerSink.hpp>
+#include <rmf_battery/agv/SimpleDevicePowerSink.hpp>
+#include <rmf_fleet_adapter/agv/parse_graph.hpp>
+#include <rmf_fleet_adapter/tasks/ParkRobotIndefinitely.hpp>
+
+#include <thread>
+#include <yaml-cpp/yaml.h>
+#include <iostream>
+
+//==============================================================================
+namespace rmf_fleet_adapter {
+namespace agv {
+
+using ConsiderRequest = PathGuide::ConsiderRequest;
+
+//==============================================================================
+class PathGuide::RobotState::Implementation
+{
+public:
+  std::string map_name;
+  Eigen::Vector3d position;
+  double battery_soc;
+};
+
+//==============================================================================
+PathGuide::RobotState::RobotState(
+  std::string map_name,
+  Eigen::Vector3d position,
+  double battery_soc)
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{
+      std::move(map_name),
+      position,
+      battery_soc
+    }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::string& PathGuide::RobotState::map() const
+{
+  return _pimpl->map_name;
+}
+
+//==============================================================================
+void PathGuide::RobotState::set_map(std::string value)
+{
+  _pimpl->map_name = std::move(value);
+}
+
+//==============================================================================
+Eigen::Vector3d PathGuide::RobotState::position() const
+{
+  return _pimpl->position;
+}
+
+//==============================================================================
+void PathGuide::RobotState::set_position(Eigen::Vector3d value)
+{
+  _pimpl->position = value;
+}
+
+//==============================================================================
+double PathGuide::RobotState::battery_state_of_charge() const
+{
+  return _pimpl->battery_soc;
+}
+
+//==============================================================================
+void PathGuide::RobotState::set_battery_state_of_charge(double value)
+{
+  _pimpl->battery_soc = value;
+}
+
+//==============================================================================
+class PathGuide::RobotConfiguration::Implementation
+{
+public:
+  std::vector<std::string> compatible_chargers;
+  std::optional<bool> responsive_wait;
+  std::optional<double> max_merge_waypoint_distance;
+  std::optional<double> max_merge_lane_distance;
+  std::optional<double> min_lane_length;
+  std::optional<rmf_task::ConstRequestFactoryPtr> finishing_request;
+};
+
+//==============================================================================
+PathGuide::RobotConfiguration::RobotConfiguration(
+  std::vector<std::string> compatible_chargers,
+  std::optional<bool> responsive_wait,
+  std::optional<double> max_merge_waypoint_distance,
+  std::optional<double> max_merge_lane_distance,
+  std::optional<double> min_lane_length)
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{
+      std::move(compatible_chargers),
+      responsive_wait,
+      max_merge_waypoint_distance,
+      max_merge_lane_distance,
+      min_lane_length,
+      std::nullopt
+    }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::vector<std::string>&
+PathGuide::RobotConfiguration::compatible_chargers() const
+{
+  return _pimpl->compatible_chargers;
+}
+
+//==============================================================================
+void PathGuide::RobotConfiguration::set_compatible_chargers(
+  std::vector<std::string> chargers)
+{
+  _pimpl->compatible_chargers = std::move(chargers);
+}
+
+//==============================================================================
+std::optional<bool> PathGuide::RobotConfiguration::responsive_wait() const
+{
+  return _pimpl->responsive_wait;
+}
+
+//==============================================================================
+void PathGuide::RobotConfiguration::set_responsive_wait(
+  std::optional<bool> enable)
+{
+  _pimpl->responsive_wait = enable;
+}
+
+//==============================================================================
+std::optional<double> PathGuide::RobotConfiguration::
+max_merge_waypoint_distance() const
+{
+  return _pimpl->max_merge_waypoint_distance;
+}
+
+//==============================================================================
+void PathGuide::RobotConfiguration::set_max_merge_waypoint_distance(
+  std::optional<double> distance)
+{
+  _pimpl->max_merge_waypoint_distance = distance;
+}
+
+//==============================================================================
+std::optional<double> PathGuide::RobotConfiguration::
+max_merge_lane_distance() const
+{
+  return _pimpl->max_merge_lane_distance;
+}
+
+//==============================================================================
+void PathGuide::RobotConfiguration::set_max_merge_lane_distance(
+  std::optional<double> distance)
+{
+  _pimpl->max_merge_lane_distance = distance;
+}
+
+//==============================================================================
+std::optional<double> PathGuide::RobotConfiguration::min_lane_length()
+const
+{
+  return _pimpl->min_lane_length;
+}
+
+//==============================================================================
+void PathGuide::RobotConfiguration::set_min_lane_length(
+  std::optional<double> distance)
+{
+  _pimpl->min_lane_length = distance;
+}
+
+//==============================================================================
+std::optional<rmf_task::ConstRequestFactoryPtr> PathGuide::
+RobotConfiguration::finishing_request() const
+{
+  return _pimpl->finishing_request;
+}
+
+//==============================================================================
+void PathGuide::RobotConfiguration::set_finishing_request(
+  std::optional<rmf_task::ConstRequestFactoryPtr> request)
+{
+  _pimpl->finishing_request = std::move(request);
+}
+
+//==============================================================================
+class PathGuide::RobotCallbacks::Implementation
+{
+public:
+  PathRequest follow_path;
+  StopRequest stop;
+  ActionExecutor action_executor;
+  LocalizationRequest localize;
+};
+
+//==============================================================================
+PathGuide::RobotCallbacks::RobotCallbacks(
+  PathRequest follow_path,
+  StopRequest stop,
+  ActionExecutor action_executor)
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{
+      std::move(follow_path),
+      std::move(stop),
+      std::move(action_executor),
+      nullptr
+    }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+auto PathGuide::RobotCallbacks::follow_path() const -> PathRequest
+{
+  return _pimpl->follow_path;
+}
+
+//==============================================================================
+auto PathGuide::RobotCallbacks::stop() const -> StopRequest
+{
+  return _pimpl->stop;
+}
+
+//==============================================================================
+auto PathGuide::RobotCallbacks::action_executor() const -> ActionExecutor
+{
+  return _pimpl->action_executor;
+}
+
+//==============================================================================
+auto PathGuide::RobotCallbacks::with_localization(
+  LocalizationRequest localization) -> RobotCallbacks&
+{
+  _pimpl->localize = std::move(localization);
+  return *this;
+}
+
+//==============================================================================
+auto PathGuide::RobotCallbacks::localize() const -> LocalizationRequest
+{
+  return _pimpl->localize;
+}
+
+//==============================================================================
+class PathGuide::CommandExecution::Implementation::Data
+{
+public:
+  std::vector<std::size_t> waypoints;
+  std::vector<std::size_t> lanes;
+  std::optional<Eigen::Vector2d> target_location;
+  std::optional<double> final_orientation;
+  rmf_traffic::Duration planned_wait_time;
+  std::optional<ScheduleOverride> schedule_override;
+  std::shared_ptr<NavParams> nav_params;
+  std::optional<double> speed_limit;
+  std::function<void(rmf_traffic::Duration)> arrival_estimator;
+
+  void release_stubbornness()
+  {
+    if (schedule_override.has_value())
+    {
+      schedule_override->release_stubbornness();
+    }
+  }
+
+  void update_location(
+    const std::shared_ptr<RobotContext>& context,
+    const std::string& map,
+    Eigen::Vector3d location)
+  {
+    if (schedule_override.has_value())
+    {
+      return schedule_override->overridden_update(
+        context,
+        map,
+        location);
+    }
+
+    auto planner = context->planner();
+    if (!planner)
+    {
+      RCLCPP_ERROR(
+        context->node()->get_logger(),
+        "Planner unavailable for robot [%s], cannot update its location",
+        context->requester_id().c_str());
+      return;
+    }
+
+    const auto& graph = planner->get_configuration().graph();
+    const rmf_traffic::agv::LaneClosure* closures =
+      context->get_lane_closures();
+    std::optional<std::pair<std::size_t, double>> on_waypoint;
+    auto p = Eigen::Vector2d(location[0], location[1]);
+    const double yaw = location[2];
+    for (std::size_t wp : waypoints)
+    {
+      if (wp >= graph.num_waypoints())
+      {
+        RCLCPP_ERROR(
+          context->node()->get_logger(),
+          "Robot [%s] has a command with a waypoint [%lu] that is outside "
+          "the range of the graph [%lu]. We will not do a location update.",
+          context->requester_id().c_str(),
+          wp,
+          graph.num_waypoints());
+        // Should we also issue a replan command?
+        return;
+      }
+
+      const auto p_wp = graph.get_waypoint(wp).get_location();
+      auto dist = (p - p_wp).norm();
+      if (dist <= nav_params->max_merge_waypoint_distance)
+      {
+        if (!on_waypoint.has_value() || dist < on_waypoint->second)
+        {
+          on_waypoint = std::make_pair(wp, dist);
+        }
+      }
+    }
+
+    rmf_traffic::agv::Plan::StartSet starts;
+    const auto now = rmf_traffic_ros2::convert(context->node()->now());
+    if (on_waypoint.has_value())
+    {
+      const auto wp = on_waypoint->first;
+      starts.push_back(rmf_traffic::agv::Plan::Start(now, wp, yaw, p));
+      for (std::size_t lane_id : graph.lanes_from(wp))
+      {
+        if (lane_id >= graph.num_lanes())
+        {
+          RCLCPP_ERROR(
+            context->node()->get_logger(),
+            "Nav graph for robot [%s] has an invalid lane ID [%lu] leaving "
+            "vertex [%lu], lane ID range is [%lu]. We will not do a location "
+            "update.",
+            context->requester_id().c_str(),
+            lane_id,
+            wp,
+            graph.num_lanes());
+          // Should we also issue a replan command?
+          return;
+        }
+
+        if (closures && closures->is_closed(lane_id))
+        {
+          // Don't use a lane that's closed
+          continue;
+        }
+
+        if (nav_params->strict_lanes.count(lane_id) > 0)
+        {
+          // The robot needs to fully approach the beginning waypoint before
+          // using this lane
+          continue;
+        }
+
+        auto wp_exit = graph.get_lane(lane_id).exit().waypoint_index();
+        starts.push_back(
+          rmf_traffic::agv::Plan::Start(now, wp_exit, yaw, p, lane_id));
+      }
+    }
+    else
+    {
+      std::optional<std::pair<std::size_t, double>> on_lane;
+      for (auto lane_id : lanes)
+      {
+        if (lane_id >= graph.num_lanes())
+        {
+          RCLCPP_ERROR(
+            context->node()->get_logger(),
+            "Robot [%s] has a command with a lane [%lu] that is outside the "
+            "range of the graph [%lu]. We will not do a location update.",
+            context->requester_id().c_str(),
+            lane_id,
+            graph.num_lanes());
+          // Should we also issue a replan command?
+          return;
+        }
+
+        if (closures && closures->is_closed(lane_id))
+        {
+          continue;
+        }
+
+        if (nav_params->strict_lanes.count(lane_id) > 0)
+        {
+          // This is a strict lane, so we cannot start from its middle.
+          continue;
+        }
+
+        const auto& lane = graph.get_lane(lane_id);
+        const auto p0 =
+          graph.get_waypoint(lane.entry().waypoint_index()).get_location();
+        const auto p1 =
+          graph.get_waypoint(lane.exit().waypoint_index()).get_location();
+        const auto lane_length = (p1 - p0).norm();
+        double dist_to_lane = 0.0;
+        if (lane_length < nav_params->min_lane_length)
+        {
+          dist_to_lane = std::min(
+            (p - p0).norm(),
+            (p - p1).norm());
+        }
+        else
+        {
+          const auto lane_u = (p1 - p0)/lane_length;
+          const auto proj = (p - p0).dot(lane_u);
+          if (proj < 0.0 || lane_length < proj)
+          {
+            continue;
+          }
+          dist_to_lane = (p - p0 - proj * lane_u).norm();
+        }
+
+        if (dist_to_lane <= nav_params->max_merge_lane_distance)
+        {
+          if (!on_lane.has_value() || dist_to_lane < on_lane->second)
+          {
+            on_lane = std::make_pair(lane_id, dist_to_lane);
+          }
+        }
+      }
+
+      if (on_lane.has_value())
+      {
+        const auto lane_id = on_lane->first;
+        const auto& lane = graph.get_lane(lane_id);
+        const auto wp0 = lane.entry().waypoint_index();
+        const auto wp1 = lane.exit().waypoint_index();
+        starts.push_back(
+          rmf_traffic::agv::Plan::Start(now, wp1, yaw, p, lane_id));
+
+        if (const auto* reverse_lane = graph.lane_from(wp1, wp0))
+        {
+          starts.push_back(rmf_traffic::agv::Plan::Start(
+              now, wp0, yaw, p, reverse_lane->index()));
+        }
+      }
+    }
+
+    if (starts.empty())
+    {
+      starts = nav_params->compute_plan_starts(*context, map, location, now);
+    }
+
+    if (!starts.empty())
+    {
+      if (context->debug_positions)
+      {
+        std::stringstream ss;
+        ss << __FILE__ << "|" << __LINE__ << ": " << starts.size()
+           << " starts:" << print_starts(starts, graph);
+        std::cout << ss.str() << std::endl;
+      }
+      context->set_location(starts);
+    }
+    else
+    {
+      if (context->debug_positions)
+      {
+        std::stringstream ss;
+        ss << __FILE__ << "|" << __LINE__ << ": setting robot to LOST | "
+           << map << " <" << location.block<2, 1>(0, 0).transpose()
+           << "> orientation " << location[2] * 180.0 / M_PI << "\n";
+        ss << waypoints.size() << " waypoints:";
+        for (std::size_t wp : waypoints)
+        {
+          ss << "\n -- " << print_waypoint(wp, graph);
+        }
+        ss << lanes.size() << " lanes:";
+        for (std::size_t lane : lanes)
+        {
+          ss << "\n -- " << print_lane(lane, graph);
+        }
+
+        std::cout << ss.str() << std::endl;
+      }
+      context->set_lost(Location { now, map, location });
+    }
+
+    if (target_location.has_value())
+    {
+      const auto p_final = *target_location;
+      const auto distance = (p_final - p).norm();
+      double rotation = 0.0;
+      if (final_orientation.has_value())
+      {
+        rotation =
+          std::fabs(rmf_utils::wrap_to_pi(location[2] - *final_orientation));
+        const auto reversible =
+          planner->get_configuration().vehicle_traits()
+          .get_differential()->is_reversible();
+        if (reversible)
+        {
+          const double alternate_orientation = rmf_utils::wrap_to_pi(
+            *final_orientation + M_PI);
+
+          const double alternate_rotation = std::fabs(
+            rmf_utils::wrap_to_pi(location[2] - alternate_orientation));
+          rotation = std::min(rotation, alternate_rotation);
+        }
+      }
+
+      const auto& traits = planner->get_configuration().vehicle_traits();
+      double v = std::max(traits.linear().get_nominal_velocity(), 0.001);
+      if (speed_limit.has_value())
+      {
+        v = std::min(v, *speed_limit);
+      }
+
+      const auto w =
+        std::max(traits.rotational().get_nominal_velocity(), 0.001);
+      const auto t = distance / v + rotation / w;
+      arrival_estimator(
+        rmf_traffic::time::from_seconds(t) + planned_wait_time);
+    }
+  }
+};
+
+void PathGuide::CommandExecution::Implementation::invalidate()
+{
+  if (identifier)
+  {
+    ActivityIdentifier::Implementation::get(*identifier).update_fn = nullptr;
+  }
+
+  if (data)
+  {
+    data->release_stubbornness();
+  }
+}
+
+void PathGuide::CommandExecution::Implementation::finish()
+{
+  if (auto context = w_context.lock())
+  {
+    context->worker().schedule(
+      [
+        context = context,
+        data = this->data,
+        identifier = this->identifier,
+        finisher = this->finisher,
+        accept_ack = this->accept_ack
+      ](const auto&)
+      {
+        if (!ActivityIdentifier::Implementation::get(*identifier).update_fn)
+        {
+          // This activity has already finished, or the path it belonged to was
+          // superseded or stopped. Either way the acknowledgement is inert.
+          return;
+        }
+
+        // Unlike EasyFullControl, the integrator holds a handle to every
+        // waypoint of the path at once, so it can call finished() on a waypoint
+        // that is not the one we are tracking. Ask the path whether this
+        // acknowledgement is in order before consuming the activity.
+        if (accept_ack && !accept_ack())
+        {
+          // accept_ack has already logged the reason.
+          return;
+        }
+
+        // Prevent this activity from doing any further updates
+        ActivityIdentifier::Implementation::get(
+          *identifier).update_fn = nullptr;
+        if (data && data->schedule_override.has_value())
+        {
+          data->release_stubbornness();
+          RCLCPP_INFO(
+            context->node()->get_logger(),
+            "Requesting replan for [%s] after finishing a schedule override",
+            context->requester_id().c_str());
+          context->request_replan();
+        }
+        else if (finisher)
+        {
+          // Trigger the next step in the sequence
+          finisher();
+        }
+      });
+  }
+}
+
+auto PathGuide::CommandExecution::Implementation::override_schedule(
+  std::string map,
+  std::vector<Eigen::Vector3d> path,
+  rmf_traffic::Duration hold) -> Stubbornness
+{
+  auto stubborn = std::make_shared<StubbornOverride>();
+  if (const auto context = w_context.lock())
+  {
+    context->worker().schedule(
+      [
+        context,
+        stubborn,
+        data = this->data,
+        identifier = this->identifier,
+        map = std::move(map),
+        path = std::move(path),
+        hold
+      ](const auto&)
+      {
+        if (!ActivityIdentifier::Implementation::get(*identifier).update_fn)
+        {
+          // Don't do anything because this command is finished
+          return;
+        }
+
+        // KNOWN BUG, deliberately left unguarded. `data` is null for a hold
+        // command -- make_hold constructs it that way, correctly, since a hold
+        // belongs to no path and so has no itinerary segment to override. The
+        // check above does not catch it: a hold has a live `update_fn`, so it
+        // passes cleanly and the next line dereferences null on the worker
+        // thread, taking the adapter down. `finish()` and `invalidate()` both
+        // guard with `if (data)`; this does not.
+        //
+        // Reachable by an integrator calling override_schedule() on the
+        // CommandExecution handed to its LocalizationRequest, which is a hold.
+        // No rmf_demos adapter does that today -- their other call sites use
+        // either a real path waypoint or RobotUpdateHandle::ActionExecution,
+        // which is a different type -- so this is latent rather than live.
+        //
+        // Not fixed here on purpose. EasyFullControl.cpp carries the identical
+        // defect, PathGuide having copied it, so guarding only this copy would
+        // leave the same crash live upstream and hide the shared cause. Being
+        // raised with upstream; see UPSTREAM-DISCUSSION.md issue 3, and the
+        // "Open design questions" section of CLAUDE.md. Match whatever shape
+        // upstream lands rather than patching this in isolation.
+        data->release_stubbornness();
+        data->schedule_override = ScheduleOverride::make(
+          context, map, path, hold, stubborn);
+      });
+  }
+
+  return Stubbornness::Implementation::make(stubborn);
+}
+
+auto PathGuide::CommandExecution::Implementation::make(
+  const std::shared_ptr<RobotContext>& context,
+  Data data_) -> CommandExecution
+{
+  auto data = std::make_shared<Data>(data_);
+  auto update_fn = [w_context = context->weak_from_this(), data](
+    const std::string& map,
+    Eigen::Vector3d location)
+    {
+      if (auto context = w_context.lock())
+      {
+        data->update_location(context, map, location);
+      }
+    };
+  auto identifier = ActivityIdentifier::Implementation::make(update_fn);
+
+  // There is no `begin` callback here: EasyFullControl uses one to issue a
+  // navigation request when the command reaches the front of the queue, but
+  // PathGuide dispatches the whole path up front instead. `finisher` and
+  // `accept_ack` are filled in by PathProgressTracker::make.
+  CommandExecution cmd;
+  cmd._pimpl = rmf_utils::make_impl<Implementation>(
+    Implementation{context, data, nullptr, nullptr, identifier});
+  return cmd;
+}
+
+auto PathGuide::CommandExecution::Implementation::make_hold(
+  const std::shared_ptr<RobotContext>& context,
+  rmf_traffic::Time expected_time,
+  rmf_traffic::PlanId plan_id,
+  std::function<void()> finisher) -> CommandExecution
+{
+  auto update_fn = [
+    w_context = context->weak_from_this(),
+    expected_time,
+    plan_id
+    ](
+    const std::string& map,
+    Eigen::Vector3d location)
+    {
+      const auto context = w_context.lock();
+      if (!context)
+        return;
+
+      const auto delay = context->now() - expected_time;
+      context->itinerary().cumulative_delay(plan_id, delay);
+      if (const auto nav_params = context->nav_params())
+      {
+        if (context->debug_positions)
+        {
+          std::cout << "Searching for location from " << __FILE__ << "|" <<
+            __LINE__ << std::endl;
+        }
+        nav_params->search_for_location(map, location, *context);
+      }
+    };
+  auto identifier = ActivityIdentifier::Implementation::make(update_fn);
+
+  // A hold command does not belong to a path, so there is no ordering to check
+  // and accept_ack stays null (meaning "always accept").
+  CommandExecution cmd;
+  cmd._pimpl = rmf_utils::make_impl<Implementation>(
+    Implementation{context, nullptr, finisher, nullptr, identifier});
+  return cmd;
+}
+
+//==============================================================================
+void PathGuide::CommandExecution::finished()
+{
+  _pimpl->finish();
+}
+
+//==============================================================================
+bool PathGuide::CommandExecution::okay() const
+{
+  if (!_pimpl->identifier)
+  {
+    return false;
+  }
+
+  if (!ActivityIdentifier::Implementation::get(*_pimpl->identifier).update_fn)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+//==============================================================================
+auto PathGuide::CommandExecution::override_schedule(
+  std::string map,
+  std::vector<Eigen::Vector3d> path,
+  rmf_traffic::Duration hold) -> Stubbornness
+{
+  return _pimpl->override_schedule(std::move(map), std::move(path), hold);
+}
+
+//==============================================================================
+auto PathGuide::CommandExecution::identifier() const
+-> ConstActivityIdentifierPtr
+{
+  return _pimpl->identifier;
+}
+
+//==============================================================================
+PathGuide::CommandExecution::CommandExecution()
+{
+  // Do nothing
+}
+
+//==============================================================================
+PathGuide::PathGuide()
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::string& PathGuide::Destination::map() const
+{
+  return _pimpl->map;
+}
+
+//==============================================================================
+Eigen::Vector3d PathGuide::Destination::position() const
+{
+  return _pimpl->position;
+}
+
+//==============================================================================
+Eigen::Vector2d PathGuide::Destination::xy() const
+{
+  return _pimpl->position.block<2, 1>(0, 0);
+}
+
+//==============================================================================
+double PathGuide::Destination::yaw() const
+{
+  return _pimpl->position[2];
+}
+
+//==============================================================================
+std::optional<std::size_t> PathGuide::Destination::graph_index() const
+{
+  return _pimpl->graph_index;
+}
+
+//==============================================================================
+std::string PathGuide::Destination::name() const
+{
+  return _pimpl->name;
+}
+
+//==============================================================================
+std::optional<double> PathGuide::Destination::speed_limit() const
+{
+  return _pimpl->speed_limit;
+}
+
+//==============================================================================
+std::optional<std::string> PathGuide::Destination::dock() const
+{
+  return _pimpl->dock;
+}
+
+//==============================================================================
+rmf_traffic::agv::Graph::LiftPropertiesPtr
+PathGuide::Destination::inside_lift() const
+{
+  return _pimpl->lift;
+}
+
+//==============================================================================
+PathGuide::Destination::Destination()
+{
+  // Do nothing
+}
+
+//==============================================================================
+const PathGuide::Destination& PathGuide::PathWaypoint::destination() const
+{
+  return _pimpl->destination;
+}
+
+//==============================================================================
+double PathGuide::PathWaypoint::merge_radius() const
+{
+  return _pimpl->merge_radius;
+}
+
+//==============================================================================
+std::size_t PathGuide::PathWaypoint::index() const
+{
+  return _pimpl->index;
+}
+
+//==============================================================================
+auto PathGuide::PathWaypoint::execution() const -> CommandExecution
+{
+  return _pimpl->execution;
+}
+
+//==============================================================================
+PathGuide::PathWaypoint::PathWaypoint()
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::vector<PathGuide::PathWaypoint>& PathGuide::Path::waypoints() const
+{
+  return _pimpl->waypoints;
+}
+
+//==============================================================================
+std::size_t PathGuide::Path::plan_id() const
+{
+  return _pimpl->plan_id;
+}
+
+//==============================================================================
+const std::string& PathGuide::Path::map() const
+{
+  return _pimpl->map;
+}
+
+//==============================================================================
+PathGuide::Path::Path()
+{
+  // Do nothing
+}
+
+//==============================================================================
+/// Tracks how far along a dispatched path the robot has reported itself to be.
+///
+/// This is where PathGuide diverges most sharply from EasyFullControl's
+/// ProgressTracker. EasyFullControl pops one command off a queue at a time and
+/// only then binds that command's `finisher`, which is safe because the
+/// integrator can never see a command it has not been handed. PathGuide hands
+/// over every command up front, so:
+///
+///  * every `finisher` and `accept_ack` is bound at construction, otherwise an
+///    acknowledgement for a not-yet-current waypoint would invoke a null
+///    std::function and take the fleet adapter down;
+///  * `accept_ack` enforces strictly in-order acknowledgement, so a confused
+///    integrator gets a warning instead of a silently skewed path;
+///  * `invalidate_all()` lets `stop()` and a replan neutralise every handle the
+///    integrator is still holding, not just the current one.
+struct PathProgressTracker : std::enable_shared_from_this<PathProgressTracker>
+{
+  /// Every command of this path, in the order the robot should complete them.
+  std::vector<PathGuide::CommandExecution> commands;
+
+  /// Index into `commands` of the waypoint the robot is currently approaching.
+  /// Equal to commands.size() once the whole path has been acknowledged.
+  std::size_t current_index = 0;
+
+  /// The identifier of the command at `current_index`, or nullptr when the path
+  /// is complete or has been invalidated.
+  PathGuide::ActivityIdentifierPtr current_identifier;
+
+  TriggerOnce finished;
+
+  /// Set once the path is superseded or stopped. A dead tracker rejects every
+  /// acknowledgement.
+  bool dead = false;
+
+  std::weak_ptr<RobotContext> w_context;
+
+  /// Keeps the reported path index monotonic for this path. Held here so it
+  /// lives exactly as long as the path does — a new path gets a fresh guard,
+  /// which is what "never decrease *for that path*" requires.
+  PathIndexGuardPtr index_guard;
+
+  /// Gate for an acknowledgement of the waypoint at `index`. Returns true only
+  /// if that waypoint is the one being tracked right now.
+  bool accept(std::size_t index)
+  {
+    if (dead)
+    {
+      return false;
+    }
+
+    if (index == current_index)
+    {
+      return true;
+    }
+
+    if (const auto context = w_context.lock())
+    {
+      if (index < current_index)
+      {
+        RCLCPP_WARN(
+          context->node()->get_logger(),
+          "Robot [%s] acknowledged waypoint [%lu] of its path, which it has "
+          "already passed. Ignoring. This is usually a duplicate "
+          "acknowledgement.",
+          context->requester_id().c_str(),
+          index);
+      }
+      else
+      {
+        RCLCPP_WARN(
+          context->node()->get_logger(),
+          "Robot [%s] acknowledged waypoint [%lu] of its path while waypoint "
+          "[%lu] is still outstanding. Waypoints must be acknowledged in "
+          "order, so this acknowledgement is ignored. If the robot skipped a "
+          "waypoint, acknowledge the skipped waypoints in sequence first.",
+          context->requester_id().c_str(),
+          index,
+          current_index);
+      }
+    }
+
+    return false;
+  }
+
+  /// Move on to the next waypoint. Called after `accept` has approved an
+  /// acknowledgement and the command has consumed its activity.
+  void advance()
+  {
+    if (dead)
+    {
+      return;
+    }
+
+    ++current_index;
+    if (current_index >= commands.size())
+    {
+      current_identifier = nullptr;
+      finished.trigger();
+      return;
+    }
+
+    current_identifier = PathGuide::CommandExecution::Implementation
+      ::get(commands[current_index]).identifier;
+  }
+
+  /// Arm the first waypoint. Called once, immediately after the path has been
+  /// handed to the integrator.
+  void begin()
+  {
+    if (commands.empty())
+    {
+      current_identifier = nullptr;
+      finished.trigger();
+      return;
+    }
+
+    current_identifier = PathGuide::CommandExecution::Implementation
+      ::get(commands[current_index]).identifier;
+  }
+
+  /// Neutralise every command of this path so that a late acknowledgement from
+  /// the integrator cannot disturb whatever the robot is doing now.
+  void invalidate_all()
+  {
+    dead = true;
+    current_identifier = nullptr;
+    for (auto& cmd : commands)
+    {
+      PathGuide::CommandExecution::Implementation::get(cmd).invalidate();
+    }
+  }
+
+  /// Takes the queue by rvalue reference on purpose. The tracker becomes the
+  /// sole owner of those CommandExecutions, because `make` binds `accept_ack`
+  /// and `finisher` onto its own copies — handles taken from anywhere else are
+  /// inert. Forcing `std::move` at the call site makes that transfer visible,
+  /// and makes reusing the caller's vector afterwards an obvious mistake rather
+  /// than a silent one.
+  static std::shared_ptr<PathProgressTracker> make(
+    const std::shared_ptr<RobotContext>& context,
+    std::vector<PathGuide::CommandExecution>&& queue,
+    std::function<void()> finished,
+    PathIndexGuardPtr index_guard)
+  {
+    auto tracker = std::make_shared<PathProgressTracker>();
+    tracker->w_context = context;
+    tracker->commands = std::move(queue);
+    tracker->finished = TriggerOnce(std::move(finished));
+    tracker->index_guard = std::move(index_guard);
+
+    // Bind the ordering gate and the advance callback for every command now,
+    // while we still own the whole queue. Doing this lazily is what would make
+    // an out-of-order acknowledgement a crash rather than a warning.
+    for (std::size_t i = 0; i < tracker->commands.size(); ++i)
+    {
+      auto& impl = PathGuide::CommandExecution::Implementation::get(
+        tracker->commands[i]);
+
+      impl.accept_ack = [w_progress = tracker->weak_from_this(), i]() -> bool
+        {
+          if (const auto progress = w_progress.lock())
+          {
+            return progress->accept(i);
+          }
+          return false;
+        };
+
+      impl.finisher = [w_progress = tracker->weak_from_this()]()
+        {
+          if (const auto progress = w_progress.lock())
+          {
+            progress->advance();
+          }
+        };
+    }
+
+    return tracker;
+  }
+};
+
+//==============================================================================
+/// Hands the whole path from follow_new_path() to the robot via its API in one
+/// request, then tracks the robot's progress through it as the integrator
+/// acknowledges each waypoint.
+class PathGuideCommandHandle : public RobotCommandHandle,
+  public std::enable_shared_from_this<PathGuideCommandHandle>
+{
+public:
+  using Planner = rmf_traffic::agv::Planner;
+  using Graph = rmf_traffic::agv::Graph;
+  using VehicleTraits = rmf_traffic::agv::VehicleTraits;
+  using ActionExecution = RobotUpdateHandle::ActionExecution;
+  using ActionExecutor = RobotUpdateHandle::ActionExecutor;
+  using PathRequest = PathGuide::PathRequest;
+  using StopRequest = PathGuide::StopRequest;
+  using Status = rmf_task::Event::Status;
+  using ActivityIdentifierPtr = PathGuide::ActivityIdentifierPtr;
+
+  // State machine values.
+  enum class InternalRobotState : uint8_t
+  {
+    IDLE = 0,
+    MOVING = 1
+  };
+
+  PathGuideCommandHandle(
+    std::shared_ptr<Location> reported_location,
+    std::shared_ptr<NavParams> nav_params,
+    PathRequest handle_path_request,
+    StopRequest handle_stop);
+
+  // Implement base class methods.
+  void stop() final;
+
+  void follow_new_path(
+    const std::vector<rmf_traffic::agv::Plan::Waypoint>& waypoints,
+    ArrivalEstimator next_arrival_estimator,
+    RequestCompleted path_finished_callback) final;
+
+  void dock(
+    const std::string& dock_name,
+    RequestCompleted docking_finished_callback) final;
+
+  Eigen::Vector3d to_robot_coordinates(
+    const std::string& map,
+    Eigen::Vector3d position) const
+  {
+    auto robot_position = nav_params->to_robot_coordinates(map, position);
+    if (robot_position.has_value())
+    {
+      return *robot_position;
+    }
+
+    if (const auto context = w_context.lock())
+    {
+      RCLCPP_WARN(
+        context->node()->get_logger(),
+        "[PathGuide] Unable to find robot transform for map [%s] for "
+        "robot [%s]. We will not apply a transform.",
+        map.c_str(),
+        context->requester_id().c_str());
+    }
+    return position;
+  }
+
+  /// The scale factor that to_robot_coordinates() applies on this map.
+  ///
+  /// Distances have to cross the same transform as the positions they are
+  /// compared against. A Destination's xy() is published in robot coordinates,
+  /// so an arrival radius left in RMF metres would be measured against a
+  /// scaled distance: too tight and the waypoint is never acknowledged and the
+  /// path freezes, too loose and every tolerance the integrator derives from it
+  /// is quietly wrong — including whatever it applies inside a lift cabin,
+  /// which is the one place a too-generous radius closes doors on a robot.
+  /// Only the scale matters — rotation and translation do not change a
+  /// distance.
+  ///
+  /// Falls back to 1.0 in exactly the cases to_robot_coordinates() falls back
+  /// to an untransformed position, so the two stay consistent.
+  double robot_coordinate_scale(const std::string& map) const
+  {
+    if (!nav_params->transforms_to_robot_coords)
+    {
+      return 1.0;
+    }
+
+    const auto tf_it = nav_params->transforms_to_robot_coords->find(map);
+    if (tf_it == nav_params->transforms_to_robot_coords->end())
+    {
+      return 1.0;
+    }
+
+    return tf_it->second.scale();
+  }
+
+  std::weak_ptr<RobotContext> w_context;
+  std::shared_ptr<NavParams> nav_params;
+  std::shared_ptr<PathProgressTracker> current_progress;
+  std::shared_ptr<Location> reported_location;
+  rclcpp::TimerBase::SharedPtr localize_timer;
+
+  // Callbacks from user
+  PathRequest handle_path_request;
+  StopRequest handle_stop;
+};
+
+//==============================================================================
+PathGuideCommandHandle::PathGuideCommandHandle(
+  std::shared_ptr<Location> reported_location_,
+  std::shared_ptr<NavParams> nav_params_,
+  PathRequest handle_path_request_,
+  StopRequest handle_stop_)
+: nav_params(std::move(nav_params_)),
+  reported_location(std::move(reported_location_)),
+  handle_path_request(std::move(handle_path_request_)),
+  handle_stop(std::move(handle_stop_))
+{
+  // Do nothing
+}
+
+//==============================================================================
+void PathGuideCommandHandle::stop()
+{
+  if (!this->current_progress)
+  {
+    return;
+  }
+
+  const auto activity_identifier = this->current_progress->current_identifier;
+
+  // Prevent any further specialized updates. The integrator is holding a
+  // CommandExecution for every remaining waypoint of this path, so all of them
+  // have to be neutralised here — not just the current one as EasyFullControl
+  // does — otherwise a late acknowledgement would advance a path that no longer
+  // exists.
+  //
+  // This happens even when there is no current identifier, i.e. the path has
+  // already completed or been invalidated. EasyFullControl can return early in
+  // that case because it never handed the integrator anything; here the handles
+  // are out in the wild either way.
+  this->current_progress->invalidate_all();
+  this->current_progress = nullptr;
+
+  if (activity_identifier)
+  {
+    this->handle_stop(activity_identifier);
+  }
+}
+
+//==============================================================================
+void PathGuideCommandHandle::follow_new_path(
+  const std::vector<rmf_traffic::agv::Plan::Waypoint>& cmd_waypoints,
+  ArrivalEstimator next_arrival_estimator_,
+  RequestCompleted path_finished_callback_)
+{
+  const auto context = w_context.lock();
+  if (!context)
+  {
+    return;
+  }
+
+  RCLCPP_DEBUG(
+    context->node()->get_logger(),
+    "follow_new_path for robot [%s] with PlanId [%ld]",
+    context->requester_id().c_str(),
+    context->itinerary().current_plan_id());
+
+  if (cmd_waypoints.empty() ||
+    next_arrival_estimator_ == nullptr ||
+    path_finished_callback_ == nullptr)
+  {
+    RCLCPP_WARN(
+      context->node()->get_logger(),
+      "Received a new path for robot [%s] with invalid parameters. "
+      " Ignoring...",
+      context->requester_id().c_str());
+    return;
+  }
+
+  const auto& planner = context->planner();
+  if (!planner)
+  {
+    RCLCPP_ERROR(
+      context->node()->get_logger(),
+      "Planner missing for [%s], cannot follow new path commands",
+      context->requester_id().c_str());
+    return;
+  }
+  const auto& graph = planner->get_configuration().graph();
+  std::vector<rmf_traffic::agv::Plan::Waypoint> waypoints = cmd_waypoints;
+
+  if (waypoints.size() < 2)
+  {
+    // This command doesn't actually want us to go anywhere so we will consider
+    // it completed right away. But in case the robot is doing something else
+    // right now, we will command it to stop.
+    stop();
+    path_finished_callback_();
+    return;
+  }
+
+  std::optional<std::string> opt_initial_map;
+  for (const auto& wp : waypoints)
+  {
+    if (wp.graph_index().has_value())
+    {
+      const std::size_t i = *wp.graph_index();
+      opt_initial_map = graph.get_waypoint(i).get_map_name();
+      break;
+    }
+  }
+
+  const auto current_location = context->location();
+  if (!opt_initial_map.has_value())
+  {
+    for (const auto& l : current_location)
+    {
+      opt_initial_map = graph.get_waypoint(l.waypoint()).get_map_name();
+      break;
+    }
+  }
+
+  if (!opt_initial_map.has_value())
+  {
+    RCLCPP_ERROR(
+      context->node()->get_logger(),
+      "Could not find an initial map in follow_new_path command for robot [%s]."
+      "This means the robot is lost and may need an operator to intervene.",
+      context->requester_id().c_str());
+    // Stop to prevent cascading problems.
+    stop();
+    return;
+  }
+  std::string initial_map = *opt_initial_map;
+  const std::string starting_map = initial_map;
+
+  std::vector<PathGuide::CommandExecution> queue;
+  std::vector<PathGuide::Destination> destinations;
+  std::vector<double> merge_radii;
+
+  // RMF forbids ever reporting a path index lower than one already reported for
+  // this path, because MoveRobot turns the index into an unclamped itinerary
+  // delay. Since the integrator picks which index gets reported — by choosing
+  // the ActivityIdentifier it passes to update() — the invariant has to be
+  // enforced here rather than trusted to integrator code. On violation the only
+  // safe response is to stop following the path and replan.
+  // \sa PathIndexGuard in internal_PathGuide.hpp
+  auto index_guard = std::make_shared<PathIndexGuard>();
+  index_guard->on_backtrack =
+    [w = weak_from_this(), w_context = context->weak_from_this()](
+    std::size_t attempted, std::size_t highest)
+    {
+      const auto context = w_context.lock();
+      if (!context)
+      {
+        return;
+      }
+
+      RCLCPP_ERROR(
+        context->node()->get_logger(),
+        "Robot [%s] reported that it is approaching path index [%lu] after "
+        "already having reported index [%lu]. Backtracking the reported path "
+        "index is not allowed: it corrupts the itinerary delay and can deadlock "
+        "other robots. Stopping the robot and requesting a replan. Report a "
+        "monotonically non-decreasing index — usually the waypoint currently "
+        "being approached, never the nearest one.",
+        context->requester_id().c_str(),
+        attempted,
+        highest);
+
+      // Deferred to the worker rather than run inline: stop() clears
+      // current_progress, which owns the tracker whose command callback we are
+      // running inside right now.
+      context->worker().schedule(
+        [w, w_context](const auto&)
+        {
+          if (const auto self = w.lock())
+          {
+            self->stop();
+          }
+
+          if (const auto context = w_context.lock())
+          {
+            context->request_replan();
+          }
+        });
+    };
+
+  bool found_connection = false;
+  std::size_t i0 = 0;
+  for (std::size_t i = 0; i < waypoints.size(); ++i)
+  {
+    const auto& wp = waypoints[i];
+    for (const auto& l : current_location)
+    {
+      if (wp.graph_index().has_value())
+      {
+        if (nav_params->in_same_stack(*wp.graph_index(),
+          l.waypoint()) && !l.lane().has_value())
+        {
+          if (l.location().has_value())
+          {
+            if (i > 0)
+            {
+              found_connection = true;
+              i0 = i - 1;
+            }
+            else
+            {
+              const double dist =
+                (*l.location() - wp.position().block<2, 1>(0, 0)).norm();
+              if (dist <= nav_params->max_merge_lane_distance)
+              {
+                found_connection = true;
+                i0 = 0;
+              }
+            }
+          }
+          else
+          {
+            found_connection = true;
+            i0 = i;
+          }
+        }
+
+        if (l.lane().has_value())
+        {
+          Eigen::Vector2d p_l;
+          if (l.location().has_value())
+          {
+            p_l = *l.location();
+          }
+          else
+          {
+            p_l = graph.get_waypoint(l.waypoint()).get_location();
+          }
+          const double dist = (wp.position().block<2, 1>(0, 0) - p_l).norm();
+          const double merge_dist = graph.get_waypoint(*wp.graph_index())
+            .merge_radius().value_or(nav_params->max_merge_lane_distance);
+          if (dist <= merge_dist)
+          {
+            found_connection = true;
+            i0 = i;
+          }
+        }
+      }
+      else
+      {
+        Eigen::Vector2d p_l;
+        if (l.location().has_value())
+        {
+          p_l = *l.location();
+        }
+        else
+        {
+          p_l = graph.get_waypoint(l.waypoint()).get_location();
+        }
+        const double dist = (wp.position().block<2, 1>(0, 0) - p_l).norm();
+        if (dist <= nav_params->max_merge_lane_distance)
+        {
+          found_connection = true;
+          i0 = i;
+        }
+      }
+    }
+
+    if (i > 0)
+    {
+      for (const auto lane : wp.approach_lanes())
+      {
+        for (const auto& l : current_location)
+        {
+          if (l.lane().has_value())
+          {
+            if (lane == *l.lane())
+            {
+              found_connection = true;
+              i0 = i - 1;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (!found_connection)
+  {
+    // The robot has drifted away from the starting point since the plan started
+    // so we'll ask for a new plan.
+    std::stringstream ss;
+    ss << "Current location" << print_starts(current_location, graph);
+    ss << "\nCommanded path:";
+    const auto t0 = waypoints.front().time();
+    for (const auto& wp : waypoints)
+    {
+      ss << "\n -- " << print_plan_waypoint(wp, graph, t0);
+    }
+
+    RCLCPP_INFO(
+      context->node()->get_logger(),
+      "Requesting replan for [%s] because it is too far from its commanded "
+      "path. Details:\n%s",
+      context->requester_id().c_str(),
+      ss.str().c_str());
+
+    // Stop the robot to prevent it from diverging too far while a replan
+    // happens.
+    stop();
+    context->request_replan();
+    return;
+  }
+
+  if (i0 >= waypoints.size() - 1)
+  {
+    // Always issue at least one command to approach the final waypoint.
+    i0 = waypoints.size() - 2;
+  }
+
+  std::size_t i1 = i0 + 1;
+  while (i1 < waypoints.size())
+  {
+    std::vector<std::size_t> cmd_wps;
+    std::vector<std::size_t> cmd_lanes;
+    const auto& wp0 = waypoints[i0];
+    const auto& wp1 = waypoints[i1];
+    if (wp0.graph_index().has_value())
+    {
+      cmd_wps.push_back(*wp0.graph_index());
+    }
+
+    for (auto lane_id : wp1.approach_lanes())
+    {
+      cmd_lanes.push_back(lane_id);
+      const auto& lane = graph.get_lane(lane_id);
+      const std::size_t entry_wp = lane.entry().waypoint_index();
+      const std::size_t exit_wp = lane.exit().waypoint_index();
+      for (auto wp : {entry_wp, exit_wp})
+      {
+        if (std::find(cmd_wps.begin(), cmd_wps.end(), wp) == cmd_wps.end())
+        {
+          cmd_wps.push_back(wp);
+        }
+      }
+    }
+
+    std::string map = [&]()
+      {
+        if (wp1.graph_index().has_value())
+        {
+          return graph.get_waypoint(*wp1.graph_index()).get_map_name();
+        }
+
+        return initial_map;
+      }();
+    if (initial_map != map)
+    {
+      initial_map = map;
+    }
+
+    std::optional<double> speed_limit;
+    for (const auto arrival_lane : wp1.approach_lanes())
+    {
+      if (const auto lane_speed_limit = graph.get_lane(
+        arrival_lane).properties().speed_limit())
+      {
+        if (!speed_limit.has_value())
+        {
+          speed_limit = lane_speed_limit;
+        }
+        else if (*lane_speed_limit < *speed_limit)
+        {
+          speed_limit = lane_speed_limit;
+        }
+      }
+    }
+
+    Eigen::Vector3d target_position = wp1.position();
+    std::size_t target_index = i1;
+    rmf_traffic::Duration planned_wait_time = rmf_traffic::Duration(0);
+
+    // Skip command points that only exist to rotate the robot. PathGuide always
+    // does this: a rotate-in-place pseudo-waypoint is meaningless inside a path
+    // the robot is expected to smooth over, so every destination we emit
+    // carries the final orientation for its vertex and the robot owns its own
+    // in-place turns.
+    std::size_t i2 = i1 + 1;
+    while (i2 < waypoints.size())
+    {
+      const auto& wp2 = waypoints[i2];
+
+      const bool midlane_wait =
+        !wp1.graph_index().has_value() && !wp2.graph_index().has_value();
+      const bool same_stack =
+        wp1.graph_index().has_value() && wp2.graph_index().has_value()
+        && nav_params->in_same_stack(*wp1.graph_index(), *wp2.graph_index());
+
+      if (same_stack || midlane_wait)
+      {
+        target_index = i2;
+        target_position = wp2.position();
+        const auto delta_yaw = rmf_utils::wrap_to_pi(
+          wp1.position()[2] - wp2.position()[2]);
+        if (std::abs(delta_yaw)*180.0 / M_PI < 1e-2)
+        {
+          // The plan had a wait between these points.
+          planned_wait_time += wp2.time() - wp1.time();
+        }
+        ++i2;
+        continue;
+      }
+      break;
+    }
+
+    rmf_traffic::agv::Graph::LiftPropertiesPtr in_lift;
+    if (wp1.graph_index().has_value())
+    {
+      in_lift = graph.get_waypoint(*wp1.graph_index()).in_lift();
+    }
+    else
+    {
+      for (const auto& lift : graph.all_known_lifts())
+      {
+        if (lift->is_in_lift(target_position.block<2, 1>(0, 0)))
+        {
+          in_lift = lift;
+          break;
+        }
+      }
+    }
+
+    // Publish the bound the integrator's arrival test must respect, taken from
+    // the tolerance RMF itself merges with so the two cannot drift apart.
+    //
+    // max_merge_lane_distance, never max_merge_waypoint_distance. The latter
+    // defaults to 1e-3 m because RMF learns exact vertex identity from the plan
+    // rather than from geometry, so it can afford to be that strict. An
+    // integrator deciding arrival from reported position cannot: a 1 mm bound
+    // would cap its arrival test at essentially nothing and no path would ever
+    // advance.
+    //
+    // This is the *robot's* value, not the fleet's -- a RobotConfiguration may
+    // narrow it, and add_robot applies that to robot_nav_params -- so a robot
+    // that merges more tightly is told so.
+    // \sa compute_merge_radius. This is a tolerance, not an arrival radius:
+    // PathGuide no longer has an opinion about when a waypoint counts as
+    // reached. The integrator decides that -- including, at a lift waypoint,
+    // the far harder question of when the robot is far enough inside the cabin
+    // for the doors to close -- from destination().inside_lift().
+    //
+    // Computed in RMF metres, then scaled into robot coordinates below so it
+    // matches the frame the destination position is published in.
+    const double waypoint_merge_radius = compute_merge_radius(
+      nav_params->max_merge_lane_distance,
+      wp1.graph_index().has_value()
+      ? graph.get_waypoint(*wp1.graph_index()).merge_radius()
+      : std::nullopt);
+
+    // \sa robot_coordinate_scale. Must be read before `map` is moved from.
+    const double scaled_merge_radius =
+      waypoint_merge_radius * robot_coordinate_scale(map);
+
+    const auto command_position = to_robot_coordinates(map, target_position);
+    auto destination = PathGuide::Destination::Implementation::make(
+      std::move(map),
+      command_position,
+      wp1.graph_index(),
+      nav_params->get_vertex_name(graph, wp1.graph_index()),
+      speed_limit,
+      in_lift);
+
+    queue.push_back(
+      PathGuide::CommandExecution::Implementation::make(
+        context,
+        PathGuide::CommandExecution::Implementation::Data{
+          cmd_wps,
+          cmd_lanes,
+          target_position.block<2, 1>(0, 0),
+          target_position[2],
+          planned_wait_time,
+          std::nullopt,
+          nav_params,
+          speed_limit,
+          [next_arrival_estimator_, target_index, index_guard](
+            rmf_traffic::Duration dt)
+          {
+            if (!index_guard->allow(target_index))
+            {
+              return;
+            }
+
+            next_arrival_estimator_(target_index, dt);
+          }
+        }));
+    destinations.push_back(std::move(destination));
+    merge_radii.push_back(scaled_merge_radius);
+
+    i0 = target_index;
+    i1 = i0 + 1;
+  }
+
+  // The integrator is still holding a CommandExecution for every waypoint of
+  // the path this one supersedes. Neutralise them so a late acknowledgement for
+  // the old path cannot advance the new one.
+  //
+  // Deliberately here rather than at the top of this function. Every early
+  // return above calls stop(), and stop() needs current_progress to still be
+  // live in order to reach handle_stop() and actually halt the robot. Clearing
+  // it earlier silently turns all three of those into no-ops — including the
+  // one that stops a robot which has drifted off its path, which under PathGuide
+  // is still holding the whole route.
+  //
+  // Saved first because invalidate_all() nulls it, and the relocalization
+  // branch below still needs it to halt the robot. \sa the handle_stop call
+  // there for why that branch cannot simply call stop().
+  PathGuide::ActivityIdentifierPtr superseded_identifier = nullptr;
+  if (this->current_progress)
+  {
+    superseded_identifier = this->current_progress->current_identifier;
+    this->current_progress->invalidate_all();
+  }
+
+  this->current_progress = PathProgressTracker::make(
+    context,
+    std::move(queue),
+    path_finished_callback_,
+    index_guard);
+
+  // `queue` is moved-from past this point. Everything below reads the tracker's
+  // `commands`, which is deliberate and not just an artefact of the move:
+  // PathProgressTracker::make binds `accept_ack` and `finisher` onto *its own*
+  // copies. A PathWaypoint built from `queue` would hand the integrator an
+  // execution whose finished() silently does nothing, so the tracker is the only
+  // valid source for these handles — and, taking size and elements from the same
+  // container, the only valid source for the count as well.
+  const auto& commands = this->current_progress->commands;
+
+  // Bundle each destination with the handle used to acknowledge it. Pairing
+  // them in one object rather than handing the integrator two parallel vectors
+  // makes an index mismatch impossible on their side.
+  //
+  // `destinations` and `merge_radii` are filled in lockstep with `commands` by
+  // the segment loop above, so all three have the same length. Keep it that way
+  // if that loop ever grows a `continue`.
+  std::vector<PathGuide::PathWaypoint> path_waypoints;
+  path_waypoints.reserve(commands.size());
+  for (std::size_t i = 0; i < commands.size(); ++i)
+  {
+    path_waypoints.push_back(
+      PathGuide::PathWaypoint::Implementation::make(
+        destinations[i],
+        merge_radii[i],
+        i,
+        commands[i]));
+  }
+
+  auto path = PathGuide::Path::Implementation::make(
+    std::move(path_waypoints),
+    context->itinerary().current_plan_id(),
+    starting_map);
+
+  // Arm the first waypoint before handing the path over, never after: the
+  // integrator may acknowledge a waypoint synchronously from inside
+  // handle_path_request, and accept() has to find the tracker already armed.
+  const auto dispatch_path =
+    [w = weak_from_this(), path]()
+    {
+      const auto self = w.lock();
+      if (!self)
+      {
+        return;
+      }
+
+      self->handle_path_request(path);
+    };
+
+  if (initial_map != reported_location->map)
+  {
+    // The robot has not localized to the current map yet. This should only
+    // happen when a replan happens while the robot is inside of a lift.
+    RCLCPP_WARN(
+      context->node()->get_logger(),
+      "Relocalizing robot [%s] from map [%s] to [%s] because of a mismatch "
+      "while starting to follow a new path",
+      context->requester_id().c_str(),
+      initial_map.c_str(),
+      reported_location->map.c_str());
+
+    // Create a shared reference to the current progress. We will swap this
+    // out for a nullptr after the first time we trigger the current_progress
+    // to make sure it's impossible for the user to do anything that would
+    // double-trigger it.
+    auto progress_ref =
+      std::make_shared<std::shared_ptr<PathProgressTracker>>(current_progress);
+
+    auto begin_following_path =
+      [w = weak_from_this(), progress_ref, dispatch_path]()
+      {
+        if (!progress_ref)
+        {
+          throw std::runtime_error(
+                  "[rmf_fleet_adapter::agv::PathGuide::follow_new_path] "
+                  "progress_ref was not initialized. This should never happen. "
+                  "please report this bug to the RMF maintainers.");
+        }
+
+        if (!*progress_ref)
+        {
+          // This was already triggered
+          return;
+        }
+
+        const auto self = w.lock();
+        if (!self)
+        {
+          // The adapter is deconstructing
+          return;
+        }
+
+        if (self->current_progress != *progress_ref)
+        {
+          // The robot is following a new path
+          return;
+        }
+
+        self->localize_timer = nullptr;
+        self->current_progress->begin();
+        *progress_ref = nullptr;
+        dispatch_path();
+      };
+
+    // Goes through the same neutral handoff as the shared phase code, rather
+    // than building our own Destination and hold: the handler registered in
+    // add_robot is what turns it back into PathGuide's types, so there is one
+    // place where that translation lives.
+    if (context->localize(
+      LocalizationHandoff{
+        context,
+        initial_map,
+        reported_location->position,
+        std::nullopt,
+        "",
+        std::nullopt,
+        nullptr,
+        std::nullopt,
+        waypoints.front().time(),
+        context->itinerary().current_plan_id(),
+        [worker = context->worker(), begin_following_path]()
+        {
+          worker.schedule([begin_following_path](const auto&)
+          {
+            begin_following_path();
+          });
+        }}))
+    {
+      // Halt the robot for the duration of the relocalization.
+      //
+      // Everywhere else in this function the new path is dispatched before we
+      // return, and that PathRequest is itself what supersedes the old one —
+      // the integrator swaps routes and no explicit stop is needed. This
+      // branch is the exception: dispatch is deferred until the integrator
+      // reports localization finished, or until the 300 s timer below gives
+      // up. Until then the integrator is still holding the *entire* remaining
+      // route of the superseded path and would keep driving it, while
+      // invalidate_all() above has already made every handle for that path
+      // inert, so the adapter could not even hear about it. EasyFullControl
+      // gets away without this because its integrator only ever holds one
+      // vertex at a time; PathGuide's holds the whole route.
+      //
+      // handle_stop directly rather than stop(): stop() invalidates
+      // current_progress and nulls it, and current_progress is now the *new*
+      // tracker. That would kill the new path before it is ever dispatched,
+      // and begin_following_path's `current_progress != *progress_ref` check
+      // would then bail out forever, leaving the robot with no path at all.
+      if (superseded_identifier)
+      {
+        this->handle_stop(superseded_identifier);
+      }
+
+      localize_timer = context->node()->try_create_wall_timer(
+        std::chrono::seconds(300),
+        [begin_following_path, w = weak_from_this()]()
+        {
+          const auto self = w.lock();
+          if (!self)
+            return;
+
+          const auto context = self->w_context.lock();
+          if (!context)
+            return;
+
+          RCLCPP_ERROR(
+            context->node()->get_logger(),
+            "Waiting for robot [%s] to localize timed out. Please ensure that "
+            "your localization function triggers execution.finished() when the "
+            "robot's localization process is finished.",
+            context->requester_id().c_str());
+
+          begin_following_path();
+        });
+
+      // Return here to avoid dispatching the path at the end of this function
+      // so that it can be dispatched once the downstream integrator triggers
+      // the localization finished callback.
+      return;
+    }
+
+    // If context->localize(...) returned false then that means the downstream
+    // integrator isn't handling localization commands and therefore will never
+    // trigger the finish callback, so we should proceed to dispatch the path
+    // below.
+  }
+
+  this->current_progress->begin();
+  dispatch_path();
+}
+
+//==============================================================================
+namespace {
+class DockFinder : public rmf_traffic::agv::Graph::Lane::Executor
+{
+public:
+  DockFinder(std::string dock_name)
+  : looking_for(std::move(dock_name))
+  {
+    // Do nothing
+  }
+
+  void execute(const DoorOpen&) override {}
+  void execute(const DoorClose&) override {}
+  void execute(const LiftSessionBegin&) override {}
+  void execute(const LiftDoorOpen&) override {}
+  void execute(const LiftSessionEnd&) override {}
+  void execute(const LiftMove&) override {}
+  void execute(const Wait&) override {}
+  void execute(const Dock& dock) override
+  {
+    if (looking_for == dock.dock_name())
+    {
+      found = true;
+    }
+  }
+
+  std::string looking_for;
+  bool found = false;
+};
+} // anonymous namespace
+
+//==============================================================================
+void PathGuideCommandHandle::dock(
+  const std::string& dock_name_,
+  RequestCompleted docking_finished_callback_)
+{
+  const auto context = w_context.lock();
+  if (!context)
+  {
+    return;
+  }
+
+  RCLCPP_DEBUG(
+    context->node()->get_logger(),
+    "Received a request to dock robot [%s] at [%s]...",
+    context->requester_id().c_str(),
+    dock_name_.c_str());
+
+  const auto plan_id = context->itinerary().current_plan_id();
+  auto planner = context->planner();
+  if (!planner)
+  {
+    RCLCPP_ERROR(
+      context->node()->get_logger(),
+      "Planner unavailable for robot [%s], cannot execute docking command [%s]",
+      context->requester_id().c_str(),
+      dock_name_.c_str());
+    return;
+  }
+
+  const auto& graph = planner->get_configuration().graph();
+  DockFinder finder(dock_name_);
+  std::optional<std::size_t> found_lane;
+  for (std::size_t i = 0; i < graph.num_lanes(); ++i)
+  {
+    const auto& lane = graph.get_lane(i);
+    if (const auto event = lane.entry().event())
+    {
+      event->execute(finder);
+    }
+
+    if (const auto event = lane.exit().event())
+    {
+      event->execute(finder);
+    }
+
+    if (finder.found)
+    {
+      found_lane = i;
+      break;
+    }
+  }
+
+  if (!found_lane.has_value())
+  {
+    RCLCPP_WARN(
+      context->node()->get_logger(),
+      "Unable to find a dock named [%s] in the graph for robot [%s]. We "
+      "will skip this command as finished to avoid permanently blocking.",
+      dock_name_.c_str(),
+      context->requester_id().c_str());
+    docking_finished_callback_();
+    return;
+  }
+
+  const auto& lane = graph.get_lane(*found_lane);
+  const std::size_t i0 = lane.entry().waypoint_index();
+  const std::size_t i1 = lane.exit().waypoint_index();
+  const auto& wp0 = graph.get_waypoint(i0);
+  const auto& wp1 = graph.get_waypoint(i1);
+  const Eigen::Vector2d p0 = wp0.get_location();
+  const Eigen::Vector2d p1 = wp1.get_location();
+  const double dist = (p1 - p0).norm();
+  const auto& traits = planner->get_configuration().vehicle_traits();
+  const double v = std::max(traits.linear().get_nominal_velocity(), 0.001);
+  const auto dt = rmf_traffic::time::from_seconds(dist / v);
+  const auto& itin = context->itinerary();
+  const auto now = context->now();
+  const auto initial_delay = itin.cumulative_delay(itin.current_plan_id())
+    .value_or(rmf_traffic::Duration(0));
+  const rmf_traffic::Time expected_arrival = now + dt - initial_delay;
+
+  const auto speed_limit = lane.properties().speed_limit();
+
+  auto data = PathGuide::CommandExecution::Implementation::Data{
+    {i0, i1},
+    {*found_lane},
+    p1,
+    std::nullopt,
+    rmf_traffic::Duration(0),
+    std::nullopt,
+    nav_params,
+    speed_limit,
+    [w_context = context->weak_from_this(), expected_arrival, plan_id](
+      rmf_traffic::Duration dt)
+    {
+      const auto context = w_context.lock();
+      if (!context)
+      {
+        return;
+      }
+
+      context->worker().schedule([
+          w = context->weak_from_this(),
+          expected_arrival,
+          plan_id,
+          dt
+        ](const auto&)
+        {
+          const auto context = w.lock();
+          if (!context)
+            return;
+
+          const rmf_traffic::Time now = context->now();
+          const auto updated_arrival = now + dt;
+          const auto delay = updated_arrival - expected_arrival;
+          context->itinerary().cumulative_delay(
+            plan_id, delay, std::chrono::seconds(1));
+        });
+    }
+  };
+
+  const double dy = p1.y() - p0.y();
+  const double dx = p1.x() - p0.x();
+  double angle = 0.0;
+  if (dx*dx + dy*dy > 1e-6)
+  {
+    angle = std::atan2(dy, dx);
+  }
+  const Eigen::Vector2d course_vector = p1 - p0;
+  Eigen::Vector3d entry_position(p0.x(), p0.y(), angle);
+  const auto* entry_constraint = lane.entry().orientation_constraint();
+  if (entry_constraint)
+  {
+    entry_constraint->apply(entry_position, course_vector);
+    angle = entry_position[2];
+  }
+  Eigen::Vector3d exit_position(p1.x(), p1.y(), angle);
+  const auto* exit_constraint = lane.exit().orientation_constraint();
+  if (exit_constraint)
+  {
+    exit_constraint->apply(exit_position, course_vector);
+    angle = exit_position[2];
+  }
+
+  // PathGuide never emits a rotate-in-place command, so unlike EasyFullControl
+  // there is no pre-rotation waypoint here even when the robot is not yet
+  // facing the docking point. The destination below carries the docking
+  // orientation and the robot turns itself.
+  const Eigen::Vector3d position(p1.x(), p1.y(), angle);
+  const auto command_position = to_robot_coordinates(
+    wp1.get_map_name(), position);
+
+  auto destination = PathGuide::Destination::Implementation::make(
+    wp1.get_map_name(),
+    command_position,
+    i1,
+    nav_params->get_vertex_name(graph, i1),
+    speed_limit,
+    wp1.in_lift(),
+    dock_name_);
+
+  // A dock inside a lift cabin is unusual but permitted, and it is judged the
+  // same way as any other waypoint there — by the integrator, from
+  // destination().inside_lift(). \sa compute_merge_radius
+  const double dock_merge_radius = compute_merge_radius(
+    nav_params->max_merge_lane_distance,
+    wp1.merge_radius());
+
+  // As in follow_new_path, the tolerance has to cross the same transform as
+  // the position it will be compared against. \sa robot_coordinate_scale
+  const double merge_radius = dock_merge_radius *
+    robot_coordinate_scale(wp1.get_map_name());
+
+  std::vector<PathGuide::CommandExecution> queue;
+  queue.push_back(PathGuide::CommandExecution::Implementation::make(
+      context,
+      data));
+
+  // As in follow_new_path: the integrator may still be holding
+  // CommandExecutions from the path this dock supersedes.
+  if (this->current_progress)
+  {
+    this->current_progress->invalidate_all();
+  }
+
+  // A dock reports no path index — its arrival estimator adjusts the cumulative
+  // delay directly — so the guard here is inert. It is still constructed so the
+  // tracker invariant holds that index_guard is never null.
+  this->current_progress = PathProgressTracker::make(
+    context,
+    std::move(queue),
+    std::move(docking_finished_callback_),
+    std::make_shared<PathIndexGuard>());
+
+  // A dock is delivered through the same callback as any other path, as a path
+  // of exactly one waypoint, so the integrator only has one shape to implement.
+  std::vector<PathGuide::PathWaypoint> path_waypoints;
+  path_waypoints.push_back(
+    PathGuide::PathWaypoint::Implementation::make(
+      std::move(destination),
+      merge_radius,
+      0,
+      this->current_progress->commands.front()));
+
+  auto path = PathGuide::Path::Implementation::make(
+    std::move(path_waypoints),
+    plan_id,
+    wp1.get_map_name());
+
+  this->current_progress->begin();
+  this->handle_path_request(path);
+}
+
+//==============================================================================
+// consider_all() is declared in FleetUpdateHandle.hpp and defined in
+// EasyFullControl.cpp, so we call it rather than defining our own.
+//
+// parse_finishing_request has no declaration in any header, so EasyFullControl
+// exports it at namespace scope. Keep our copy in an anonymous namespace,
+// otherwise the two translation units export the same symbol and the library
+// fails to link.
+namespace {
+
+std::optional<rmf_task::ConstRequestFactoryPtr> parse_finishing_request(
+  const YAML::Node& finishing_request_yaml,
+  const rmf_traffic::agv::Graph& graph,
+  std::optional<std::string> robot_name,
+  bool& error)
+{
+  rmf_task::ConstRequestFactoryPtr finishing_request;
+  std::string finishing_request_string;
+
+  if (!finishing_request_yaml)
+  {
+    if (robot_name.has_value())
+    {
+      // No finishing request is provided for this specific robot, default to
+      // fleet-wide finishing request by returning nullopt.
+      return std::nullopt;
+    }
+    // No finishing request specified for fleet, default to nothing.
+    std::cout
+      << "A default finishing request was not provided for the fleet. The "
+      "valid finishing requests are [charge, park, nothing]. The task planner "
+      "will default to [nothing]."
+      << std::endl;
+    return finishing_request;
+  }
+
+  if (finishing_request_yaml.IsMap())
+  {
+    // Configure the robot-specific finishing request
+    const YAML::Node& request_type_yaml = finishing_request_yaml["type"];
+    std::string request_type_string;
+
+    if (request_type_yaml)
+    {
+      request_type_string = request_type_yaml.as<std::string>();
+      if (request_type_string == "park")
+      {
+        // Check if a specific parking spot waypoint was chosen
+        const YAML::Node& parking_spot_yaml =
+          finishing_request_yaml["waypoint_name"];
+        std::string parking_spot_string;
+        if (parking_spot_yaml)
+        {
+          if (!robot_name.has_value())
+          {
+            // We don't accept this specification for fleet-wide finishing
+            // requests because we can't send all the same robots to the same
+            // parking spot.
+            const auto mark = parking_spot_yaml.Mark();
+            std::cerr
+              << "Cannot assign a specific parking spot waypoint to the "
+              "fleet-wide default finishing request (line " << (mark.line + 1)
+              << ", column " << mark.column << ") because then all robots "
+              "would attempt to park at the same location." << std::endl;
+            error = true;
+            return nullptr;
+          }
+
+          parking_spot_string = parking_spot_yaml.as<std::string>();
+          const auto* parking_wp = graph.find_waypoint(parking_spot_string);
+          if (!parking_wp)
+          {
+            const auto mark = parking_spot_yaml.Mark();
+            std::cerr
+              << "Provided parking spot [" << parking_spot_string
+              << "] (line " << (mark.line + 1) << ", column " << mark.column
+              << ") is not found in the fleet navigation graph. Unable to "
+              "configure the fleet." << std::endl;
+            error = true;
+            return nullptr;
+          }
+
+          std::size_t parking_wp_index = parking_wp->index();
+          finishing_request =
+            std::make_shared<rmf_fleet_adapter::tasks::ParkRobotIndefinitely>(
+            "idle", nullptr, parking_wp_index);
+          std::cout
+            << "Robot [" << robot_name.value()
+            << "] is configured to perform ParkRobot at ["
+            << parking_spot_string << "] as finishing request." << std::endl;
+          return finishing_request;
+        }
+      }
+      finishing_request_string = request_type_string;
+    }
+    else
+    {
+      const auto mark = finishing_request_yaml.Mark();
+      std::cerr
+        << "Missing [type] for finishing_request object (line "
+        << (mark.line + 1) << ", column " << mark.column << ")" << std::endl;
+      error = true;
+      return nullptr;
+    }
+  }
+  else
+  {
+    finishing_request_string = finishing_request_yaml.as<std::string>();
+  }
+
+  if (finishing_request_string == "charge")
+  {
+    auto charge_factory =
+      std::make_shared<rmf_task::requests::ChargeBatteryFactory>();
+    charge_factory->set_indefinite(true);
+    finishing_request = charge_factory;
+  }
+  else if (finishing_request_string == "park")
+  {
+    finishing_request =
+      std::make_shared<rmf_fleet_adapter::tasks::ParkRobotIndefinitely>(
+      "idle", nullptr);
+  }
+  else if (finishing_request_string == "nothing")
+  {
+    // Do nothing
+  }
+  else
+  {
+    const auto mark = finishing_request_yaml.Mark();
+    std::cerr
+      << "The finishing request [" << finishing_request_string << "] (line "
+      << (mark.line + 1) << ", column " << mark.column
+      << ") is unsupported. The valid finishing requests are "
+      "[charge, park, nothing].";
+
+    error = true;
+    return nullptr;
+  }
+
+  if (robot_name.has_value())
+  {
+    std::cout
+      << "Robot-specific finishing task for [" << robot_name.value()
+      << "] set to [" << finishing_request_string << "]" << std::endl;
+  }
+  else
+  {
+    std::cout
+      << "Default fleet finishing task set to [" << finishing_request_string
+      << "]" << std::endl;
+  }
+
+  return finishing_request;
+}
+
+} // anonymous namespace
+
+//==============================================================================
+class PathGuide::PathRobotUpdateHandle::Implementation
+{
+public:
+
+  struct Updater
+  {
+    std::shared_ptr<Location> reported_location;
+    std::shared_ptr<RobotUpdateHandle> handle;
+    std::shared_ptr<NavParams> nav_params;
+
+    Updater(
+      std::shared_ptr<Location> reported_location_,
+      std::shared_ptr<NavParams> params_)
+    : reported_location(std::move(reported_location_)),
+      handle(nullptr),
+      nav_params(std::move(params_))
+    {
+      // Do nothing
+    }
+
+    Eigen::Vector3d to_rmf_coordinates(
+      const std::string& map,
+      Eigen::Vector3d position,
+      const RobotContext& context) const
+    {
+      const auto p = nav_params->to_rmf_coordinates(map, position);
+      if (p.has_value())
+      {
+        return *p;
+      }
+
+      RCLCPP_WARN(
+        context.node()->get_logger(),
+        "[PathGuide] Unable to find robot transform for map [%s] for "
+        "robot [%s]. We will not apply a transform.",
+        map.c_str(),
+        context.requester_id().c_str());
+      return position;
+    }
+  };
+
+  std::shared_ptr<Updater> updater;
+  rxcpp::schedulers::worker worker;
+
+  static Implementation& get(PathRobotUpdateHandle& handle)
+  {
+    return *handle._pimpl;
+  }
+
+  Implementation(
+    std::shared_ptr<Location> reported_location_,
+    std::shared_ptr<NavParams> params_,
+    rxcpp::schedulers::worker worker_)
+  : updater(std::make_shared<Updater>(std::move(reported_location_), params_)),
+    worker(worker_)
+  {
+    // Do nothing
+  }
+
+  static std::shared_ptr<PathRobotUpdateHandle> make(
+    std::shared_ptr<Location> reported_location_,
+    std::shared_ptr<NavParams> params_,
+    rxcpp::schedulers::worker worker_)
+  {
+    auto handle = std::shared_ptr<PathRobotUpdateHandle>(
+      new PathRobotUpdateHandle);
+    handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
+      std::move(reported_location_), std::move(params_), std::move(worker_));
+    return handle;
+  }
+};
+
+//==============================================================================
+void PathGuide::PathRobotUpdateHandle::update(
+  RobotState state,
+  ConstActivityIdentifierPtr current_activity)
+{
+
+  _pimpl->worker.schedule(
+    [
+      state = std::move(state),
+      current_activity = std::move(current_activity),
+      updater = _pimpl->updater
+    ](const auto&)
+    {
+      if (!updater->handle)
+      {
+        return;
+      }
+
+      auto context = RobotUpdateHandle::Implementation
+      ::get(*updater->handle).get_context();
+
+      context->current_battery_soc(state.battery_state_of_charge());
+
+      const auto position = updater->to_rmf_coordinates(
+        state.map(), state.position(), *context);
+
+      *updater->reported_location = Location {
+        context->now(),
+        state.map(),
+        position
+      };
+
+      if (current_activity)
+      {
+        const auto update_fn =
+        ActivityIdentifier::Implementation::get(*current_activity).update_fn;
+        if (update_fn)
+        {
+          update_fn(
+            state.map(), position);
+          return;
+        }
+      }
+
+      if (context->debug_positions)
+      {
+        std::cout << "Searching for location from " << __FILE__ << "|" << __LINE__ << std::endl;
+      }
+      updater->nav_params->search_for_location(state.map(), position, *context);
+    });
+}
+
+//==============================================================================
+double PathGuide::PathRobotUpdateHandle::max_merge_waypoint_distance()
+const
+{
+  return _pimpl->updater->nav_params->max_merge_waypoint_distance;
+}
+
+//==============================================================================
+void PathGuide::PathRobotUpdateHandle::set_max_merge_waypoint_distance(
+  double distance)
+{
+  _pimpl->updater->nav_params->max_merge_waypoint_distance = distance;
+}
+
+//==============================================================================
+double PathGuide::PathRobotUpdateHandle::max_merge_lane_distance() const
+{
+  return _pimpl->updater->nav_params->max_merge_lane_distance;
+}
+
+//==============================================================================
+void PathGuide::PathRobotUpdateHandle::set_max_merge_lane_distance(
+  double distance)
+{
+  _pimpl->updater->nav_params->max_merge_lane_distance = distance;
+}
+
+//==============================================================================
+double PathGuide::PathRobotUpdateHandle::min_lane_length() const
+{
+  return _pimpl->updater->nav_params->min_lane_length;
+}
+
+//==============================================================================
+void PathGuide::PathRobotUpdateHandle::set_min_lane_length(
+  double length)
+{
+  _pimpl->updater->nav_params->min_lane_length = length;
+}
+
+//==============================================================================
+std::shared_ptr<RobotUpdateHandle>
+PathGuide::PathRobotUpdateHandle::more()
+{
+  if (_pimpl->updater)
+  {
+    return _pimpl->updater->handle;
+  }
+  return nullptr;
+}
+
+//==============================================================================
+std::shared_ptr<const RobotUpdateHandle>
+PathGuide::PathRobotUpdateHandle::more() const
+{
+  if (_pimpl->updater)
+  {
+    return _pimpl->updater->handle;
+  }
+
+  return nullptr;
+}
+
+//==============================================================================
+PathGuide::PathRobotUpdateHandle::PathRobotUpdateHandle()
+{
+  // Do nothing
+}
+
+//==============================================================================
+class PathGuide::FleetConfiguration::Implementation
+{
+public:
+  std::string fleet_name;
+  std::optional<std::unordered_map<std::string,
+    Transformation>> transformations_to_robot_coordinates;
+  std::unordered_map<std::string,
+    RobotConfiguration> known_robot_configurations;
+  std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits;
+  std::shared_ptr<const rmf_traffic::agv::Graph> graph;
+  rmf_battery::agv::ConstBatterySystemPtr battery_system;
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink;
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink;
+  rmf_battery::ConstDevicePowerSinkPtr tool_sink;
+  double recharge_threshold;
+  double recharge_soc;
+  bool account_for_battery_drain;
+  std::optional<rmf_traffic::Duration> retreat_to_charger_interval;
+  std::unordered_map<std::string, ConsiderRequest> task_consideration;
+  std::unordered_map<std::string, ConsiderRequest> action_consideration;
+  rmf_task::ConstRequestFactoryPtr finishing_request;
+  std::optional<std::string> server_uri;
+  rmf_traffic::Duration max_delay;
+  rmf_traffic::Duration update_interval;
+  bool default_responsive_wait;
+  double default_max_merge_waypoint_distance;
+  double default_max_merge_lane_distance;
+  double default_min_lane_length;
+  std::unordered_map<std::string, std::string> lift_emergency_levels;
+  std::unordered_set<std::size_t> strict_lanes;
+  bool use_parking_reservation;
+  AssignmentStrategy task_assignment_strategy;
+};
+
+//==============================================================================
+PathGuide::FleetConfiguration::FleetConfiguration(
+  const std::string& fleet_name,
+  std::optional<std::unordered_map<std::string, Transformation>>
+  transformations_to_robot_coordinates,
+  std::unordered_map<std::string, RobotConfiguration>
+  known_robot_configurations,
+  std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
+  std::shared_ptr<const rmf_traffic::agv::Graph> graph,
+  rmf_battery::agv::ConstBatterySystemPtr battery_system,
+  rmf_battery::ConstMotionPowerSinkPtr motion_sink,
+  rmf_battery::ConstDevicePowerSinkPtr ambient_sink,
+  rmf_battery::ConstDevicePowerSinkPtr tool_sink,
+  double recharge_threshold,
+  double recharge_soc,
+  bool account_for_battery_drain,
+  std::unordered_map<std::string, ConsiderRequest> task_consideration,
+  std::unordered_map<std::string, ConsiderRequest> action_consideration,
+  rmf_task::ConstRequestFactoryPtr finishing_request,
+  std::optional<std::string> server_uri,
+  rmf_traffic::Duration max_delay,
+  rmf_traffic::Duration update_interval,
+  bool default_responsive_wait,
+  double default_max_merge_waypoint_distance,
+  double default_max_merge_lane_distance,
+  double default_min_lane_length)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(fleet_name),
+        std::move(transformations_to_robot_coordinates),
+        std::move(known_robot_configurations),
+        std::move(traits),
+        std::move(graph),
+        std::move(battery_system),
+        std::move(motion_sink),
+        std::move(ambient_sink),
+        std::move(tool_sink),
+        std::move(recharge_threshold),
+        std::move(recharge_soc),
+        std::move(account_for_battery_drain),
+        std::chrono::seconds(10),
+        std::move(task_consideration),
+        std::move(action_consideration),
+        std::move(finishing_request),
+        std::move(server_uri),
+        std::move(max_delay),
+        std::move(update_interval),
+        default_responsive_wait,
+        std::move(default_max_merge_waypoint_distance),
+        std::move(default_max_merge_lane_distance),
+        std::move(default_min_lane_length),
+        {},
+        {},
+        false, // Parking reservation system
+        AssignmentStrategy::make(AssignmentStrategy::Profile::DefaultFastest)
+      }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+std::optional<PathGuide::FleetConfiguration>
+PathGuide::FleetConfiguration::from_config_files(
+  const std::string& config_file,
+  const std::string& nav_graph_path,
+  std::optional<std::string> server_uri)
+{
+  // Load fleet config file
+  const auto fleet_config = YAML::LoadFile(config_file);
+  // Check that config file is valid and contains all necessary nodes
+  const YAML::Node rmf_fleet = fleet_config["rmf_fleet"];
+  if (!rmf_fleet)
+  {
+    std::cout
+      << "rmf_fleet dictionary is not provided in the configuration file ["
+      << config_file << "] so we cannot parse a fleet configuration."
+      << std::endl;
+    return std::nullopt;
+  }
+
+  // Fleet name
+  if (!rmf_fleet["name"])
+  {
+    std::cout << "Fleet name is not provided" << std::endl;
+    return std::nullopt;
+  }
+  const std::string fleet_name = rmf_fleet["name"].as<std::string>();
+
+  // Profile
+  if (!rmf_fleet["profile"] || !rmf_fleet["profile"]["footprint"] ||
+    !rmf_fleet["profile"]["vicinity"])
+  {
+    std::cout << "Fleet profile is not provided" << std::endl;
+    return std::nullopt;
+  }
+  const YAML::Node profile = rmf_fleet["profile"];
+  const double footprint_rad = profile["footprint"].as<double>();
+  const double vicinity_rad = profile["vicinity"].as<double>();
+
+  // Traits
+  if (!rmf_fleet["limits"] || !rmf_fleet["limits"]["linear"] ||
+    !rmf_fleet["limits"]["angular"])
+  {
+    std::cout << "Fleet traits are not provided" << std::endl;
+    return std::nullopt;
+  }
+  const YAML::Node limits = rmf_fleet["limits"];
+  const YAML::Node linear = limits["linear"];
+  const double v_nom = linear[0].as<double>();
+  const double a_nom = linear[1].as<double>();
+  const YAML::Node angular = limits["angular"];
+  const double w_nom = angular[0].as<double>();
+  const double b_nom = angular[1].as<double>();
+
+  // Reversibility, defaults to false
+  bool reversible = false;
+  if (rmf_fleet["reversible"])
+  {
+    reversible = rmf_fleet["reversible"].as<bool>();
+  }
+
+  auto traits = std::make_shared<VehicleTraits>(VehicleTraits{
+        {v_nom, a_nom},
+        {w_nom, b_nom},
+        rmf_traffic::Profile{
+          rmf_traffic::geometry::make_final_convex<rmf_traffic::geometry::Circle>(
+            footprint_rad),
+          rmf_traffic::geometry::make_final_convex<rmf_traffic::geometry::Circle>(
+            vicinity_rad)
+        }
+      });
+  traits->get_differential()->set_reversible(reversible);
+
+  // Graph
+  const auto graph = parse_graph(nav_graph_path, *traits);
+
+  // Set up parameters required for task planner
+  // Battery system
+  if (!rmf_fleet["battery_system"] || !rmf_fleet["battery_system"]["voltage"] ||
+    !rmf_fleet["battery_system"]["capacity"] ||
+    !rmf_fleet["battery_system"]["charging_current"])
+  {
+    std::cout << "Fleet battery system is not provided" << std::endl;
+    return std::nullopt;
+  }
+  const YAML::Node battery = rmf_fleet["battery_system"];
+  const double voltage = battery["voltage"].as<double>();
+  const double capacity = battery["capacity"].as<double>();
+  const double charging_current = battery["charging_current"].as<double>();
+
+  const auto battery_system_optional = rmf_battery::agv::BatterySystem::make(
+    voltage, capacity, charging_current);
+  if (!battery_system_optional.has_value())
+  {
+    std::cout << "Invalid battery parameters" << std::endl;
+    return std::nullopt;
+  }
+  const auto battery_system = std::make_shared<rmf_battery::agv::BatterySystem>(
+    *battery_system_optional);
+
+  // Mechanical system
+  if (!rmf_fleet["mechanical_system"])
+  {
+    std::cout << "Fleet [mechanical_system] information is not provided"
+              << std::endl;
+    return std::nullopt;
+  }
+
+  if (
+    !rmf_fleet["mechanical_system"]["mass"] ||
+    !rmf_fleet["mechanical_system"]["moment_of_inertia"] ||
+    !rmf_fleet["mechanical_system"]["friction_coefficient"])
+  {
+    std::cout << "Fleet [mechanical_system] information is not valid"
+              << std::endl;
+    return std::nullopt;
+  }
+
+  const YAML::Node mechanical = rmf_fleet["mechanical_system"];
+  const double mass = mechanical["mass"].as<double>();
+  const double moment_of_inertia = mechanical["moment_of_inertia"].as<double>();
+  const double friction = mechanical["friction_coefficient"].as<double>();
+
+  auto mechanical_system_optional = rmf_battery::agv::MechanicalSystem::make(
+    mass, moment_of_inertia, friction);
+  if (!mechanical_system_optional.has_value())
+  {
+    std::cout << "Invalid mechanical parameters" << std::endl;
+    return std::nullopt;
+  }
+  rmf_battery::agv::MechanicalSystem& mechanical_system =
+    *mechanical_system_optional;
+
+  const auto motion_sink =
+    std::make_shared<rmf_battery::agv::SimpleMotionPowerSink>(
+    *battery_system, mechanical_system);
+
+  // Ambient power system
+  if (!rmf_fleet["ambient_system"] || !rmf_fleet["ambient_system"]["power"])
+  {
+    std::cout << "Fleet ambient system is not provided" << std::endl;
+    return std::nullopt;
+  }
+  const YAML::Node ambient_system = rmf_fleet["ambient_system"];
+  const double ambient_power_drain = ambient_system["power"].as<double>();
+  auto ambient_power_system = rmf_battery::agv::PowerSystem::make(
+    ambient_power_drain);
+  if (!ambient_power_system)
+  {
+    std::cout << "Invalid values supplied for ambient power system"
+              << std::endl;
+    return std::nullopt;
+  }
+  const auto ambient_sink =
+    std::make_shared<rmf_battery::agv::SimpleDevicePowerSink>(
+    *battery_system, *ambient_power_system);
+
+  // Tool power system
+  if (!rmf_fleet["tool_system"] || !rmf_fleet["tool_system"]["power"])
+  {
+    std::cout << "Fleet tool system is not provided" << std::endl;
+    return std::nullopt;
+  }
+  const YAML::Node tool_system = rmf_fleet["tool_system"];
+  const double tool_power_drain = tool_system["power"].as<double>();
+  auto tool_power_system = rmf_battery::agv::PowerSystem::make(
+    tool_power_drain);
+  if (!tool_power_system)
+  {
+    std::cout << "Invalid values supplied for tool power system" << std::endl;
+    return std::nullopt;
+  }
+  const auto tool_sink =
+    std::make_shared<rmf_battery::agv::SimpleDevicePowerSink>(
+    *battery_system, *tool_power_system);
+
+  // Drain battery
+  bool account_for_battery_drain = true;
+  if (!rmf_fleet["account_for_battery_drain"])
+  {
+    std::cout << "[account_for_battery_drain] value is not provided, "
+              << "default to True" << std::endl;
+  }
+  else
+  {
+    account_for_battery_drain =
+      rmf_fleet["account_for_battery_drain"].as<bool>();
+  }
+  // Recharge threshold
+  double recharge_threshold = 0.2;
+  if (!rmf_fleet["recharge_threshold"])
+  {
+    std::cout
+      << "Recharge threshold is not provided, default to 0.2" << std::endl;
+  }
+  else
+  {
+    recharge_threshold = rmf_fleet["recharge_threshold"].as<double>();
+  }
+  // Recharge state of charge
+  double recharge_soc = 0.2;
+  if (!rmf_fleet["recharge_soc"])
+  {
+    std::cout << "Recharge state of charge is not provided, default to 1.0"
+              << std::endl;
+  }
+  else
+  {
+    recharge_soc = rmf_fleet["recharge_soc"].as<double>();
+  }
+  // Retreat to charger
+  std::optional<rmf_traffic::Duration> retreat_to_charger_interval =
+    rmf_traffic::time::from_seconds(10);
+  const auto retreat_to_charger_yaml = rmf_fleet["retreat_to_charger_interval"];
+  if (!retreat_to_charger_yaml)
+  {
+    std::cout << "[retreat_to_charger_interval] value is not provided, "
+              << "default to 10 seconds" << std::endl;
+  }
+  else if (retreat_to_charger_yaml.IsScalar())
+  {
+    const double retreat_to_charger_interval_sec =
+      retreat_to_charger_yaml.as<double>();
+    if (retreat_to_charger_interval_sec <= 0.0)
+    {
+      std::cout
+        << "[retreat_to_charger_interval] has invalid value ["
+        << retreat_to_charger_interval_sec << "]. Turning off retreat to "
+        << "behavior." << std::endl;
+      retreat_to_charger_interval = std::nullopt;
+    }
+    else
+    {
+      retreat_to_charger_interval =
+        rmf_traffic::time::from_seconds(retreat_to_charger_interval_sec);
+    }
+  }
+  else if (retreat_to_charger_yaml.IsNull())
+  {
+    retreat_to_charger_interval = std::nullopt;
+  }
+  else
+  {
+    const auto mark = retreat_to_charger_yaml.Mark();
+    std::cout << "[retreat_to_charger_interval] Unsupported value type "
+              << "provided: line " << (mark.line + 1) << ", column " << mark.column
+              << std::endl;
+    return std::nullopt;
+  }
+
+  // Task capabilities
+  std::unordered_map<std::string, ConsiderRequest> task_consideration;
+  const YAML::Node task_capabilities = rmf_fleet["task_capabilities"];
+  if (!task_capabilities)
+  {
+    std::cout
+      << "[task_capabilities] dictionary was not provided in config file ["
+      << config_file << "]" << std::endl;
+  }
+  else
+  {
+    for (const auto& capability : task_capabilities)
+    {
+      std::string task = capability.first.as<std::string>();
+      if (task == "loop")
+      {
+        // Always change loop to patrol to support legacy terminology
+        task = "patrol";
+      }
+
+      if (capability.second.as<bool>())
+      {
+        task_consideration[task] = consider_all();
+      }
+    }
+
+    if (task_consideration.empty())
+    {
+      std::cout
+        << "No known task capabilities found in config file ["
+        << config_file << "]" << std::endl;
+    }
+  }
+
+  // Action considerations
+  std::unordered_map<std::string, ConsiderRequest> action_consideration;
+  const auto& actions_yaml = rmf_fleet["actions"];
+  if (actions_yaml)
+  {
+    const auto actions = actions_yaml.as<std::vector<std::string>>();
+    for (const std::string& action : actions)
+    {
+      action_consideration[action] = consider_all();
+    }
+  }
+
+  // Finishing tasks
+  rmf_task::ConstRequestFactoryPtr default_finishing_request;
+  const auto& default_finishing_request_yaml = rmf_fleet["finishing_request"];
+  bool fleet_request_error = false;
+  auto configured_default_finishing_request = parse_finishing_request(
+    default_finishing_request_yaml, graph, std::nullopt, fleet_request_error);
+  if (fleet_request_error)
+  {
+    // Invalid FleetConfiguration
+    return std::nullopt;
+  }
+  if (configured_default_finishing_request.has_value())
+    default_finishing_request = configured_default_finishing_request.value();
+
+  // PathGuide always skips rotate-in-place commands, so this EasyFullControl
+  // key has no effect here. Warn rather than ignore silently, since an operator
+  // porting a config.yaml across would reasonably expect it to do something.
+  if (rmf_fleet["skip_rotation_commands"])
+  {
+    std::cout
+      << "[PathGuide] The [skip_rotation_commands] key in the configuration "
+      << "file is ignored: PathGuide never issues rotate-in-place commands, so "
+      << "the behaviour is always as though this were true."
+      << std::endl;
+  }
+
+  // Set the fleet state topic publish period
+  double fleet_state_frequency = 2.0;
+  if (!rmf_fleet["publish_fleet_state"])
+  {
+    std::cout
+      << "Fleet state publish frequency is not provided, default to 2.0"
+      << std::endl;
+  }
+  else
+  {
+    fleet_state_frequency = rmf_fleet["publish_fleet_state"].as<double>();
+  }
+  const double update_interval = 1.0/fleet_state_frequency;
+
+  // Set the maximum delay
+  double max_delay = 10.0;
+  if (!rmf_fleet["max_delay"])
+  {
+    std::cout << "Maximum delay is not provided, default to 10.0" << std::endl;
+  }
+  else
+  {
+    max_delay = rmf_fleet["max_delay"].as<double>();
+  }
+
+  std::optional<std::unordered_map<std::string, Transformation>> tf_dict;
+  const auto transforms = rmf_fleet["transforms"];
+  if (transforms)
+  {
+    if (!transforms.IsMap())
+    {
+      std::cerr
+        << "[transforms] entry should be a dictionary in config file ["
+        << config_file << "]" << std::endl;
+    }
+    else
+    {
+      tf_dict = std::unordered_map<std::string, Transformation>();
+      for (const auto& node : transforms)
+      {
+        const auto map = node.first.as<std::string>();
+        const auto& transform_yaml = node.second;
+        const auto translation_yaml = transform_yaml["translation"];
+        Eigen::Vector2d translation = Eigen::Vector2d(0.0, 0.0);
+        if (translation_yaml)
+        {
+          const auto xy_vec = translation_yaml.as<std::vector<double>>();
+          if (xy_vec.size() != 2)
+          {
+            std::cerr
+              << "[traslation] element has invalid number of elements ["
+              << xy_vec.size() << "] (it should be exactly 2) in config file ["
+              << config_file << "]" << std::endl;
+          }
+
+          std::size_t N = std::min(xy_vec.size(), (std::size_t)2);
+          for (std::size_t i = 0; i < N; ++i)
+          {
+            translation[i] = xy_vec[i];
+          }
+        }
+
+        const auto rotation_yaml = transform_yaml["rotation"];
+        double rotation = 0.0;
+        if (rotation_yaml)
+        {
+          rotation = rotation_yaml.as<double>();
+        }
+
+        const auto scale_yaml = transform_yaml["scale"];
+        double scale = 1.0;
+        if (scale_yaml)
+        {
+          scale = scale_yaml.as<double>();
+        }
+
+        tf_dict->insert({map, Transformation(rotation, scale, translation)});
+      }
+    }
+  }
+
+  bool default_responsive_wait = false;
+  const YAML::Node& default_responsive_wait_yaml = rmf_fleet["responsive_wait"];
+  if (default_responsive_wait_yaml)
+  {
+    default_responsive_wait = default_responsive_wait_yaml.as<bool>();
+  }
+
+  bool use_simple_parking_reservation_system = false;
+  const YAML::Node& parking_reservation = rmf_fleet["use_parking_reservations"];
+  if (parking_reservation)
+  {
+    use_simple_parking_reservation_system =
+      parking_reservation.as<bool>();
+  }
+
+  double default_max_merge_waypoint_distance = 1e-3;
+  const YAML::Node& default_max_merge_waypoint_distance_yaml =
+    rmf_fleet["max_merge_waypoint_distance"];
+  if (default_max_merge_waypoint_distance_yaml)
+  {
+    default_max_merge_waypoint_distance =
+      default_max_merge_waypoint_distance_yaml.as<double>();
+  }
+
+  double default_max_merge_lane_distance = 0.3;
+  const YAML::Node& default_max_merge_lane_distance_yaml =
+    rmf_fleet["max_merge_lane_distance"];
+  if (default_max_merge_lane_distance_yaml)
+  {
+    default_max_merge_lane_distance =
+      default_max_merge_lane_distance_yaml.as<double>();
+  }
+
+  double default_min_lane_length = 1e-8;
+  const YAML::Node& default_min_lane_length_yaml = rmf_fleet["min_lane_length"];
+  if (default_min_lane_length_yaml)
+  {
+    default_min_lane_length =
+      default_min_lane_length_yaml.as<double>();
+  }
+
+  std::unordered_map<std::string,
+    RobotConfiguration> known_robot_configurations;
+  const YAML::Node& robots = rmf_fleet["robots"];
+  if (robots)
+  {
+    if (!robots.IsMap())
+    {
+      std::cerr
+        << "[robots] element is not a map in config file [" << config_file
+        << "] so we cannot parse any known robot configurations." << std::endl;
+      return std::nullopt;
+    }
+    else
+    {
+      for (const auto& robot : robots)
+      {
+        const auto robot_name = robot.first.as<std::string>();
+        const YAML::Node& robot_config_yaml = robot.second;
+
+        if (!robot_config_yaml.IsMap() && !robot_config_yaml.IsNull())
+        {
+          std::cerr
+            << "Entry for [" << robot_name << "] in [robots] dictionary is not "
+            << "a dictionary, so it cannot be parsed." << std::endl;
+          return std::nullopt;
+        }
+
+        if (robot_config_yaml.IsMap())
+        {
+          std::vector<std::string> chargers;
+          const YAML::Node& charger_yaml = robot_config_yaml["charger"];
+          if (charger_yaml)
+          {
+            chargers.push_back(charger_yaml.as<std::string>());
+          }
+
+          const YAML::Node& responsive_wait_yaml =
+            robot_config_yaml["responsive_wait"];
+          std::optional<bool> responsive_wait = std::nullopt;
+          if (responsive_wait_yaml)
+          {
+            responsive_wait = responsive_wait_yaml.as<bool>();
+          }
+
+          const YAML::Node& max_merge_waypoint_distance_yaml =
+            robot_config_yaml["max_merge_waypoint_distance"];
+          std::optional<double> max_merge_waypoint_distance = std::nullopt;
+          if (max_merge_waypoint_distance_yaml)
+          {
+            max_merge_waypoint_distance =
+              max_merge_waypoint_distance_yaml.as<double>();
+          }
+
+          const YAML::Node& max_merge_lane_distance_yaml =
+            robot_config_yaml["max_merge_lane_distance"];
+          std::optional<double> max_merge_lane_distance = std::nullopt;
+          if (max_merge_lane_distance_yaml)
+          {
+            max_merge_lane_distance = max_merge_lane_distance_yaml.as<double>();
+          }
+
+          const YAML::Node& min_lane_length_yaml =
+            robot_config_yaml["min_lane_length"];
+          std::optional<double> min_lane_length = std::nullopt;
+          if (min_lane_length_yaml)
+          {
+            min_lane_length = min_lane_length_yaml.as<double>();
+          }
+
+          std::optional<rmf_task::ConstRequestFactoryPtr> finishing_request =
+            std::nullopt;
+          const YAML::Node& finishing_request_yaml =
+            robot_config_yaml["finishing_request"];
+          bool robot_request_error = false;
+          finishing_request = parse_finishing_request(
+            finishing_request_yaml, graph, robot_name, robot_request_error);
+          if (robot_request_error)
+          {
+            // Invalid FleetConfiguration
+            return std::nullopt;
+          }
+
+          auto config = RobotConfiguration(
+            std::move(chargers),
+            responsive_wait,
+            max_merge_waypoint_distance,
+            max_merge_lane_distance,
+            min_lane_length);
+          config.set_finishing_request(finishing_request);
+          known_robot_configurations.insert_or_assign(robot_name, config);
+        }
+        else
+        {
+          auto config = RobotConfiguration({});
+          known_robot_configurations.insert_or_assign(robot_name, config);
+        }
+      }
+    }
+  }
+
+  std::unordered_map<std::string, std::string> lift_emergency_levels;
+  const YAML::Node& lift_emergency_levels_yaml =
+    rmf_fleet["lift_emergency_levels"];
+  if (lift_emergency_levels_yaml)
+  {
+    if (!lift_emergency_levels_yaml.IsMap())
+    {
+      std::cerr
+        << "[lift_emergency_levels] element is not a map in the config file ["
+        << config_file << "] so we cannot parse what level each lift will go "
+        << "to in an emergency." << std::endl;
+      return std::nullopt;
+    }
+    else
+    {
+      for (const auto& lift : lift_emergency_levels_yaml)
+      {
+        auto lift_name = lift.first.as<std::string>();
+        auto level_name = lift.second.as<std::string>();
+        lift_emergency_levels[std::move(lift_name)] = std::move(level_name);
+      }
+    }
+  }
+
+  std::unordered_set<std::size_t> strict_lanes;
+  const YAML::Node& strict_lanes_yaml = rmf_fleet["strict_lanes"];
+  if (strict_lanes_yaml)
+  {
+    if (!strict_lanes_yaml.IsSequence())
+    {
+      std::cerr
+        << "[strict_lanes] element is not a sequence in the config file ["
+        << config_file << "] so we cannot parse which lanes need to be "
+        << "considered strict." << std::endl;
+      return std::nullopt;
+    }
+
+    const auto vertex_stacks = compute_stacked_vertices(
+      graph, default_max_merge_waypoint_distance);
+    for (const auto& lane_yaml : strict_lanes_yaml)
+    {
+      if (!lane_yaml.IsSequence() || lane_yaml.size() != 2)
+      {
+        const auto mark = lane_yaml.Mark();
+        std::cerr << "[strict_lanes] Unrecognized lane format at line "
+          << (mark.line + 1) << ", column " << mark.column << std::endl;
+        return std::nullopt;
+      }
+
+      const auto wp0_name = lane_yaml[0].as<std::string>();
+      const auto wp1_name = lane_yaml[1].as<std::string>();
+      const auto* wp0 = graph.find_waypoint(wp0_name);
+      if (!wp0)
+      {
+        const auto mark = lane_yaml[0].Mark();
+        std::cerr << "[strict_lanes] Unrecognized waypoint name [" << wp0_name
+          << "] at line " << (mark.line + 1) << ", column " << mark.column << std::endl;
+        return std::nullopt;
+      }
+
+      const auto* wp1 = graph.find_waypoint(wp1_name);
+      if (!wp1)
+      {
+        const auto mark = lane_yaml[1].Mark();
+        std::cerr << "[strict_lanes] Unrecognized waypoint name [" << wp1_name
+          << "] at line " << (mark.line + 1) << ", column " << mark.column << std::endl;
+        return std::nullopt;
+      }
+
+      const auto stack_0_it = vertex_stacks.find(wp0->index());
+      VertexStack stack_0;
+      if (stack_0_it == vertex_stacks.end())
+      {
+        stack_0 = std::make_shared<std::unordered_set<std::size_t>>();
+        stack_0->insert(wp0->index());
+      }
+      else
+      {
+        stack_0 = stack_0_it->second;
+      }
+
+      const auto stack_1_it = vertex_stacks.find(wp1->index());
+      VertexStack stack_1;
+      if (stack_1_it == vertex_stacks.end())
+      {
+        stack_1 = std::make_shared<std::unordered_set<std::size_t>>();
+        stack_1->insert(wp1->index());
+      }
+      else
+      {
+        stack_1 = stack_1_it->second;
+      }
+
+      bool found_lane = false;
+      for (std::size_t wp_i : *stack_0)
+      {
+        for (std::size_t wp_j : *stack_1)
+        {
+          const auto* lane = graph.lane_from(wp_i, wp_j);
+          if (lane)
+          {
+            strict_lanes.insert(lane->index());
+            found_lane = true;
+          }
+        }
+      }
+
+      if (!found_lane)
+      {
+        const auto mark = lane_yaml.Mark();
+        std::cerr << "[strict_lanes] Unable to find a lane from [" << wp0_name
+          << "] to [" << wp1_name << "] at line " << (mark.line + 1) << ", column "
+          << mark.column << std::endl;
+      }
+    }
+  }
+
+  // Task Planning Assignment Strategy
+  AssignmentStrategy task_assignment_strategy =
+    AssignmentStrategy::make(AssignmentStrategy::Profile::DefaultFastest);
+  if (rmf_fleet["task_assignment_strategy"])
+  {
+    if (rmf_fleet["task_assignment_strategy"]["profile"])
+    {
+      const auto profile_str =
+        rmf_fleet["task_assignment_strategy"]["profile"].as<std::string>();
+      if (profile_str == "DefaultFastest")
+      {
+        task_assignment_strategy =
+          AssignmentStrategy::make(AssignmentStrategy::Profile::DefaultFastest);
+      }
+      else if (profile_str == "BatteryAware")
+      {
+        task_assignment_strategy =
+          AssignmentStrategy::make(AssignmentStrategy::Profile::BatteryAware);
+      }
+      else if (profile_str == "Custom")
+      {
+        std::vector<double> weights_finish_time{1.0};
+        std::vector<double> weights_battery_penalty{};
+        std::vector<double> weights_busy_penalty{};
+        if (rmf_fleet["task_assignment_strategy"]["weights"])
+        {
+          const auto weights_node =
+            rmf_fleet["task_assignment_strategy"]["weights"];
+          if (weights_node["finish_time"])
+            weights_finish_time = weights_node["finish_time"].as<std::vector<double>>();
+          if (weights_node["battery_penalty"])
+            weights_battery_penalty = weights_node["battery_penalty"].as<std::vector<double>>();
+          if (weights_node["busy_penalty"])
+            weights_busy_penalty = weights_node["busy_penalty"].as<std::vector<double>>();
+        }
+
+        auto busy_mode = AssignmentStrategy::BusyMode::Binary;
+        if (rmf_fleet["task_assignment_strategy"]["options"] &&
+          rmf_fleet["task_assignment_strategy"]["options"]["busy_mode"])
+        {
+          const auto busy_mode_str =
+            rmf_fleet["task_assignment_strategy"]["options"]["busy_mode"]
+            .as<std::string>();
+          if (busy_mode_str == "Binary")
+            busy_mode = AssignmentStrategy::BusyMode::Binary;
+          else if (busy_mode_str == "Count")
+            busy_mode = AssignmentStrategy::BusyMode::Count;
+        }
+        task_assignment_strategy = AssignmentStrategy::make(AssignmentStrategy::Profile::Unset);
+        task_assignment_strategy.finish_time_weights(weights_finish_time);
+        task_assignment_strategy.battery_penalty_weights(weights_battery_penalty);
+        task_assignment_strategy.busy_penalty_weights(weights_busy_penalty);
+        task_assignment_strategy.busy_mode(busy_mode);
+      }
+    }
+  }
+
+  auto config = FleetConfiguration(
+    fleet_name,
+    std::move(tf_dict),
+    std::move(known_robot_configurations),
+    std::move(traits),
+    std::make_shared<rmf_traffic::agv::Graph>(std::move(graph)),
+    battery_system,
+    motion_sink,
+    ambient_sink,
+    tool_sink,
+    recharge_threshold,
+    recharge_soc,
+    account_for_battery_drain,
+    task_consideration,
+    action_consideration,
+    default_finishing_request,
+    server_uri,
+    rmf_traffic::time::from_seconds(max_delay),
+    rmf_traffic::time::from_seconds(update_interval),
+    default_responsive_wait,
+    default_max_merge_waypoint_distance,
+    default_max_merge_lane_distance,
+    default_min_lane_length);
+  config.change_lift_emergency_levels() = lift_emergency_levels;
+  config.set_retreat_to_charger_interval(retreat_to_charger_interval);
+  config.use_parking_reservation_system(use_simple_parking_reservation_system);
+  config.change_strict_lanes() = std::move(strict_lanes);
+  config.set_task_assignment_strategy(task_assignment_strategy);
+  return config;
+}
+
+//==============================================================================
+const std::string& PathGuide::FleetConfiguration::fleet_name() const
+{
+  return _pimpl->fleet_name;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_fleet_name(std::string value)
+{
+  _pimpl->fleet_name = std::move(value);
+}
+
+//==============================================================================
+const std::optional<TransformDictionary>&
+PathGuide::FleetConfiguration::transformations_to_robot_coordinates()
+const
+{
+  return _pimpl->transformations_to_robot_coordinates;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::add_robot_coordinate_transformation(
+  std::string map,
+  Transformation transformation)
+{
+  if (!_pimpl->transformations_to_robot_coordinates.has_value())
+  {
+    _pimpl->transformations_to_robot_coordinates = TransformDictionary();
+  }
+
+  _pimpl->transformations_to_robot_coordinates
+  ->insert_or_assign(std::move(map), transformation);
+}
+
+//==============================================================================
+auto PathGuide::FleetConfiguration::known_robot_configurations() const
+-> const std::unordered_map<std::string, RobotConfiguration>&
+{
+  return _pimpl->known_robot_configurations;
+}
+
+//==============================================================================
+std::vector<std::string>
+PathGuide::FleetConfiguration::known_robots() const
+{
+  std::vector<std::string> names;
+  for (const auto& [name, _] : _pimpl->known_robot_configurations)
+  {
+    names.push_back(name);
+  }
+  return names;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::add_known_robot_configuration(
+  std::string robot_name,
+  RobotConfiguration configuration)
+{
+  _pimpl->known_robot_configurations.insert_or_assign(
+    std::move(robot_name), std::move(configuration));
+}
+
+//==============================================================================
+auto PathGuide::FleetConfiguration::get_known_robot_configuration(
+  const std::string& robot_name) const -> std::optional<RobotConfiguration>
+{
+  const auto r_it = _pimpl->known_robot_configurations.find(robot_name);
+  if (r_it == _pimpl->known_robot_configurations.end())
+    return std::nullopt;
+
+  return r_it->second;
+}
+
+//==============================================================================
+auto PathGuide::FleetConfiguration::vehicle_traits() const
+-> const std::shared_ptr<const VehicleTraits>&
+{
+  return _pimpl->traits;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_vehicle_traits(
+  std::shared_ptr<const VehicleTraits> value)
+{
+  _pimpl->traits = std::move(value);
+}
+
+//==============================================================================
+auto PathGuide::FleetConfiguration::graph() const
+-> const std::shared_ptr<const Graph>&
+{
+  return _pimpl->graph;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_graph(
+  std::shared_ptr<const Graph> value)
+{
+  _pimpl->graph = std::move(value);
+}
+
+//==============================================================================
+rmf_battery::agv::ConstBatterySystemPtr
+PathGuide::FleetConfiguration::battery_system() const
+{
+  return _pimpl->battery_system;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_battery_system(
+  rmf_battery::agv::ConstBatterySystemPtr value)
+{
+  _pimpl->battery_system = std::move(value);
+}
+
+//==============================================================================
+rmf_battery::ConstMotionPowerSinkPtr
+PathGuide::FleetConfiguration::motion_sink() const
+{
+  return _pimpl->motion_sink;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_motion_sink(
+  rmf_battery::ConstMotionPowerSinkPtr value)
+{
+  _pimpl->motion_sink = std::move(value);
+}
+
+//==============================================================================
+rmf_battery::ConstDevicePowerSinkPtr
+PathGuide::FleetConfiguration::ambient_sink() const
+{
+  return _pimpl->ambient_sink;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_ambient_sink(
+  rmf_battery::ConstDevicePowerSinkPtr value)
+{
+  _pimpl->ambient_sink = std::move(value);
+}
+
+//==============================================================================
+rmf_battery::ConstDevicePowerSinkPtr
+PathGuide::FleetConfiguration::tool_sink() const
+{
+  return _pimpl->tool_sink;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_tool_sink(
+  rmf_battery::ConstDevicePowerSinkPtr value)
+{
+  _pimpl->tool_sink = std::move(value);
+}
+
+//==============================================================================
+double PathGuide::FleetConfiguration::recharge_threshold() const
+{
+  return _pimpl->recharge_threshold;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_recharge_threshold(double value)
+{
+  _pimpl->recharge_threshold = value;
+}
+
+//==============================================================================
+double PathGuide::FleetConfiguration::recharge_soc() const
+{
+  return _pimpl->recharge_soc;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_recharge_soc(double value)
+{
+  _pimpl->recharge_soc = value;
+}
+
+//==============================================================================
+bool PathGuide::FleetConfiguration::account_for_battery_drain() const
+{
+  return _pimpl->account_for_battery_drain;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_account_for_battery_drain(
+  bool value)
+{
+  _pimpl->account_for_battery_drain = value;
+}
+
+//==============================================================================
+std::optional<rmf_traffic::Duration>
+PathGuide::FleetConfiguration::retreat_to_charger_interval() const
+{
+  return _pimpl->retreat_to_charger_interval;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_retreat_to_charger_interval(
+  std::optional<rmf_traffic::Duration> value)
+{
+  _pimpl->retreat_to_charger_interval = value;
+}
+
+//==============================================================================
+const std::unordered_map<std::string, ConsiderRequest>&
+PathGuide::FleetConfiguration::task_consideration() const
+{
+  return _pimpl->task_consideration;
+}
+
+//==============================================================================
+std::unordered_map<std::string, ConsiderRequest>&
+PathGuide::FleetConfiguration::task_consideration()
+{
+  return _pimpl->task_consideration;
+}
+
+//==============================================================================
+const std::unordered_map<std::string, ConsiderRequest>&
+PathGuide::FleetConfiguration::action_consideration() const
+{
+  return _pimpl->action_consideration;
+}
+
+//==============================================================================
+std::unordered_map<std::string, ConsiderRequest>&
+PathGuide::FleetConfiguration::action_consideration()
+{
+  return _pimpl->action_consideration;
+}
+
+//==============================================================================
+rmf_task::ConstRequestFactoryPtr
+PathGuide::FleetConfiguration::finishing_request() const
+{
+  return _pimpl->finishing_request;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_finishing_request(
+  rmf_task::ConstRequestFactoryPtr value)
+{
+  _pimpl->finishing_request = std::move(value);
+}
+
+//==============================================================================
+std::optional<std::string> PathGuide::FleetConfiguration::server_uri()
+const
+{
+  return _pimpl->server_uri;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_server_uri(
+  std::optional<std::string> value)
+{
+  _pimpl->server_uri = std::move(value);
+}
+
+//==============================================================================
+rmf_traffic::Duration PathGuide::FleetConfiguration::max_delay() const
+{
+  return _pimpl->max_delay;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_max_delay(
+  rmf_traffic::Duration value)
+{
+  _pimpl->max_delay = value;
+}
+
+//==============================================================================
+rmf_traffic::Duration PathGuide::FleetConfiguration::update_interval()
+const
+{
+  return _pimpl->update_interval;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_update_interval(
+  rmf_traffic::Duration value)
+{
+  _pimpl->update_interval = value;
+}
+
+//==============================================================================
+bool PathGuide::FleetConfiguration::default_responsive_wait() const
+{
+  return _pimpl->default_responsive_wait;
+}
+
+//==============================================================================
+bool PathGuide::FleetConfiguration::using_parking_reservation_system()
+  const
+{
+  return _pimpl->use_parking_reservation;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::use_parking_reservation_system(
+  const bool use)
+{
+  _pimpl->use_parking_reservation = use;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_default_responsive_wait(
+  bool enable)
+{
+  _pimpl->default_responsive_wait = enable;
+}
+
+//==============================================================================
+double PathGuide::FleetConfiguration::default_max_merge_waypoint_distance()
+const
+{
+  return _pimpl->default_max_merge_waypoint_distance;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::
+set_default_max_merge_waypoint_distance(double distance)
+{
+  _pimpl->default_max_merge_waypoint_distance = distance;
+}
+
+//==============================================================================
+double PathGuide::FleetConfiguration::default_max_merge_lane_distance()
+const
+{
+  return _pimpl->default_max_merge_lane_distance;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_default_max_merge_lane_distance(
+  double distance)
+{
+  _pimpl->default_max_merge_lane_distance = distance;
+}
+
+//==============================================================================
+double PathGuide::FleetConfiguration::default_min_lane_length() const
+{
+  return _pimpl->default_min_lane_length;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_default_min_lane_length(
+  double distance)
+{
+  _pimpl->default_min_lane_length = distance;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_lift_emergency_level(
+  std::string lift_name,
+  std::string emergency_level_name)
+{
+  _pimpl->lift_emergency_levels[std::move(lift_name)] =
+    std::move(emergency_level_name);
+}
+
+//==============================================================================
+std::unordered_map<std::string, std::string>&
+PathGuide::FleetConfiguration::change_lift_emergency_levels()
+{
+  return _pimpl->lift_emergency_levels;
+}
+
+//==============================================================================
+const std::unordered_map<std::string, std::string>&
+PathGuide::FleetConfiguration::lift_emergency_levels() const
+{
+  return _pimpl->lift_emergency_levels;
+}
+
+//==============================================================================
+const std::unordered_set<std::size_t>&
+PathGuide::FleetConfiguration::strict_lanes() const
+{
+  return _pimpl->strict_lanes;
+}
+
+//==============================================================================
+std::unordered_set<std::size_t>&
+PathGuide::FleetConfiguration::change_strict_lanes()
+{
+  return _pimpl->strict_lanes;
+}
+
+//==============================================================================
+const rmf_task::TaskPlanner::TaskAssignmentStrategy&
+  PathGuide::FleetConfiguration::task_assignment_strategy() const
+{
+  return _pimpl->task_assignment_strategy;
+}
+
+//==============================================================================
+void PathGuide::FleetConfiguration::set_task_assignment_strategy(
+  const rmf_task::TaskPlanner::TaskAssignmentStrategy& strategy)
+{
+  _pimpl->task_assignment_strategy = strategy;
+}
+
+//==============================================================================
+using PathGuideCommandHandlePtr = std::shared_ptr<PathGuideCommandHandle>;
+
+//==============================================================================
+std::shared_ptr<FleetUpdateHandle> PathGuide::more()
+{
+  return _pimpl->fleet_handle;
+}
+
+//==============================================================================
+std::shared_ptr<const FleetUpdateHandle> PathGuide::more() const
+{
+  return _pimpl->fleet_handle;
+}
+
+//==============================================================================
+auto PathGuide::add_robot(
+  std::string robot_name,
+  RobotState initial_state,
+  RobotConfiguration configuration,
+  RobotCallbacks callbacks) -> std::shared_ptr<PathRobotUpdateHandle>
+{
+  const auto node = _pimpl->node();
+
+  rmf_traffic::Time now = std::chrono::steady_clock::time_point(
+    std::chrono::nanoseconds(node->now().nanoseconds()));
+
+  auto reported_location = std::make_shared<Location>(Location {
+        now,
+        initial_state.map(),
+        initial_state.position()
+      });
+  auto worker =
+    FleetUpdateHandle::Implementation::get(*_pimpl->fleet_handle).worker;
+  auto robot_nav_params = std::make_shared<NavParams>(_pimpl->nav_params);
+  auto path_updater = PathRobotUpdateHandle::Implementation::make(
+    reported_location, robot_nav_params, worker);
+
+  LocalizationRequest localization = nullptr;
+  if (callbacks.localize())
+  {
+    localization = [
+      inner = callbacks.localize(),
+      nav_params = robot_nav_params
+      ](Destination estimate, CommandExecution execution)
+      {
+        auto robot_position = nav_params->to_robot_coordinates(
+          estimate.map(),
+          estimate.position());
+        if (robot_position.has_value())
+        {
+          auto transformed_estimate = estimate;
+          Destination::Implementation::get(transformed_estimate)
+          .position = *robot_position;
+
+          inner(transformed_estimate, execution);
+        }
+      };
+  }
+
+  const auto& fleet_impl =
+    FleetUpdateHandle::Implementation::get(*_pimpl->fleet_handle);
+  const auto& planner = *fleet_impl.planner;
+  const auto& graph = planner->get_configuration().graph();
+  const auto& traits = planner->get_configuration().vehicle_traits();
+  const auto& fleet_name = _pimpl->fleet_handle->fleet_name();
+
+  RCLCPP_INFO(
+    node->get_logger(),
+    "Adding robot [%s] to fleet [%s].",
+    robot_name.c_str(),
+    fleet_name.c_str());
+
+  auto insertion = _pimpl->cmd_handles.insert({robot_name, nullptr});
+  if (!insertion.second)
+  {
+    RCLCPP_WARN(
+      node->get_logger(),
+      "Robot [%s] was previously added to fleet [%s]. Ignoring request...",
+      robot_name.c_str(),
+      fleet_name.c_str());
+    return nullptr;
+  }
+
+  if (configuration.compatible_chargers().size() > 1)
+  {
+    RCLCPP_WARN(
+      node->get_logger(),
+      "Robot [%s] is configured to have %lu chargers, but we will only make "
+      "use of the first one. Making use of multiple chargers will be added in "
+      "a future version of RMF.",
+      robot_name.c_str(),
+      configuration.compatible_chargers().size());
+  }
+
+  std::optional<std::size_t> charger_index;
+  if (!configuration.compatible_chargers().empty())
+  {
+    const auto& charger_name = configuration.compatible_chargers().front();
+    const auto* charger_wp = graph.find_waypoint(charger_name);
+    if (!charger_wp)
+    {
+      RCLCPP_ERROR(
+        node->get_logger(),
+        "Cannot find a waypoint named [%s] in the navigation graph of fleet "
+        "[%s] needed for the charging point of robot [%s]. We will not add the "
+        "robot to the fleet.",
+        charger_name.c_str(),
+        fleet_name.c_str(),
+        robot_name.c_str());
+
+      _pimpl->cmd_handles.erase(robot_name);
+      return nullptr;
+    }
+
+    charger_index = charger_wp->index();
+  }
+
+  const auto position_opt = robot_nav_params->to_rmf_coordinates(
+    initial_state.map(), initial_state.position());
+  if (!position_opt.has_value())
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "[PathGuide] Unable to find a robot transform for map [%s] while "
+      "adding robot [%s]. We cannot initialize this robot.",
+      initial_state.map().c_str(),
+      robot_name.c_str());
+
+    _pimpl->cmd_handles.erase(robot_name);
+    return nullptr;
+  }
+
+  if (configuration.max_merge_waypoint_distance().has_value())
+  {
+    robot_nav_params->max_merge_waypoint_distance =
+      *configuration.max_merge_waypoint_distance();
+  }
+  if (configuration.max_merge_lane_distance().has_value())
+  {
+    robot_nav_params->max_merge_lane_distance =
+      *configuration.max_merge_lane_distance();
+  }
+
+  if (configuration.min_lane_length().has_value())
+  {
+    robot_nav_params->min_lane_length = *configuration.min_lane_length();
+  }
+
+  robot_nav_params->find_stacked_vertices(graph);
+  const Eigen::Vector3d position = *position_opt;
+  auto starts = robot_nav_params->unfiltered_compute_plan_starts(
+    graph, initial_state.map(), position, now);
+
+  if (starts.empty())
+  {
+    const auto& p = position;
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Unable to compute a location on the navigation graph for robot [%s] "
+      "being added to fleet [%s] using map [%s] and position [%.3f, %.3f, %.3f] "
+      "specified in the initial_state argument. This can happen if the map in "
+      "initial_state does not match any of the map names in the navigation "
+      "graph supplied or if the position reported in the initial_state is far "
+      "way from the navigation graph. This robot will not be added to the "
+      "fleet.",
+      robot_name.c_str(),
+      fleet_name.c_str(),
+      initial_state.map().c_str(),
+      p[0], p[1], p[2]);
+
+    _pimpl->cmd_handles.erase(robot_name);
+    return nullptr;
+  }
+
+  const auto handle_path_request = callbacks.follow_path();
+  const auto handle_stop = callbacks.stop();
+  if (handle_path_request == nullptr || handle_stop == nullptr)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "One or more required callbacks given to [PathGuide::add_robot] "
+      "were null. The robot [%s] will not be added to fleet [%s].",
+      robot_name.c_str(),
+      _pimpl->fleet_handle->fleet_name().c_str());
+
+    _pimpl->cmd_handles.erase(robot_name);
+    return nullptr;
+  }
+
+  const auto cmd_handle = std::make_shared<PathGuideCommandHandle>(
+    reported_location,
+    robot_nav_params,
+    std::move(handle_path_request),
+    std::move(handle_stop));
+  insertion.first->second = cmd_handle;
+
+  bool enable_responsive_wait = _pimpl->default_responsive_wait;
+  if (configuration.responsive_wait().has_value())
+  {
+    enable_responsive_wait = *configuration.responsive_wait();
+  }
+
+  auto finishing_request = configuration.finishing_request();
+
+  _pimpl->fleet_handle->add_robot(
+    insertion.first->second,
+    robot_name,
+    traits.profile(),
+    starts,
+    [
+      cmd_handle,
+      path_updater,
+      node,
+      robot_name = robot_name,
+      fleet_name = fleet_name,
+      charger_index,
+      action_executor = callbacks.action_executor(),
+      localization = std::move(localization),
+      nav_params = robot_nav_params,
+      enable_responsive_wait,
+      use_parking_reservation = _pimpl->use_parking_reservation,
+      finishing_request
+    ](const RobotUpdateHandlePtr& updater)
+    {
+      auto context = RobotUpdateHandle::Implementation::get(*updater)
+      .get_context();
+
+      context->worker().schedule(
+        [
+          cmd_handle,
+          path_updater,
+          node,
+          handle = updater,
+          robot_name,
+          fleet_name,
+          charger_index,
+          action_executor,
+          localization,
+          context,
+          nav_params,
+          enable_responsive_wait,
+          use_parking_reservation,
+          finishing_request
+        ](const auto&)
+        {
+          cmd_handle->w_context = context;
+          context->_set_reported_location(cmd_handle->reported_location);
+          context->set_nav_params(nav_params);
+          PathRobotUpdateHandle::Implementation::get(*path_updater)
+          .updater->handle = handle;
+          handle->set_action_executor(action_executor);
+          // A flavour registers one adapter from the neutral handoff into its
+          // own types. This call is the whole of what a new fleet-adapter
+          // flavour has to do to receive localization requests -- shared phase
+          // code raises them without naming any flavour.
+          context->set_localization_handler(
+            [localization](LocalizationHandoff handoff)
+            {
+              if (!localization)
+                return false;
+
+              localization(
+                make_localization_destination<Destination>(handoff),
+                make_localization_hold<CommandExecution>(handoff));
+
+              return true;
+            });
+          if (charger_index.has_value())
+          {
+            handle->set_charger_waypoint(*charger_index);
+          }
+          handle->enable_responsive_wait(enable_responsive_wait);
+          if (finishing_request.has_value())
+          {
+            handle->set_finishing_request(finishing_request.value());
+            context->robot_finishing_request(true);
+          }
+
+          context->_set_parking_spot_manager(use_parking_reservation);
+
+          RCLCPP_INFO(
+            node->get_logger(),
+            "Successfully added robot [%s] to the fleet [%s].",
+            robot_name.c_str(),
+            fleet_name.c_str());
+        });
+    });
+
+  return path_updater;
+}
+
+} // namespace agv
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -16,6 +16,9 @@
 */
 
 #include "internal_RobotUpdateHandle.hpp"
+// For the EasyFullControl adapter in set_localization below, which builds that
+// flavour's Destination and hold from the neutral handoff.
+#include "internal_EasyFullControl.hpp"
 #include "../TaskManager.hpp"
 
 #include <rmf_traffic_ros2/Time.hpp>
@@ -1237,6 +1240,23 @@ const Reporting& RobotContext::reporting() const
 }
 
 //==============================================================================
+bool RobotContext::localize(LocalizationHandoff handoff) const
+{
+  if (_localization_handler)
+  {
+    return _localization_handler(std::move(handoff));
+  }
+
+  return false;
+}
+
+//==============================================================================
+void RobotContext::set_localization_handler(LocalizationHandler handler)
+{
+  _localization_handler = std::move(handler);
+}
+
+//==============================================================================
 bool RobotContext::localize(
   EasyFullControl::Destination estimate,
   EasyFullControl::CommandExecution execution) const
@@ -1254,7 +1274,34 @@ bool RobotContext::localize(
 void RobotContext::set_localization(
   EasyFullControl::LocalizationRequest localization)
 {
-  _localize = std::move(localization);
+  _localize = localization;
+
+  if (!localization)
+  {
+    // Preserves the previous behaviour: EasyFullControl::add_robot calls this
+    // unconditionally with a null request when the integrator supplied no
+    // localization callback, and `localize` must then report false so
+    // RequestLift does not arm its watchdog waiting for a finish that is never
+    // coming.
+    _localization_handler = nullptr;
+    return;
+  }
+
+  // Adapts EasyFullControl's typed request into the one neutral slot. This
+  // lives here rather than in EasyFullControl.cpp only because that file is
+  // kept byte-identical to upstream; it is otherwise exactly the handler any
+  // other flavour registers for itself via set_localization_handler. If
+  // upstream ever adopts a neutral slot, this function deletes and
+  // EasyFullControl registers its own handler like everybody else.
+  _localization_handler =
+    [localization = std::move(localization)](LocalizationHandoff handoff)
+    {
+      localization(
+        make_localization_destination<EasyFullControl::Destination>(handoff),
+        make_localization_hold<EasyFullControl::CommandExecution>(handoff));
+
+      return true;
+    };
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -25,6 +25,8 @@
 #include <rmf_fleet_adapter/agv/EasyFullControl.hpp>
 #include <rmf_fleet_adapter/StandardNames.hpp>
 
+#include "internal_Localization.hpp"
+
 #include <rmf_fleet_msgs/msg/mutex_group_manual_release.hpp>
 #include <rmf_task_msgs/action/dynamic_event.hpp>
 #include <rmf_task_msgs/msg/dynamic_event_description.hpp>
@@ -772,13 +774,45 @@ public:
 
   const Reporting& reporting() const;
 
-  /// Tell the robot to localize near here
+  /// Tell the robot to localize near here, whatever flavour it belongs to.
+  ///
+  /// There is one slot, not one per flavour. A robot belongs to exactly one
+  /// flavour, and shared phase code must not have to know which — when it did,
+  /// it bound the wrong slot and the request vanished without a warning. See
+  /// `LocalizationHandoff` for that history.
+  ///
+  /// Returns true if the request reached an integrator.
+  bool localize(LocalizationHandoff handoff) const;
+
+  /// Register this robot's flavour adapter for localization requests. A new
+  /// fleet-adapter flavour needs this call and nothing else — no new slot, no
+  /// new overload, and no edit to the phase code that raises the request.
+  void set_localization_handler(LocalizationHandler handler);
+
+  /// Set the callback for localizing the robot.
+  ///
+  /// EasyFullControl convenience: it registers its typed
+  /// `LocalizationRequest` directly, and `EasyFullControl.cpp` is kept
+  /// byte-identical to upstream, so the adaptation into the neutral handler
+  /// above lives here instead. Every other flavour should call
+  /// `set_localization_handler`.
+  void set_localization(EasyFullControl::LocalizationRequest localization);
+
+  /// Deliver an already-built EasyFullControl localization request.
+  ///
+  /// **EasyFullControl's own back-channel, not a dispatch path.** Its
+  /// `follow_new_path` builds its own `Destination` and hold and calls this
+  /// rather than handing over a `LocalizationHandoff`, and a built
+  /// `CommandExecution` cannot be decomposed back into one. It exists only
+  /// because `EasyFullControl.cpp` is off limits; letting one edit there
+  /// build a handoff instead would delete this method and the `_localize`
+  /// member behind it.
+  ///
+  /// Shared phase code must **never** call this — that is the bug this whole
+  /// arrangement exists to prevent. Use `localize(LocalizationHandoff)`.
   bool localize(
     EasyFullControl::Destination estimate,
     EasyFullControl::CommandExecution execution) const;
-
-  /// Set the callback for localizing the robot
-  void set_localization(EasyFullControl::LocalizationRequest localization);
 
   /// Get the current lift destination request for this robot
   const LiftDestination* current_lift_destination() const;
@@ -1087,6 +1121,10 @@ private:
     std::make_unique<std::mutex>();
   RobotUpdateHandle::Commission _commission;
   bool _emergency = false;
+  LocalizationHandler _localization_handler;
+  // Backs the EasyFullControl-only overload above. Both are filled by the same
+  // set_localization call, so they can never disagree about whether this robot
+  // has a localization callback.
   EasyFullControl::LocalizationRequest _localize;
 
   std::shared_ptr<const Location> _reported_location;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_Localization.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_Localization.hpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__AGV__INTERNAL_LOCALIZATION_HPP
+#define SRC__RMF_FLEET_ADAPTER__AGV__INTERNAL_LOCALIZATION_HPP
+
+#include <rmf_traffic/Route.hpp>
+#include <rmf_traffic/Time.hpp>
+#include <rmf_traffic/agv/Graph.hpp>
+
+#include <Eigen/Geometry>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+class RobotContext;
+
+//==============================================================================
+/// Everything a fleet-adapter flavour needs in order to build its own
+/// localization request, expressed without naming any flavour's types.
+///
+/// Shared phase code — `RequestLift`, and anything else that asks a robot to
+/// re-localize — fills one of these and hands it to
+/// `RobotContext::localize`. Which flavour receives it is decided by whichever
+/// `LocalizationHandler` that robot registered, so shared code needs no
+/// knowledge of flavours at all and a new flavour needs no change here.
+///
+/// This exists because the alternative does not scale and failed silently.
+/// `RequestLift` used to call a `RobotContext::localize` overload typed on
+/// `EasyFullControl::Destination`; a PathGuide robot registered a different
+/// slot, so the call found an empty `std::function` and returned `false` —
+/// indistinguishable from "this integrator does not implement localization".
+/// Post-lift relocalization was skipped for every PathGuide robot from the day
+/// the adapter was written until 2026-08-28.
+struct LocalizationHandoff
+{
+  /// Carried rather than recovered via `shared_from_this()`: `localize` is
+  /// const, which would yield a `shared_ptr<const RobotContext>` while every
+  /// flavour's `make_hold` wants a mutable one.
+  std::shared_ptr<RobotContext> context;
+
+  // The `Destination` fields. Every flavour models these identically — same
+  // seven members, same order — so they are the neutral currency here.
+  std::string map;
+  Eigen::Vector3d position;
+  std::optional<std::size_t> graph_index;
+  std::string name;
+  std::optional<double> speed_limit;
+  rmf_traffic::agv::Graph::LiftPropertiesPtr lift;
+  std::optional<std::string> dock;
+
+  // What every flavour's `CommandExecution::Implementation::make_hold` takes.
+  // `expected_finish` and `plan_id` are the reason this is a struct rather
+  // than a translation layer over the existing typed slots: a `LocalizationRequest`
+  // signature carries neither, so an adapter registered at that level cannot
+  // reproduce `RequestLift`'s cumulative_delay bookkeeping and would have to
+  // stamp a delay from `now()`, erasing whatever had genuinely accumulated.
+  rmf_traffic::Time expected_finish;
+  rmf_traffic::PlanId plan_id;
+  std::function<void()> finisher;
+};
+
+//==============================================================================
+/// A flavour's adapter from the neutral handoff to its own integrator
+/// callback. Returns true if the request actually reached an integrator, which
+/// is what tells `RequestLift` whether to arm its 300 s watchdog.
+using LocalizationHandler = std::function<bool(LocalizationHandoff)>;
+
+//==============================================================================
+/// Build a flavour's `Destination` from a handoff.
+///
+/// A template rather than two hand-written call sites, because this is a
+/// seven-argument positional aggregate construction over fields that are not
+/// distinguishable by type: `map` and `name` are both `std::string`,
+/// `graph_index` and `dock` are both optional. Transposing a pair compiles
+/// cleanly and hands the integrator a perfectly plausible `Destination`
+/// describing somewhere else. Writing it once means the order can be wrong in
+/// at most one place, and `test_LocalizationHandoff.cpp` pins that place.
+///
+/// Instantiated only where the flavour's `Destination::Implementation` is
+/// visible — `RobotContext.cpp` for EasyFullControl, `PathGuide.cpp` for
+/// PathGuide.
+template<typename Destination>
+Destination make_localization_destination(const LocalizationHandoff& handoff)
+{
+  return Destination::Implementation::make(
+    handoff.map,
+    handoff.position,
+    handoff.graph_index,
+    handoff.name,
+    handoff.speed_limit,
+    handoff.lift,
+    handoff.dock);
+}
+
+//==============================================================================
+/// Build a flavour's hold `CommandExecution` from a handoff.
+///
+/// Consumes `handoff.finisher`, so call it once. Same reasoning as above,
+/// though the risk is lower here — the four arguments have distinct types.
+template<typename CommandExecution>
+CommandExecution make_localization_hold(LocalizationHandoff& handoff)
+{
+  return CommandExecution::Implementation::make_hold(
+    handoff.context,
+    handoff.expected_finish,
+    handoff.plan_id,
+    std::move(handoff.finisher));
+}
+
+} // namespace agv
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__AGV__INTERNAL_LOCALIZATION_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_PathGuide.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_PathGuide.hpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_fleet_adapter/agv/PathGuide.hpp>
+
+#include "internal_FleetUpdateHandle.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+class RobotContext;
+
+class PathGuideCommandHandle;
+using PathGuideCommandHandlePtr = std::shared_ptr<PathGuideCommandHandle>;
+
+//==============================================================================
+/// Enforces that the path index reported to the traffic schedule never
+/// backtracks, for the lifetime of one path.
+///
+/// RMF forbids this outright: once the fleet adapter has said the robot is
+/// approaching path index 5, it may never again report 4 or less for that path.
+/// See https://github.com/open-rmf/rmf_ros2/issues/530#issuecomment-5099640879
+///
+/// The reason is that `phases::MoveRobot` turns the reported index into an
+/// itinerary delay — `now + estimate - waypoints[path_index].time()` — with no
+/// clamping. A lower index has an earlier planned time, so the delay jumps
+/// larger and the itinerary is pushed into the future. Other robots negotiate
+/// against that itinerary, so a phantom delay makes this robot appear to occupy
+/// space long after it has left, which can deadlock them.
+/// (`Participant::reached` is safe by comparison: `Progress::update` clamps.)
+///
+/// PathGuide needs an explicit guard because the integrator, not the adapter,
+/// chooses which index gets reported — it picks the ActivityIdentifier passed to
+/// `PathRobotUpdateHandle::update`, and every command from the current one
+/// onwards has a live update function. Reporting 7 and then 3 is therefore
+/// possible, and must be caught here rather than trusted to integrator code.
+///
+/// This deliberately holds no context or command handle: the reaction is
+/// injected, which keeps the type unit-testable with no ROS graph, fleet or
+/// plan. \sa test/agv/test_PathIndexGuard.cpp
+struct PathIndexGuard
+{
+  /// Invoked exactly once, on the first backtrack, as
+  /// `on_backtrack(attempted_index, highest_reported)`. PathGuide supplies the
+  /// log plus stop-and-replan; tests supply a recorder.
+  std::function<void(std::size_t, std::size_t)> on_backtrack;
+
+  /// The highest index ever reported for this path.
+  std::size_t highest_reported = 0;
+
+  /// False until the first successful report, so that index 0 is accepted
+  /// without being mistaken for a backtrack against the default above.
+  bool reported_any = false;
+
+  /// Latches on the first backtrack so the reaction fires once and every
+  /// subsequent report is refused.
+  bool violated = false;
+
+  /// Whether `index` may be reported to the arrival estimator.
+  ///
+  /// Returns false — and triggers `on_backtrack` the first time — if `index`
+  /// would move the reported progress backwards.
+  bool allow(std::size_t index)
+  {
+    if (violated)
+    {
+      // A stop and replan is already in flight; stay quiet.
+      return false;
+    }
+
+    if (reported_any && index < highest_reported)
+    {
+      violated = true;
+      if (on_backtrack)
+      {
+        on_backtrack(index, highest_reported);
+      }
+      return false;
+    }
+
+    if (!reported_any || index > highest_reported)
+    {
+      highest_reported = index;
+    }
+    reported_any = true;
+    return true;
+  }
+};
+using PathIndexGuardPtr = std::shared_ptr<PathIndexGuard>;
+
+//==============================================================================
+/// How far off its lane RMF can still localize this robot, at this waypoint.
+///
+/// **This is not an arrival radius.** PathGuide has no opinion about when a
+/// waypoint counts as reached — that is the integrator's call, exactly as it is
+/// under EasyFullControl, where the integrator decides arrival outright by
+/// choosing when to call `finished()`. What the adapter can usefully say is how
+/// far the robot may stray and still be found on the graph, which is an **upper
+/// bound** on how loose an arrival test may safely be.
+///
+/// Why the bound matters: crediting a path's final waypoint ends the movement
+/// phase, so the robot stops wherever it happens to be. If the integrator
+/// credits it further out than this, RMF may be unable to merge the stopped
+/// robot back onto its lane — it is declared lost, replans, and a lift already
+/// summoned for it can be re-summoned to the wrong floor.
+///
+/// Two inputs: the robot's `max_merge_lane_distance`, widened to the graph
+/// vertex's own `merge_radius` where the author set a larger one. A graph may
+/// be more permissive at an unusually open vertex, never stricter.
+///
+/// Deciding arrival — including the far harder question of when a robot is far
+/// enough inside a lift cabin for the doors to close safely — belongs to the
+/// integrator, which knows its true footprint shape, its heading on arrival and
+/// its controller's real stopping accuracy. The adapter knows none of those.
+/// `PathGuide::Destination::inside_lift()` is what that decision is made from;
+/// mind the coordinate frames noted there.
+/// \sa test/agv/test_MergeRadius.cpp
+inline double compute_merge_radius(
+  double robot_max_merge_lane_distance,
+  std::optional<double> vertex_merge_radius)
+{
+  return std::max(
+    robot_max_merge_lane_distance, vertex_merge_radius.value_or(0.0));
+}
+
+//==============================================================================
+class PathGuide::Implementation
+{
+public:
+  std::shared_ptr<FleetUpdateHandle> fleet_handle;
+  // Map robot name to its PathGuideCommandHandle
+  std::unordered_map<std::string, PathGuideCommandHandlePtr> cmd_handles;
+  NavParams nav_params;
+  bool default_responsive_wait;
+  bool use_parking_reservation;
+
+  static std::shared_ptr<PathGuide> make(
+    std::shared_ptr<FleetUpdateHandle> fleet_handle,
+    std::shared_ptr<TransformDictionary> transforms_to_robot_coords,
+    std::unordered_set<std::size_t> strict_lanes,
+    bool default_responsive_wait,
+    double default_max_merge_waypoint_distance,
+    double default_max_merge_lane_distance,
+    double default_min_lane_length,
+    bool use_parking_reservation)
+  {
+    auto handle = std::shared_ptr<PathGuide>(new PathGuide);
+    handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
+      Implementation{
+        fleet_handle,
+        {},
+        NavParams{
+          // PathGuide never emits a rotate-in-place waypoint, so rotation
+          // command skipping is always on. See PathGuide.hpp for why this is
+          // not configurable.
+          true,
+          std::move(transforms_to_robot_coords),
+          std::move(strict_lanes),
+          default_max_merge_waypoint_distance,
+          default_max_merge_lane_distance,
+          default_min_lane_length,
+        },
+        default_responsive_wait,
+        use_parking_reservation
+      });
+    return handle;
+  }
+
+  const std::shared_ptr<Node>& node() const
+  {
+    return FleetUpdateHandle::Implementation::get(*fleet_handle).node;
+  }
+};
+
+//==============================================================================
+class PathGuide::Destination::Implementation
+{
+public:
+  std::string map;
+  Eigen::Vector3d position;
+  std::optional<std::size_t> graph_index;
+  std::string name;
+  std::optional<double> speed_limit;
+  rmf_traffic::agv::Graph::LiftPropertiesPtr lift;
+  std::optional<std::string> dock = std::nullopt;
+
+  template<typename... Args>
+  static Destination make(Args&&... args)
+  {
+    Destination output;
+    output._pimpl = rmf_utils::make_impl<Implementation>(
+      Implementation{std::forward<Args>(args)...});
+    return output;
+  }
+
+  static Implementation& get(Destination& self)
+  {
+    return *self._pimpl;
+  }
+};
+
+//==============================================================================
+class PathGuide::CommandExecution::Implementation
+{
+public:
+  class Data;
+  using DataPtr = std::shared_ptr<Data>;
+
+  std::weak_ptr<RobotContext> w_context;
+  std::shared_ptr<Data> data;
+
+  /// Called once an acknowledgement has been accepted, to advance the path.
+  std::function<void()> finisher;
+
+  /// Gate for out-of-order acknowledgements. Returns true if this command is
+  /// the one the path is currently tracking, and logs a warning otherwise. A
+  /// nullptr means "always accept" and is used for the localization hold
+  /// command, which does not belong to a path.
+  std::function<bool()> accept_ack;
+
+  ActivityIdentifierPtr identifier;
+
+  void finish();
+
+  Stubbornness override_schedule(
+    std::string map,
+    std::vector<Eigen::Vector3d> path,
+    rmf_traffic::Duration hold);
+
+  /// Stop this command from making any further updates to the robot's location
+  /// or the traffic schedule. Used when a path is superseded or the robot is
+  /// stopped, so that a late acknowledgement from the integrator is inert.
+  void invalidate();
+
+  static CommandExecution make(
+    const std::shared_ptr<RobotContext>& context,
+    Data data_);
+
+  static CommandExecution make_hold(
+    const std::shared_ptr<RobotContext>& context,
+    rmf_traffic::Time expected_time,
+    rmf_traffic::PlanId plan_id,
+    std::function<void()> finisher);
+
+  static Implementation& get(CommandExecution& cmd)
+  {
+    return *cmd._pimpl;
+  }
+};
+
+//==============================================================================
+class PathGuide::PathWaypoint::Implementation
+{
+public:
+  Destination destination;
+  double merge_radius;
+  std::size_t index;
+  CommandExecution execution;
+
+  static PathWaypoint make(
+    Destination destination,
+    double merge_radius,
+    std::size_t index,
+    CommandExecution execution)
+  {
+    PathWaypoint output;
+    output._pimpl = rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(destination),
+        merge_radius,
+        index,
+        std::move(execution)
+      });
+    return output;
+  }
+};
+
+//==============================================================================
+class PathGuide::Path::Implementation
+{
+public:
+  std::vector<PathWaypoint> waypoints;
+  std::size_t plan_id;
+  std::string map;
+
+  static Path make(
+    std::vector<PathWaypoint> waypoints,
+    std::size_t plan_id,
+    std::string map)
+  {
+    Path output;
+    output._pimpl = rmf_utils::make_impl<Implementation>(
+      Implementation{std::move(waypoints), plan_id, std::move(map)});
+    return output;
+  }
+};
+
+} // namespace agv
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.cpp
@@ -266,22 +266,30 @@ void RequestLift::ActivePhase::_init_obs()
               });
             };
 
-            auto cmd = agv::EasyFullControl
-            ::CommandExecution::Implementation::make_hold(
-              me->_context,
-              me->_data.expected_finish,
-              *me->_data.plan_id,
-              std::move(finish));
-
-            agv::Destination::Implementation::get(*me->_data.localize_after)
-            .position = me->_context->position();
+            auto& estimate = agv::Destination::Implementation::get(
+              *me->_data.localize_after);
+            estimate.position = me->_context->position();
 
             const auto graph = me->_context->navigation_graph();
-            agv::Destination::Implementation::get(*me->_data.localize_after)
-            .lift = graph.find_known_lift(me->_lift_name);
+            estimate.lift = graph.find_known_lift(me->_lift_name);
 
-            if (me->_context->localize(*me->_data.localize_after,
-            std::move(cmd)))
+            // Handed over without naming a flavour: whichever adapter this
+            // robot registered builds its own Destination and hold. This phase
+            // is shared by every flavour, and when it named one of them
+            // directly the request silently went nowhere for the others.
+            if (me->_context->localize(
+              agv::LocalizationHandoff{
+                me->_context,
+                estimate.map,
+                estimate.position,
+                estimate.graph_index,
+                estimate.name,
+                estimate.speed_limit,
+                estimate.lift,
+                estimate.dock,
+                me->_data.expected_finish,
+                *me->_data.plan_id,
+                std::move(finish)}))
             {
               me->_rewait_timer = me->_context->node()->try_create_wall_timer(
                 std::chrono::seconds(300),

--- a/rmf_fleet_adapter_python/CMakeLists.txt
+++ b/rmf_fleet_adapter_python/CMakeLists.txt
@@ -68,6 +68,7 @@ pybind11_add_module(rmf_adapter SHARED
   src/vehicletraits/vehicletraits.cpp
   src/battery/battery.cpp
   src/schedule/schedule.cpp
+  src/path_guide/path_guide.cpp
 )
 
 target_link_libraries(rmf_adapter PRIVATE

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -75,6 +75,7 @@ void bind_tests(py::module&);
 void bind_nodes(py::module&);
 void bind_battery(py::module&);
 void bind_schedule(py::module&);
+void bind_path_guide(py::module&);
 
 /// Helper function to parse major and minor version as integers
 /// Returns a pair<int, int> {major, minor} or {-1, -1} on parsing failure.
@@ -207,6 +208,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
   bind_nodes(m);
   bind_battery(m);
   bind_schedule(m);
+  bind_path_guide(m);
 
   // ROBOTCOMMAND HANDLE =====================================================
   // Abstract class
@@ -905,6 +907,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
     py::arg("wait_time") = rmf_utils::optional<rmf_traffic::Duration>(
       rmf_utils::nullopt))
   .def("add_easy_fleet", &agv::Adapter::add_easy_fleet,
+    py::arg("configuration"))
+  .def("add_path_guide_fleet", &agv::Adapter::add_path_guide_fleet,
     py::arg("configuration"))
   .def("add_fleet", &agv::Adapter::add_fleet,
     py::arg("fleet_name"),

--- a/rmf_fleet_adapter_python/src/path_guide/path_guide.cpp
+++ b/rmf_fleet_adapter_python/src/path_guide/path_guide.cpp
@@ -1,0 +1,444 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
+#include <pybind11/chrono.h>
+#include <pybind11/eigen.h>
+#include <pybind11/stl.h>
+// Required, not optional: the task/action consideration callbacks below take an
+// nlohmann::json argument, and without this caster pybind11 falls back to
+// resolving its internal `concat` against nlohmann's, which fails to compile
+// with a wall of template errors rather than anything readable.
+#include "pybind11_json/pybind11_json.hpp"
+
+#include <rmf_fleet_adapter/agv/PathGuide.hpp>
+
+#include <rmf_battery/agv/BatterySystem.hpp>
+#include <rmf_battery/agv/SimpleDevicePowerSink.hpp>
+#include <rmf_battery/agv/SimpleMotionPowerSink.hpp>
+
+#include <rmf_task/requests/ChargeBatteryFactory.hpp>
+#include <rmf_task/requests/ParkRobotFactory.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace py = pybind11;
+namespace agv = rmf_fleet_adapter::agv;
+namespace battery = rmf_battery::agv;
+
+namespace {
+
+/// Same shape as the helper in adapter.cpp: replaces the by-reference `confirm`
+/// argument with a return value, which is much friendlier from Python.
+using Confirmation = agv::FleetUpdateHandle::Confirmation;
+using ConsiderRequest = agv::FleetUpdateHandle::ConsiderRequest;
+using ModifiedConsiderRequest =
+  std::function<Confirmation(const nlohmann::json& description)>;
+
+std::unordered_map<std::string, ConsiderRequest> convert_consideration(
+  const std::unordered_map<std::string, ModifiedConsiderRequest>& consideration)
+{
+  std::unordered_map<std::string, ConsiderRequest> output;
+  for (const auto& element : consideration)
+  {
+    output[element.first] = [consider = element.second](
+      const nlohmann::json& description, Confirmation& confirm)
+      {
+        confirm = consider(description);
+      };
+  }
+  return output;
+}
+
+rmf_task::ConstRequestFactoryPtr parse_finishing_request(
+  const std::string& finishing_request_string)
+{
+  if (finishing_request_string == "charge")
+  {
+    return std::make_shared<rmf_task::requests::ChargeBatteryFactory>();
+  }
+
+  if (finishing_request_string == "park")
+  {
+    return std::make_shared<rmf_task::requests::ParkRobotFactory>();
+  }
+
+  return nullptr;
+}
+
+} // anonymous namespace
+
+void bind_path_guide(py::module& m)
+{
+  py::class_<agv::PathGuide, std::shared_ptr<agv::PathGuide>>(
+    m, "PathGuide")
+  .def("add_robot", &agv::PathGuide::add_robot)
+  .def("more", [](agv::PathGuide& self)
+    {
+      return self.more();
+    });
+
+  auto m_path_guide = m.def_submodule("path_guide");
+
+  // PathRobotUpdateHandle ====================================================
+  py::class_<
+    agv::PathGuide::PathRobotUpdateHandle,
+    std::shared_ptr<agv::PathGuide::PathRobotUpdateHandle>
+  >(m_path_guide, "PathRobotUpdateHandle")
+  .def("update", &agv::PathGuide::PathRobotUpdateHandle::update)
+  .def("max_merge_waypoint_distance",
+    &agv::PathGuide::PathRobotUpdateHandle::max_merge_waypoint_distance)
+  .def("set_max_merge_waypoint_distance",
+    &agv::PathGuide::PathRobotUpdateHandle::set_max_merge_waypoint_distance)
+  .def("max_merge_lane_distance",
+    &agv::PathGuide::PathRobotUpdateHandle::max_merge_lane_distance)
+  .def("set_max_merge_lane_distance",
+    &agv::PathGuide::PathRobotUpdateHandle::set_max_merge_lane_distance)
+  .def("min_lane_length",
+    &agv::PathGuide::PathRobotUpdateHandle::min_lane_length)
+  .def("set_min_lane_length",
+    &agv::PathGuide::PathRobotUpdateHandle::set_min_lane_length)
+  .def("more", [](agv::PathGuide::PathRobotUpdateHandle& self)
+    {
+      return self.more();
+    });
+
+  // RobotState ===============================================================
+  py::class_<agv::PathGuide::RobotState>(m_path_guide, "RobotState")
+  .def(py::init<
+      const std::string&,
+      Eigen::Vector3d,
+      double>(),
+    py::arg("map"),
+    py::arg("position"),
+    py::arg("battery_soc"))
+  .def_property(
+    "map",
+    &agv::PathGuide::RobotState::map,
+    &agv::PathGuide::RobotState::set_map)
+  .def_property(
+    "position",
+    &agv::PathGuide::RobotState::position,
+    &agv::PathGuide::RobotState::set_position)
+  .def_property(
+    "battery_state_of_charge",
+    &agv::PathGuide::RobotState::battery_state_of_charge,
+    &agv::PathGuide::RobotState::set_battery_state_of_charge);
+
+  // RobotConfiguration =======================================================
+  py::class_<agv::PathGuide::RobotConfiguration>(
+    m_path_guide, "RobotConfiguration")
+  .def(py::init<std::vector<std::string>>(),
+    py::arg("compatible_chargers"))
+  .def_property(
+    "compatible_chargers",
+    &agv::PathGuide::RobotConfiguration::compatible_chargers,
+    &agv::PathGuide::RobotConfiguration::set_compatible_chargers)
+  .def_property(
+    "finishing_request",
+    &agv::PathGuide::RobotConfiguration::finishing_request,
+    &agv::PathGuide::RobotConfiguration::set_finishing_request);
+
+  // RobotCallbacks ===========================================================
+  py::class_<agv::PathGuide::RobotCallbacks>(m_path_guide, "RobotCallbacks")
+  .def(py::init<
+      agv::PathGuide::PathRequest,
+      agv::PathGuide::StopRequest,
+      agv::PathGuide::ActionExecutor>(),
+    py::arg("follow_path"),
+    py::arg("stop"),
+    py::arg("action_executor"))
+  .def_property_readonly(
+    "follow_path",
+    &agv::PathGuide::RobotCallbacks::follow_path)
+  .def_property_readonly(
+    "stop",
+    &agv::PathGuide::RobotCallbacks::stop)
+  .def_property_readonly(
+    "action_executor",
+    &agv::PathGuide::RobotCallbacks::action_executor)
+  .def_property(
+    "localize",
+    &agv::PathGuide::RobotCallbacks::localize,
+    &agv::PathGuide::RobotCallbacks::with_localization
+  );
+
+  // CommandExecution =========================================================
+  py::class_<agv::PathGuide::CommandExecution>(
+    m_path_guide, "CommandExecution")
+  .def("finished", &agv::PathGuide::CommandExecution::finished)
+  .def("okay", &agv::PathGuide::CommandExecution::okay)
+  .def(
+    "override_schedule",
+    [](
+      agv::PathGuide::CommandExecution& self,
+      std::string map,
+      std::vector<Eigen::Vector3d> path,
+      double hold)
+    {
+      return self.override_schedule(
+        std::move(map),
+        std::move(path),
+        rmf_traffic::time::from_seconds(hold));
+    },
+    py::arg("map"),
+    py::arg("path"),
+    py::arg("hold") = 0.0)
+  .def_property_readonly("identifier",
+    &agv::PathGuide::CommandExecution::identifier);
+
+  // Destination ==============================================================
+  py::class_<agv::PathGuide::Destination>(m_path_guide, "Destination")
+  .def_property_readonly("map", &agv::PathGuide::Destination::map)
+  .def_property_readonly("position", &agv::PathGuide::Destination::position)
+  .def_property_readonly("xy", &agv::PathGuide::Destination::xy)
+  .def_property_readonly("yaw", &agv::PathGuide::Destination::yaw)
+  .def_property_readonly("graph_index",
+    &agv::PathGuide::Destination::graph_index)
+  .def_property_readonly("name", &agv::PathGuide::Destination::name)
+  .def_property_readonly("dock", &agv::PathGuide::Destination::dock)
+  .def_property_readonly("speed_limit",
+    &agv::PathGuide::Destination::speed_limit)
+  .def_property_readonly("inside_lift",
+    &agv::PathGuide::Destination::inside_lift);
+
+  // PathWaypoint =============================================================
+  py::class_<agv::PathGuide::PathWaypoint>(m_path_guide, "PathWaypoint")
+  .def_property_readonly("destination",
+    &agv::PathGuide::PathWaypoint::destination)
+  .def_property_readonly("merge_radius",
+    &agv::PathGuide::PathWaypoint::merge_radius)
+  .def_property_readonly("index", &agv::PathGuide::PathWaypoint::index)
+  .def_property_readonly("execution",
+    &agv::PathGuide::PathWaypoint::execution);
+
+  // Path =====================================================================
+  py::class_<agv::PathGuide::Path>(m_path_guide, "Path")
+  .def_property_readonly("waypoints", &agv::PathGuide::Path::waypoints)
+  .def_property_readonly("plan_id", &agv::PathGuide::Path::plan_id)
+  .def_property_readonly("map", &agv::PathGuide::Path::map)
+  .def("__len__", [](const agv::PathGuide::Path& self)
+    {
+      return self.waypoints().size();
+    })
+  .def("__getitem__",
+    [](const agv::PathGuide::Path& self, std::size_t index)
+    {
+      if (index >= self.waypoints().size())
+      {
+        throw py::index_error();
+      }
+      return self.waypoints()[index];
+    });
+
+  // FleetConfiguration =======================================================
+  // Mirrors the EasyFullControl binding, minus skip_rotation_commands, which
+  // PathGuide does not have: it never issues a rotate-in-place command.
+  py::class_<agv::PathGuide::FleetConfiguration>(
+    m_path_guide, "FleetConfiguration")
+  .def(py::init([]( // Lambda function to convert reference to shared ptr
+        std::string& fleet_name,
+        std::optional<std::unordered_map<std::string,
+        agv::Transformation>> transformations_to_robot_coordinates,
+        std::unordered_map<std::string,
+        agv::PathGuide::RobotConfiguration> known_robot_configurations,
+        rmf_traffic::agv::VehicleTraits& traits,
+        rmf_traffic::agv::Graph& graph,
+        battery::BatterySystem& battery_system,
+        battery::SimpleMotionPowerSink& motion_sink,
+        battery::SimpleDevicePowerSink& ambient_sink,
+        battery::SimpleDevicePowerSink& tool_sink,
+        double recharge_threshold,
+        double recharge_soc,
+        bool account_for_battery_drain,
+        std::unordered_map<std::string,
+        ModifiedConsiderRequest> task_consideration,
+        std::unordered_map<std::string,
+        ModifiedConsiderRequest> action_consideration,
+        std::string& finishing_request_string,
+        std::optional<std::string> server_uri,
+        rmf_traffic::Duration max_delay,
+        rmf_traffic::Duration update_interval,
+        bool default_responsive_wait,
+        double default_max_merge_waypoint_distance,
+        double default_max_merge_lane_distance,
+        double default_min_lane_length)
+        {
+          return agv::PathGuide::FleetConfiguration(
+            fleet_name,
+            std::move(transformations_to_robot_coordinates),
+            std::move(known_robot_configurations),
+            std::make_shared<rmf_traffic::agv::VehicleTraits>(traits),
+            std::make_shared<rmf_traffic::agv::Graph>(graph),
+            std::make_shared<battery::BatterySystem>(battery_system),
+            std::make_shared<battery::SimpleMotionPowerSink>(motion_sink),
+            std::make_shared<battery::SimpleDevicePowerSink>(ambient_sink),
+            std::make_shared<battery::SimpleDevicePowerSink>(tool_sink),
+            recharge_threshold,
+            recharge_soc,
+            account_for_battery_drain,
+            convert_consideration(task_consideration),
+            convert_consideration(action_consideration),
+            parse_finishing_request(finishing_request_string),
+            server_uri,
+            max_delay,
+            update_interval,
+            default_responsive_wait,
+            default_max_merge_waypoint_distance,
+            default_max_merge_lane_distance,
+            default_min_lane_length);
+        }
+        ),
+    py::arg("fleet_name"),
+    py::arg("transformations_to_robot_coordinates"),
+    py::arg("known_robot_configurations"),
+    py::arg("traits"),
+    py::arg("graph"),
+    py::arg("battery_system"),
+    py::arg("motion_sink"),
+    py::arg("ambient_sink"),
+    py::arg("tool_sink"),
+    py::arg("recharge_threshold"),
+    py::arg("recharge_soc"),
+    py::arg("account_for_battery_drain"),
+    py::arg("task_categories"),
+    py::arg("action_categories"),
+    py::arg("finishing_request") = "nothing",
+    py::arg("server_uri") = std::nullopt,
+    py::arg("max_delay") = rmf_traffic::time::from_seconds(10.0),
+    py::arg("update_interval") = rmf_traffic::time::from_seconds(0.5),
+    py::arg("default_responsive_wait") = false,
+    py::arg("default_max_merge_waypoint_distance") = 1e-3,
+    py::arg("default_max_merge_lane_distance") = 0.3,
+    py::arg("default_min_lane_length") = 1e-8)
+  .def_static("from_config_files",
+    &agv::PathGuide::FleetConfiguration::from_config_files,
+    py::arg("config_file"),
+    py::arg("nav_graph_path"),
+    py::arg("server_uri") = std::nullopt)
+  .def_property(
+    "fleet_name",
+    &agv::PathGuide::FleetConfiguration::fleet_name,
+    &agv::PathGuide::FleetConfiguration::set_fleet_name)
+  .def_property(
+    "vehicle_traits",
+    &agv::PathGuide::FleetConfiguration::vehicle_traits,
+    &agv::PathGuide::FleetConfiguration::set_vehicle_traits)
+  .def_property_readonly(
+    "transformations_to_robot_coordinates",
+    &agv::PathGuide::FleetConfiguration::
+    transformations_to_robot_coordinates)
+  .def(
+    "add_robot_coordinates_transformation",
+    &agv::PathGuide::FleetConfiguration::
+    add_robot_coordinate_transformation)
+  .def_property_readonly(
+    "known_robot_configurations",
+    &agv::PathGuide::FleetConfiguration::known_robot_configurations)
+  .def_property_readonly(
+    "known_robots",
+    &agv::PathGuide::FleetConfiguration::known_robots)
+  .def(
+    "add_known_robot_configuration",
+    &agv::PathGuide::FleetConfiguration::add_known_robot_configuration)
+  .def(
+    "get_known_robot_configuration",
+    &agv::PathGuide::FleetConfiguration::get_known_robot_configuration)
+  .def_property(
+    "retreat_to_charger_interval",
+    &agv::PathGuide::FleetConfiguration::retreat_to_charger_interval,
+    &agv::PathGuide::FleetConfiguration::set_retreat_to_charger_interval)
+  .def_property(
+    "graph",
+    &agv::PathGuide::FleetConfiguration::graph,
+    &agv::PathGuide::FleetConfiguration::set_graph)
+  .def_property(
+    "battery_system",
+    &agv::PathGuide::FleetConfiguration::battery_system,
+    &agv::PathGuide::FleetConfiguration::set_battery_system)
+  .def_property(
+    "motion_sink",
+    &agv::PathGuide::FleetConfiguration::motion_sink,
+    &agv::PathGuide::FleetConfiguration::set_motion_sink)
+  .def_property(
+    "ambient_sink",
+    &agv::PathGuide::FleetConfiguration::ambient_sink,
+    &agv::PathGuide::FleetConfiguration::set_ambient_sink)
+  .def_property(
+    "tool_sink",
+    &agv::PathGuide::FleetConfiguration::tool_sink,
+    &agv::PathGuide::FleetConfiguration::set_tool_sink)
+  .def_property(
+    "recharge_threshold",
+    &agv::PathGuide::FleetConfiguration::recharge_threshold,
+    &agv::PathGuide::FleetConfiguration::set_recharge_threshold)
+  .def_property(
+    "recharge_soc",
+    &agv::PathGuide::FleetConfiguration::recharge_soc,
+    &agv::PathGuide::FleetConfiguration::set_recharge_soc)
+  .def_property(
+    "account_for_battery_drain",
+    &agv::PathGuide::FleetConfiguration::account_for_battery_drain,
+    &agv::PathGuide::FleetConfiguration::set_account_for_battery_drain)
+  .def_property(
+    "finishing_request",
+    &agv::PathGuide::FleetConfiguration::finishing_request,
+    &agv::PathGuide::FleetConfiguration::set_finishing_request)
+  .def_property(
+    "server_uri",
+    &agv::PathGuide::FleetConfiguration::server_uri,
+    &agv::PathGuide::FleetConfiguration::set_server_uri)
+  .def_property(
+    "max_delay",
+    &agv::PathGuide::FleetConfiguration::max_delay,
+    &agv::PathGuide::FleetConfiguration::set_max_delay)
+  .def_property(
+    "update_interval",
+    &agv::PathGuide::FleetConfiguration::update_interval,
+    &agv::PathGuide::FleetConfiguration::set_update_interval)
+  .def_property(
+    "default_responsive_wait",
+    &agv::PathGuide::FleetConfiguration::default_responsive_wait,
+    &agv::PathGuide::FleetConfiguration::set_default_responsive_wait)
+  .def_property(
+    "default_max_merge_waypoint_distance",
+    &agv::PathGuide::FleetConfiguration::
+    default_max_merge_waypoint_distance,
+    &agv::PathGuide::FleetConfiguration::
+    set_default_max_merge_waypoint_distance)
+  .def_property(
+    "default_max_merge_lane_distance",
+    &agv::PathGuide::FleetConfiguration::default_max_merge_lane_distance,
+    &agv::PathGuide::FleetConfiguration::
+    set_default_max_merge_lane_distance)
+  .def_property(
+    "default_min_lane_length",
+    &agv::PathGuide::FleetConfiguration::default_min_lane_length,
+    &agv::PathGuide::FleetConfiguration::set_default_min_lane_length)
+
+  .def_property_readonly(
+    "lift_emergency_lanes",
+    &agv::PathGuide::FleetConfiguration::lift_emergency_levels)
+  .def(
+    "set_lift_emergency_level",
+    &agv::PathGuide::FleetConfiguration::set_lift_emergency_level);
+}


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discourse [discussions page](https://discourse.openrobotics.org/c/open-rmf/open-rmf-general/103) or [proposals page](https://discourse.openrobotics.org/c/open-rmf/open-rmf-ideas/105).
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## New feature implementation

### Implemented feature

A third fleet-adapter flavor alongside Full Control and Easy Full Control. Where EasyFullControl hands the integrator one vertex at a time and waits for finished() before sending the next, PathGuide hands over the whole remaining route in a single PathRequest, so a fleet manager can smooth across it. It can be refer to [PMC Board](https://github.com/open-rmf/rmf_ros2/issues/530)

### Implementation description

Because the integrator now holds a CommandExecution for every waypoint at once, followings differ from EasyFullControl: 

1) The `PathProgressTracker` binds every finisher up front, acknowledgements are strictly in order, stop() and replan invalidate the whole queue, and `PathIndexGuard` enforces that the reported path index never decreases.

2) Each `PathWaypoint` publishes `merge_radius()` -- how far off-lane RMF can still localize the robot there. It is a bound, not an arrival radius: deciding arrival, including when a robot is far enough inside a lift cabin for the doors to close, is the integrator's call.

3) Also replaces RobotContext's per-flavor localization slots with a single neutral one. RequestLift previously called an overload typed on EasyFullControl::Destination, so a `PathGuide` robot's slot was never found and post-lift relocalization was silently skipped for every such robot. Shared phase code now fills a `LocalizationHandoff` and whichever handler the robot registered translates it back; a new flavor registers one handler and changes nothing else.

4) `EasyFullControl.hpp`, `EasyFullControl.cpp` and `internal_EasyFullControl.hpp` are left untouched.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [/] I used a GenAI tool in this PR. (Claude Code, Opus 5)
- [ ] I did not use GenAI

Generated-by:


