### PR TITLE
Support both JSON schema validator target names in rmf_fleet_adapter

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -51,6 +51,12 @@ foreach(pkg ${dep_pkgs})
   find_package(${pkg} REQUIRED)
 endforeach()
 
+if(TARGET nlohmann_json_schema_validator)
+  set(json_schema_validator_target nlohmann_json_schema_validator)
+else()
+  set(json_schema_validator_target nlohmann_json_schema_validator::validator)
+endif()
+
 # Backward compatibility for yaml-cpp 0.7 that exports a yaml-cpp target
 # while 0.8.0 and above export yaml-cpp::yaml-cpp
 if (TARGET yaml-cpp)
@@ -107,7 +113,7 @@ target_link_libraries(rmf_fleet_adapter
     rmf_websocket::rmf_websocket
     nlohmann_json::nlohmann_json
     rmf_api_msgs::rmf_api_msgs
-    nlohmann_json_schema_validator::validator
+    ${json_schema_validator_target}
 )
 
 target_include_directories(rmf_fleet_adapter
@@ -164,7 +170,7 @@ if (BUILD_TESTING)
       rmf_fleet_adapter
       rmf_utils::rmf_utils
       rmf_api_msgs::rmf_api_msgs
-      nlohmann_json_schema_validator::validator
+      ${json_schema_validator_target}
   )
 
   target_compile_definitions(test_rmf_fleet_adapter


### PR DESCRIPTION
## Summary

#541 added a fallback for installations that export the JSON schema validator as `nlohmann_json_schema_validator` rather than `nlohmann_json_schema_validator::validator`, but it covered only `rmf_task_ros2` and `rmf_websocket`. `rmf_fleet_adapter` links the same library and still hardcodes the namespaced name, so on those installations its CMake generate step fails:

```
CMake Error at CMakeLists.txt:110 (target_link_libraries):
  Target "rmf_fleet_adapter" links to:

    nlohmann_json_schema_validator::validator

  but the target was not found.
```

This applies the same pattern `rmf_websocket` already uses, covering both the library and the `BUILD_TESTING` target. Installations that export the namespaced target take the `else()` branch and are unaffected.

## Test plan

Built with colcon on ROS 2 Jazzy in a workspace whose `nlohmann_json_schema_validator_vendor` exports the unnamespaced target. Before this change `rmf_fleet_adapter` failed at the CMake generate step; after it, the package configures and builds cleanly. The other two packages already fixed by #541 are unchanged.

## GenAI use

- [x] I used a GenAI tool in this PR.
- [ ] I did not use a GenAI tool in this PR.

We hit this while building `rmf_fleet_adapter` to pick up another fix. The investigation and this PR description were prepared with the assistance of an AI coding assistant (Claude).
